### PR TITLE
Add the ability to capture the state of a slice.

### DIFF
--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -328,7 +328,7 @@ mod tests {
         let metadata = compiler_location.metadata().unwrap();
         let mut compiler = StateSet::new();
         // size +1, I'd give it all up for just a little more
-        compiler.set_state(
+        compiler.set_file_state(
             &compiler_location,
             FileTime::from_system_time(metadata.modified().unwrap()),
             metadata.len() + 1,

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -9,8 +9,8 @@ use clap::Parser;
 use fontc::Error;
 use fontir::{
     error::WorkError,
-    filestate::FileStateSet,
     source::{DeleteWork, Input, Paths, Source, Work},
+    stateset::StateSet,
 };
 use log::{debug, error, info, warn};
 use rayon::prelude::*;
@@ -29,13 +29,13 @@ struct Args {
 struct Config {
     args: Args,
     // The compiler previously used so if the compiler changes config invalidates
-    compiler: FileStateSet,
+    compiler: StateSet,
 }
 
 impl Config {
     fn new(args: Args) -> Result<Config, io::Error> {
-        let mut compiler = FileStateSet::new();
-        compiler.insert(&std::env::current_exe()?)?;
+        let mut compiler = StateSet::new();
+        compiler.track_file(&std::env::current_exe()?)?;
         Ok(Config { args, compiler })
     }
 
@@ -258,7 +258,7 @@ mod tests {
     };
 
     use filetime::FileTime;
-    use fontir::{filestate::FileStateSet, source::Paths};
+    use fontir::{source::Paths, stateset::StateSet};
     use tempfile::tempdir;
 
     use crate::{
@@ -326,7 +326,7 @@ mod tests {
 
         let compiler_location = std::env::current_exe().unwrap();
         let metadata = compiler_location.metadata().unwrap();
-        let mut compiler = FileStateSet::new();
+        let mut compiler = StateSet::new();
         // size +1, I'd give it all up for just a little more
         compiler.set_state(
             &compiler_location,

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -20,6 +20,8 @@ bincode = "1.3.3"
 filetime = "0.2.18"
 thiserror = "1.0.37"
 
+blake3 = "1.3.3"
+
 log = "0.4"
 env_logger = "0.9.0"
 

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -11,7 +11,7 @@ pub enum Error {
     #[error("IO failure")]
     IoError(#[from] io::Error),
     #[error("Unable to parse")]
-    ParseError(PathBuf, Box<dyn error::Error>),
+    ParseError(PathBuf, String),
     #[error("Illegible source")]
     UnableToLoadSource(Box<dyn error::Error>),
     #[error("Missing layer")]

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     NoLocationsForGlyph(String),
     #[error("Asked to create work for something other than the last input we created")]
     UnableToCreateGlyphIrWork,
+    #[error("Unexpected state encountered in a state set")]
+    UnexpectedState,
 }
 
 /// An async work error, hence one that must be Send

--- a/fontir/src/lib.rs
+++ b/fontir/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod error;
-pub mod filestate;
 pub mod ir;
 pub(crate) mod serde;
 pub mod source;
+pub mod stateset;

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -1,70 +1,108 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use filetime::FileTime;
 use serde::{Deserialize, Serialize};
 
-use crate::filestate::{FileState, FileStateSet};
+use crate::stateset::{FileState, SliceState, State, StateSet};
 
-// We use a named field because toml doesn't like tuple-structs very much
+// Use intermediary structs because toml doesn't much like multiple vecs
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct FileStateSetSerdeRepr {
-    entries: Vec<PathStateSerdeRepr>,
+pub(crate) struct StateSetSerdeRepr {
+    files: FileStatesSerdeRepr,
+    slices: SliceStatesSerdeRepr,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-struct FileStateSerdeRepr {
-    path: PathBuf,
-    depends_on: Vec<PathBuf>,
+pub(crate) struct FileStatesSerdeRepr {
+    entries: Vec<FileStateSerdeRepr>,
 }
 
-impl From<FileStateSetSerdeRepr> for FileStateSet {
-    fn from(from: FileStateSetSerdeRepr) -> Self {
-        FileStateSet {
-            entries: from
-                .entries
-                .iter()
-                .map(|d| {
-                    (
-                        PathBuf::from(&d.path),
-                        FileState {
-                            mtime: FileTime::from_unix_time(d.unix_seconds, d.nanos),
-                            size: d.size,
-                        },
-                    )
-                })
-                .collect(),
-        }
-    }
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub(crate) struct SliceStatesSerdeRepr {
+    entries: Vec<SliceStateSerdeRepr>,
 }
 
-impl From<FileStateSet> for FileStateSetSerdeRepr {
-    fn from(fs: FileStateSet) -> Self {
-        let mut entries: Vec<PathStateSerdeRepr> = fs
+impl From<StateSetSerdeRepr> for StateSet {
+    fn from(from: StateSetSerdeRepr) -> Self {
+        let entries: HashMap<PathBuf, State> = from
+            .files
             .entries
-            .iter()
-            .map(|e| {
-                let path = e.0.to_str().expect("Only UTF names please").to_string();
-                PathStateSerdeRepr {
-                    path,
-                    unix_seconds: e.1.mtime.unix_seconds(),
-                    nanos: e.1.mtime.nanoseconds(),
-                    size: e.1.size,
-                }
+            .into_iter()
+            .map(|serde_repr| {
+                (
+                    PathBuf::from(&serde_repr.path),
+                    State::File(FileState {
+                        mtime: FileTime::from_unix_time(serde_repr.unix_seconds, serde_repr.nanos),
+                        size: serde_repr.size,
+                    }),
+                )
             })
+            .chain(from.slices.entries.into_iter().map(|serde_repr| {
+                (
+                    PathBuf::from(&serde_repr.path),
+                    State::Slice(SliceState {
+                        hash: blake3::Hash::from_hex(serde_repr.hash).unwrap(),
+                        size: serde_repr.size,
+                    }),
+                )
+            }))
             .collect();
-        entries.sort_by(|e1, e2| e1.path.cmp(&e2.path));
-        FileStateSetSerdeRepr { entries }
+        StateSet { entries }
     }
 }
 
-/// The serde-friendly representation of a [FileState] for a [std::path::Path].
+impl From<StateSet> for StateSetSerdeRepr {
+    fn from(fs: StateSet) -> Self {
+        let mut files = Vec::new();
+        let mut slices = Vec::new();
+
+        for (path, state) in fs.entries {
+            let path = path.to_str().expect("Only UTF names please").to_string();
+            match state {
+                State::File(state) => {
+                    files.push(FileStateSerdeRepr {
+                        path,
+                        unix_seconds: state.mtime.unix_seconds(),
+                        nanos: state.mtime.nanoseconds(),
+                        size: state.size,
+                    });
+                }
+                State::Slice(state) => {
+                    slices.push(SliceStateSerdeRepr {
+                        path,
+                        hash: state.hash.to_hex().to_string(),
+                        size: state.size,
+                    });
+                }
+            }
+        }
+        files.sort_by(|e1, e2| e1.path.cmp(&e2.path));
+        slices.sort_by(|e1, e2| e1.path.cmp(&e2.path));
+        let files = FileStatesSerdeRepr { entries: files };
+        let slices = SliceStatesSerdeRepr { entries: slices };
+        StateSetSerdeRepr { files, slices }
+    }
+}
+
+/// The serde-friendly representation of a [FileState].
 ///
 /// SystemTime lacks a platform independent representation we can
 /// depend on so use FileTime's unix_seconds,nanos.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-struct PathStateSerdeRepr {
+struct FileStateSerdeRepr {
     path: String,
     unix_seconds: i64,
     nanos: u32,
     size: u64,
+}
+
+/// The serde-friendly representation of a [SliceState].
+///
+/// SystemTime lacks a platform independent representation we can
+/// depend on so use FileTime's unix_seconds,nanos.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct SliceStateSerdeRepr {
+    path: String,
+    hash: String,
+    size: usize,
 }

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{Error, WorkError},
-    filestate::FileStateSet,
+    stateset::StateSet,
 };
 
 /// A unit of work safe to run in parallel
@@ -103,9 +103,9 @@ impl Paths {
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Input {
     /// The input(s) that inform font_info
-    pub font_info: FileStateSet,
+    pub font_info: StateSet,
     /// The input(s) that inform glyph construction, grouped by gyph name
-    pub glyphs: HashMap<String, FileStateSet>,
+    pub glyphs: HashMap<String, StateSet>,
 }
 
 impl Input {
@@ -124,7 +124,7 @@ mod tests {
 
     use tempfile::{tempdir, TempDir};
 
-    use crate::filestate::FileStateSet;
+    use crate::stateset::StateSet;
 
     use super::Input;
 
@@ -135,17 +135,17 @@ mod tests {
     }
 
     fn create_test_input(temp_dir: &TempDir) -> Input {
-        let mut font_info = FileStateSet::new();
+        let mut font_info = StateSet::new();
         font_info
-            .insert(&write(temp_dir, Path::new("some.designspace"), "blah"))
+            .track_file(&write(temp_dir, Path::new("some.designspace"), "blah"))
             .unwrap();
 
-        let mut glyph = FileStateSet::new();
+        let mut glyph = StateSet::new();
         glyph
-            .insert(&write(temp_dir, Path::new("regular.space.glif"), "blah"))
+            .track_file(&write(temp_dir, Path::new("regular.space.glif"), "blah"))
             .unwrap();
         glyph
-            .insert(&write(temp_dir, Path::new("bold.space.glif"), "blah"))
+            .track_file(&write(temp_dir, Path::new("bold.space.glif"), "blah"))
             .unwrap();
 
         let mut glyphs = HashMap::new();

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -8,7 +8,7 @@ use fontir::{
     error::{Error, WorkError},
     ir::DesignSpaceLocation,
     source::{Input, Paths, Source, Work},
-    stateset::StateSet,
+    stateset::{StateIdentifier, StateSet},
 };
 use log::debug;
 use norad::designspace::{self, DesignSpaceDocument};
@@ -231,13 +231,16 @@ impl DesignSpaceIrSource {
         // So resolve each file to 1..N locations in designspace
 
         let glyph_name = glyph_name.to_string();
-        let fileset = input
+        let stateset = input
             .glyphs
             .get(&glyph_name)
             .ok_or_else(|| Error::NoFilesForGlyph(glyph_name.clone()))?;
         let mut glif_files = HashMap::new();
         let glif_locations = self.glif_locations.as_ref().unwrap();
-        for glif_file in fileset {
+        for state_key in stateset.keys() {
+            let StateIdentifier::File(glif_file) = state_key else {
+                return Err(Error::UnexpectedState);
+            };
             let locations = glif_locations
                 .location_of(glif_file)
                 .ok_or_else(|| Error::NoLocationsForGlyph(glyph_name.clone()))?;

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -6,9 +6,9 @@ use std::{
 
 use fontir::{
     error::{Error, WorkError},
-    filestate::FileStateSet,
     ir::DesignSpaceLocation,
     source::{Input, Paths, Source, Work},
+    stateset::StateSet,
 };
 use log::debug;
 use norad::designspace::{self, DesignSpaceDocument};
@@ -37,13 +37,13 @@ impl DesignSpaceIrSource {
 
 // A cache of locations, valid provided no global metadata changes
 struct GlifLocationCache {
-    global_metadata_sources: FileStateSet,
+    global_metadata_sources: StateSet,
     locations: HashMap<PathBuf, Vec<DesignSpaceLocation>>,
 }
 
 impl GlifLocationCache {
     fn new(
-        global_metadata_sources: FileStateSet,
+        global_metadata_sources: StateSet,
         locations: HashMap<PathBuf, Vec<DesignSpaceLocation>>,
     ) -> GlifLocationCache {
         GlifLocationCache {
@@ -52,7 +52,7 @@ impl GlifLocationCache {
         }
     }
 
-    fn is_valid_for(&self, global_metadata_sources: &FileStateSet) -> bool {
+    fn is_valid_for(&self, global_metadata_sources: &StateSet) -> bool {
         self.global_metadata_sources == *global_metadata_sources
     }
 
@@ -77,7 +77,7 @@ fn glif_files<'a>(
         return Err(Error::FileExpected(glyph_list_file));
     }
     let result: BTreeMap<String, PathBuf> = plist::from_file(&glyph_list_file)
-        .map_err(|e| Error::ParseError(glyph_list_file, e.into()))?;
+        .map_err(|e| Error::ParseError(glyph_list_file, e.to_string()))?;
 
     Ok(result
         .into_iter()
@@ -91,7 +91,7 @@ fn layer_contents(ufo_dir: &Path) -> Result<HashMap<String, PathBuf>, Error> {
         return Err(Error::FileExpected(file));
     }
     let contents: Vec<(String, PathBuf)> =
-        plist::from_file(&file).map_err(|e| Error::ParseError(file, e.into()))?;
+        plist::from_file(&file).map_err(|e| Error::ParseError(file, e.to_string()))?;
     Ok(contents.into_iter().collect())
 }
 
@@ -126,9 +126,9 @@ impl DesignSpaceIrSource {
     fn global_rebuild_triggers(
         &self,
         designspace: &DesignSpaceDocument,
-    ) -> Result<FileStateSet, Error> {
-        let mut font_info = FileStateSet::new();
-        font_info.insert(&self.designspace_file)?;
+    ) -> Result<StateSet, Error> {
+        let mut font_info = StateSet::new();
+        font_info.track_file(&self.designspace_file)?;
         for source in designspace.sources.iter() {
             let ufo_dir = self.designspace_dir.join(&source.filename);
             for filename in ["fontinfo.plist", "layercontents.plist"] {
@@ -136,7 +136,7 @@ impl DesignSpaceIrSource {
                 if !font_info_file.is_file() {
                     return Err(Error::FileExpected(font_info_file));
                 }
-                font_info.insert(&font_info_file)?;
+                font_info.track_file(&font_info_file)?;
             }
         }
         Ok(font_info)
@@ -150,7 +150,7 @@ impl Source for DesignSpaceIrSource {
 
         // glif filenames are not reversible so we need to read contents.plist to figure out groups
         // See https://github.com/unified-font-object/ufo-spec/issues/164.
-        let mut glyphs: HashMap<String, FileStateSet> = HashMap::new();
+        let mut glyphs: HashMap<String, StateSet> = HashMap::new();
 
         // UFO filename => map of layer
         let mut layer_cache = HashMap::new();
@@ -173,7 +173,10 @@ impl Source for DesignSpaceIrSource {
                     return Err(Error::FileExpected(glif_file));
                 }
                 let glif_file = glif_file.clone();
-                glyphs.entry(glyph_name).or_default().insert(&glif_file)?;
+                glyphs
+                    .entry(glyph_name)
+                    .or_default()
+                    .track_file(&glif_file)?;
 
                 let glif_locations = glif_locations.entry(glif_file).or_default();
                 glif_locations.push(location.clone());


### PR DESCRIPTION
Intended use is to capture slices from .glyphs files so we can see things like which glyphs have changed since the prior compile (wip of this in #21)