### PR TITLE
Provide the location when creating glif work

### DIFF
--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
     UnableToLoadSource(Box<dyn error::Error>),
     #[error("Missing layer")]
     NoSuchLayer(String),
+    #[error("No files associated with glyph")]
+    NoFilesForGlyph(String),
+    #[error("No design space location(s) associated with glyph")]
+    NoLocationsForGlyph(String),
+    #[error("Asked to create work for something other than the last input we created")]
+    UnableToCreateGlyphIrWork,
 }
 
 /// An async work error, hence one that must be Send

--- a/fontir/src/filestate.rs
+++ b/fontir/src/filestate.rs
@@ -3,7 +3,7 @@ use filetime::FileTime;
 use serde::{Deserialize, Serialize};
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{hash_map::Keys, HashMap, HashSet},
     fs, io,
     path::{Path, PathBuf},
     vec,
@@ -35,6 +35,28 @@ impl FileState {
 impl FileStateSet {
     pub fn new() -> FileStateSet {
         Default::default()
+    }
+}
+
+impl<'a> IntoIterator for &'a FileStateSet {
+    type Item = &'a Path;
+    type IntoIter = FileStateSetIntoIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        FileStateSetIntoIter {
+            iter: self.entries.keys(),
+        }
+    }
+}
+
+pub struct FileStateSetIntoIter<'a> {
+    iter: Keys<'a, PathBuf, FileState>,
+}
+
+impl<'a> Iterator for FileStateSetIntoIter<'a> {
+    type Item = &'a Path;
+    fn next(&mut self) -> Option<&'a Path> {
+        self.iter.next().map(|pb| pb.as_path())
     }
 }
 

--- a/fontir/src/filestate.rs
+++ b/fontir/src/filestate.rs
@@ -70,6 +70,10 @@ impl FileStateSet {
 }
 
 impl FileStateSet {
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
     pub fn contains(&self, path: &Path) -> bool {
         self.entries.contains_key(path)
     }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1,5 +1,7 @@
 //! Serde types for font IR. See TODO:PublicLink.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -10,6 +12,9 @@ pub struct Axis {
     pub max: f32,
     pub hidden: bool,
 }
+
+// TODO(https://github.com/googlefonts/fontmake-rs/pull/4) fix this type
+pub type DesignSpaceLocation = BTreeMap<String, i32>;
 
 #[cfg(test)]
 mod tests {

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -1,7 +1,7 @@
 //! Generic model of font sources.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -46,14 +46,18 @@ impl Work<()> for DeleteWork {
 /// Manipulations on some sort of font source.
 pub trait Source {
     /// Resolve a source to a set of files and their dependencies.
-    fn inputs(&self) -> Result<Input, Error>;
+    ///
+    /// Mut to permit caching.
+    fn inputs(&mut self) -> Result<Input, Error>;
 
-    // Create a function that could be called to generate IR for a glyph
+    /// Create a function that could be called to generate IR for glyphs.
+    ///
+    /// Batched because some formats require IO to figure out the work.
     fn create_glyph_ir_work(
         &self,
-        glyph_name: &str,
-        glyph_files: &FileStateSet,
-    ) -> Box<dyn Work<()>>;
+        glyph_names: &HashSet<&str>,
+        input: &Input,
+    ) -> Result<Vec<Box<dyn Work<()>>>, Error>;
 }
 
 /// Where does IR go anyway?

--- a/resources/testdata/WghtVar-Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/WghtVar-Bold.ufo/glyphs/contents.plist
@@ -4,5 +4,7 @@
   <dict>
     <key>bar</key>
     <string>bar.glif</string>
+    <key>plus</key>
+    <string>plus.glif</string>
   </dict>
 </plist>

--- a/resources/testdata/WghtVar-Bold.ufo/glyphs/plus.glif
+++ b/resources/testdata/WghtVar-Bold.ufo/glyphs/plus.glif
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="plus" format="2">
+  <advance width="572"/>
+  <unicode hex="002B"/>
+  <outline>
+    <contour>
+      <point x="232" y="111" type="line"/>
+      <point x="339" y="111" type="line"/>
+      <point x="339" y="299" type="line"/>
+      <point x="528" y="299" type="line"/>
+      <point x="528" y="406" type="line"/>
+      <point x="339" y="406" type="line"/>
+      <point x="339" y="596" type="line"/>
+      <point x="232" y="596" type="line"/>
+      <point x="232" y="406" type="line"/>
+      <point x="43" y="406" type="line"/>
+      <point x="43" y="299" type="line"/>
+      <point x="232" y="299" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/WghtVar-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/WghtVar-Regular.ufo/glyphs/contents.plist
@@ -4,5 +4,7 @@
   <dict>
     <key>bar</key>
     <string>bar.glif</string>
+    <key>plus</key>
+    <string>plus.glif</string>
   </dict>
 </plist>

--- a/resources/testdata/WghtVar-Regular.ufo/glyphs/plus.glif
+++ b/resources/testdata/WghtVar-Regular.ufo/glyphs/plus.glif
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="plus" format="2">
+  <advance width="557"/>
+  <unicode hex="002B"/>
+  <outline>
+    <contour>
+      <point x="242" y="111" type="line"/>
+      <point x="314" y="111" type="line"/>
+      <point x="314" y="317" type="line"/>
+      <point x="513" y="317" type="line"/>
+      <point x="513" y="388" type="line"/>
+      <point x="314" y="388" type="line"/>
+      <point x="314" y="595" type="line"/>
+      <point x="242" y="595" type="line"/>
+      <point x="242" y="388" type="line"/>
+      <point x="43" y="388" type="line"/>
+      <point x="43" y="317" type="line"/>
+      <point x="242" y="317" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -30,3 +30,4 @@ plist = { version =  "1.3.1", features = ["serde"] }
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"
+tempfile = "3.3.0"


### PR DESCRIPTION
Provide a set of Path:DesignSpaceLocation(s) to the create IR function. Intended to leave us in a good position to actually build glyph IR.