### PR TITLE
Use hashable types and derived plist conversion instead of raw access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "glyphs2fontir",
     "ufo2fontir",
     "fontc",
+    "glyphs-reader",
 ]

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use filetime::FileTime;
 use serde::{Deserialize, Serialize};
 
-use crate::stateset::{FileState, SliceState, State, StateIdentifier, StateSet};
+use crate::stateset::{FileState, MemoryState, State, StateIdentifier, StateSet};
 
 // Use intermediary structs because toml doesn't much like multiple vecs
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -40,7 +40,7 @@ impl From<StateSetSerdeRepr> for StateSet {
             .chain(from.slices.entries.into_iter().map(|serde_repr| {
                 (
                     StateIdentifier::Memory(serde_repr.identifier),
-                    State::Memory(SliceState {
+                    State::Memory(MemoryState {
                         hash: blake3::Hash::from_hex(serde_repr.hash).unwrap(),
                         size: serde_repr.size,
                     }),
@@ -101,7 +101,7 @@ struct FileStateSerdeRepr {
     size: u64,
 }
 
-/// The serde-friendly representation of a [SliceState].
+/// The serde-friendly representation of a [MemoryState].
 ///
 /// SystemTime lacks a platform independent representation we can
 /// depend on so use FileTime's unix_seconds,nanos.
@@ -109,5 +109,5 @@ struct FileStateSerdeRepr {
 struct SliceStateSerdeRepr {
     identifier: String,
     hash: String,
-    size: usize,
+    size: u64,
 }

--- a/fontir/src/stateset.rs
+++ b/fontir/src/stateset.rs
@@ -163,7 +163,7 @@ impl StateSet {
     pub fn track_memory(
         &mut self,
         identifier: String,
-        memory: Box<impl Hash>,
+        memory: &(impl Hash + ?Sized),
     ) -> Result<(), io::Error> {
         self.entries.insert(
             StateIdentifier::Memory(identifier),
@@ -277,12 +277,11 @@ mod tests {
         let p2 = String::from("/glyphs/hyphen");
 
         let mut s1 = StateSet::new();
-        s1.track_memory(p1.clone(), Box::new("this is a glyph"))
-            .unwrap();
-        s1.track_memory(p2, Box::new("another glyph")).unwrap();
+        s1.track_memory(p1.clone(), "this is a glyph").unwrap();
+        s1.track_memory(p2, "another glyph").unwrap();
 
         let mut s2 = s1.clone();
-        s2.track_memory(p1.clone(), Box::new("this changes everything"))
+        s2.track_memory(p1.clone(), "this changes everything")
             .unwrap();
 
         assert_eq!(
@@ -442,7 +441,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         let (_, _, mut fs) = one_changed_file_one_not(&temp_dir);
-        fs.track_memory("/glyph/glyph_name".to_string(), Box::new("Hi World!"))
+        fs.track_memory("/glyph/glyph_name".to_string(), "Hi World!")
             .unwrap();
 
         let toml = toml::ser::to_string_pretty(&fs).unwrap();
@@ -455,7 +454,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         let (_, _, mut fs) = one_changed_file_one_not(&temp_dir);
-        fs.track_memory("/glyph/glyph_name".to_string(), Box::new("Hi World!"))
+        fs.track_memory("/glyph/glyph_name".to_string(), "Hi World!")
             .unwrap();
 
         let bc = bincode::serialize(&fs).unwrap();

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "glyphs-reader"
+version = "0.0.1"
+license = "MIT/Apache-2.0"
+authors = ["Raph Levien <raph.levien@gmail.com>"]
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+kurbo = "0.5.1"
+plist_derive = { path = "plist_derive" }
+ordered-float = "3.4.0"

--- a/glyphs-reader/README.md
+++ b/glyphs-reader/README.md
@@ -1,0 +1,10 @@
+Plist code copied from https://github.com/raphlinus/interp-toy/tree/main/glyphstool
+at e87f62c0922ce04ea0cee83d624bd9b7d8eafbd8.
+
+Lightly modified:
+
+* removed code related to modifying the font to focus on reading
+* fixed clippy warnings
+* made Plist Hash
+
+TODO: make from_plist return a Result

--- a/glyphs-reader/plist_derive/Cargo.toml
+++ b/glyphs-reader/plist_derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "plist_derive"
+version = "0.1.0"
+authors = ["Raph Levien <raph.levien@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0.5"
+quote = "1.0.2"
+proc-macro2 = "1.0"

--- a/glyphs-reader/plist_derive/src/lib.rs
+++ b/glyphs-reader/plist_derive/src/lib.rs
@@ -1,0 +1,175 @@
+extern crate proc_macro;
+
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{parse_macro_input, Attribute, Data, DeriveInput, Fields};
+
+#[proc_macro_derive(FromPlist, attributes(rest))]
+pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let deser = add_deser(&input.data);
+
+    let expanded = quote! {
+        impl crate::from_plist::FromPlist for #name {
+            fn from_plist(plist: crate::plist::Plist) -> Self {
+                let mut map = plist.into_btreemap();
+                #name {
+                    #deser
+                }
+            }
+        }
+    };
+    proc_macro::TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(ToPlist, attributes(rest))]
+pub fn derive_to(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let ser_rest = add_ser_rest(&input.data);
+    let ser = add_ser(&input.data);
+
+    let expanded = quote! {
+        impl crate::to_plist::ToPlist for #name {
+            fn to_plist(self) -> crate::plist::Plist {
+                #ser_rest
+                #ser
+                map.into()
+            }
+        }
+    };
+    proc_macro::TokenStream::from(expanded)
+}
+
+fn add_deser(data: &Data) -> TokenStream {
+    match *data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => {
+                let recurse = fields.named.iter().filter_map(|f| {
+                    if !is_rest(&f.attrs) {
+                        let name = &f.ident;
+                        let name_str = name.as_ref().unwrap().to_string();
+                        let snake_name = snake_to_camel_case(&name_str);
+                        Some(quote_spanned! {f.span() =>
+                            #name: crate::from_plist::FromPlistOpt::from_plist(
+                                map.remove(#snake_name)
+                            ),
+                        })
+                    } else {
+                        None
+                    }
+                });
+                let recurse_rest = fields.named.iter().filter_map(|f| {
+                    if is_rest(&f.attrs) {
+                        let name = &f.ident;
+                        Some(quote_spanned! {f.span() =>
+                            #name: map,
+                        })
+                    } else {
+                        None
+                    }
+                });
+                quote! {
+                    #( #recurse )*
+                    #( #recurse_rest )*
+                }
+            }
+            _ => unimplemented!(),
+        },
+        _ => unimplemented!(),
+    }
+}
+
+fn add_ser(data: &Data) -> TokenStream {
+    match *data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => {
+                let recurse = fields.named.iter().filter_map(|f| {
+                    if !is_rest(&f.attrs) {
+                        let name = &f.ident;
+                        let name_str = name.as_ref().unwrap().to_string();
+                        let snake_name = snake_to_camel_case(&name_str);
+                        Some(quote_spanned! {f.span() =>
+                            if let Some(plist) = crate::to_plist::ToPlistOpt::to_plist(self.#name) {
+                                map.insert(#snake_name.to_string(), plist);
+                            }
+                        })
+                    } else {
+                        None
+                    }
+                });
+                quote! {
+                    #( #recurse )*
+                }
+            }
+            _ => unimplemented!(),
+        },
+        _ => unimplemented!(),
+    }
+}
+
+fn add_ser_rest(data: &Data) -> TokenStream {
+    match *data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => {
+                for f in fields.named.iter() {
+                    if is_rest(&f.attrs) {
+                        let name = &f.ident;
+                        return quote_spanned! { f.span() =>
+                            let mut map = self.#name;
+                        };
+                    }
+                }
+                quote! { let mut map = BTreeMap::new(); }
+            }
+            _ => unimplemented!(),
+        },
+        _ => unimplemented!(),
+    }
+}
+
+fn is_rest(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path
+            .get_ident()
+            .map(|ident| ident == "rest")
+            .unwrap_or(false)
+    })
+}
+
+fn snake_to_camel_case(id: &str) -> String {
+    let mut result = String::new();
+    let mut hump = false;
+    for c in id.chars() {
+        if c == '_' {
+            hump = true;
+        } else {
+            if hump {
+                result.push(c.to_ascii_uppercase());
+            } else {
+                result.push(c);
+            }
+            hump = false;
+        }
+    }
+    result
+}
+
+/*
+fn to_snake_case(id: &str) -> String {
+    let mut result = String::new();
+    for c in id.chars() {
+        if c.is_ascii_uppercase() {
+            result.push('_');
+            result.push(c.to_ascii_lowercase());
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+*/

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -1,0 +1,267 @@
+//! The general strategy is just to use a plist for storage. Also, lots of
+//! unwrapping.
+//!
+//! There are lots of other ways this could go, including something serde-like
+//! where it gets serialized to more Rust-native structures, proc macros, etc.
+
+use std::collections::BTreeMap;
+use std::hash::Hash;
+
+use ordered_float::OrderedFloat;
+
+use crate::from_plist::FromPlist;
+use crate::plist::Plist;
+use crate::to_plist::ToPlist;
+
+#[derive(Debug, FromPlist, ToPlist, Hash)]
+pub struct Font {
+    pub glyphs: Vec<Glyph>,
+    pub font_master: Vec<FontMaster>,
+    #[rest]
+    pub other_stuff: BTreeMap<String, Plist>,
+}
+
+#[derive(Clone, Debug, FromPlist, ToPlist, Hash)]
+pub struct Glyph {
+    pub layers: Vec<Layer>,
+    pub glyphname: String,
+    #[rest]
+    pub other_stuff: BTreeMap<String, Plist>,
+}
+
+#[derive(Clone, Debug, FromPlist, ToPlist, Hash)]
+pub struct Layer {
+    pub layer_id: String,
+    pub width: OrderedFloat<f64>,
+    pub paths: Option<Vec<Path>>,
+    pub components: Option<Vec<Component>>,
+    pub anchors: Option<Vec<Anchor>>,
+    pub guide_lines: Option<Vec<GuideLine>>,
+    #[rest]
+    pub other_stuff: BTreeMap<String, Plist>,
+}
+
+#[derive(Clone, Debug, FromPlist, ToPlist, Hash)]
+pub struct Path {
+    pub closed: bool,
+    pub nodes: Vec<Node>,
+}
+
+// We do not use kurbo's point because it does not hash
+#[derive(Clone, Debug, Hash)]
+pub struct Point {
+    x: OrderedFloat<f64>,
+    y: OrderedFloat<f64>,
+}
+
+impl Point {
+    pub fn new(x: f64, y: f64) -> Point {
+        Point {
+            x: x.into(),
+            y: y.into(),
+        }
+    }
+}
+
+// We do not use kurbo's affine because it does not hash
+#[derive(Clone, Debug, Hash)]
+pub struct Affine([OrderedFloat<f64>; 6]);
+
+impl Affine {
+    pub fn new(matrix: [f64; 6]) -> Affine {
+        Affine([
+            matrix[0].into(),
+            matrix[1].into(),
+            matrix[2].into(),
+            matrix[3].into(),
+            matrix[4].into(),
+            matrix[5].into(),
+        ])
+    }
+}
+
+#[derive(Clone, Debug, Hash)]
+pub struct Node {
+    pub pt: Point,
+    pub node_type: NodeType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NodeType {
+    Line,
+    LineSmooth,
+    OffCurve,
+    Curve,
+    CurveSmooth,
+}
+
+#[derive(Clone, Debug, FromPlist, ToPlist, Hash)]
+pub struct Component {
+    pub name: String,
+    pub transform: Option<Affine>,
+    #[rest]
+    pub other_stuff: BTreeMap<String, Plist>,
+}
+
+#[derive(Clone, Debug, FromPlist, ToPlist, Hash)]
+pub struct Anchor {
+    pub name: String,
+    pub position: Point,
+}
+
+#[derive(Clone, Debug, FromPlist, ToPlist, Hash)]
+pub struct GuideLine {
+    pub angle: Option<OrderedFloat<f64>>,
+    pub position: Point,
+}
+
+#[derive(Debug, FromPlist, ToPlist, Hash)]
+pub struct FontMaster {
+    pub id: String,
+    #[rest]
+    pub other_stuff: BTreeMap<String, Plist>,
+}
+
+impl Font {
+    pub fn load(path: &std::path::Path) -> Result<Font, String> {
+        let contents = std::fs::read_to_string(path).map_err(|e| format!("{:?}", e))?;
+        let plist = Plist::parse(&contents).map_err(|e| format!("{:?}", e))?;
+        Ok(FromPlist::from_plist(plist))
+    }
+
+    pub fn get_glyph(&self, glyphname: &str) -> Option<&Glyph> {
+        self.glyphs.iter().find(|g| g.glyphname == glyphname)
+    }
+
+    pub fn get_glyph_mut(&mut self, glyphname: &str) -> Option<&mut Glyph> {
+        self.glyphs.iter_mut().find(|g| g.glyphname == glyphname)
+    }
+}
+
+impl Glyph {
+    pub fn get_layer(&self, layer_id: &str) -> Option<&Layer> {
+        self.layers.iter().find(|l| l.layer_id == layer_id)
+    }
+}
+
+impl FromPlist for Node {
+    fn from_plist(plist: Plist) -> Self {
+        let mut spl = plist.as_str().unwrap().splitn(3, ' ');
+        let x = spl.next().unwrap().parse().unwrap();
+        let y = spl.next().unwrap().parse().unwrap();
+        let pt = Point::new(x, y);
+        let node_type = spl.next().unwrap().parse().unwrap();
+        Node { pt, node_type }
+    }
+}
+
+impl std::str::FromStr for NodeType {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LINE" => Ok(NodeType::Line),
+            "LINE SMOOTH" => Ok(NodeType::LineSmooth),
+            "OFFCURVE" => Ok(NodeType::OffCurve),
+            "CURVE" => Ok(NodeType::Curve),
+            "CURVE SMOOTH" => Ok(NodeType::CurveSmooth),
+            _ => Err(format!("unknown node type {}", s)),
+        }
+    }
+}
+
+impl NodeType {
+    fn glyphs_str(&self) -> &'static str {
+        match self {
+            NodeType::Line => "LINE",
+            NodeType::LineSmooth => "LINE SMOOTH",
+            NodeType::OffCurve => "OFFCURVE",
+            NodeType::Curve => "CURVE",
+            NodeType::CurveSmooth => "CURVE SMOOTH",
+        }
+    }
+}
+
+impl ToPlist for Node {
+    fn to_plist(self) -> Plist {
+        format!(
+            "{} {} {}",
+            self.pt.x,
+            self.pt.y,
+            self.node_type.glyphs_str()
+        )
+        .into()
+    }
+}
+
+impl FromPlist for Affine {
+    fn from_plist(plist: Plist) -> Self {
+        let raw = plist.as_str().unwrap();
+        let raw = &raw[1..raw.len() - 1];
+        let coords: Vec<f64> = raw.split(", ").map(|c| c.parse().unwrap()).collect();
+        Affine::new([
+            coords[0], coords[1], coords[2], coords[3], coords[4], coords[5],
+        ])
+    }
+}
+
+impl ToPlist for Affine {
+    fn to_plist(self) -> Plist {
+        let c = self.0;
+        format!(
+            "{{{}, {}, {}, {}, {}, {}}}",
+            c[0], c[1], c[2], c[3], c[4], c[5]
+        )
+        .into()
+    }
+}
+
+impl FromPlist for Point {
+    fn from_plist(plist: Plist) -> Self {
+        let raw = plist.as_str().unwrap();
+        let raw = &raw[1..raw.len() - 1];
+        let coords: Vec<f64> = raw.split(", ").map(|c| c.parse().unwrap()).collect();
+        Point::new(coords[0], coords[1])
+    }
+}
+
+impl ToPlist for Point {
+    fn to_plist(self) -> Plist {
+        format!("{{{}, {}}}", self.x, self.y).into()
+    }
+}
+
+impl FromPlist for OrderedFloat<f64> {
+    fn from_plist(plist: Plist) -> Self {
+        plist.as_f64().unwrap().into()
+    }
+}
+
+impl ToPlist for OrderedFloat<f64> {
+    fn to_plist(self) -> Plist {
+        Plist::Float(self)
+    }
+}
+
+impl Path {
+    pub fn new(closed: bool) -> Path {
+        Path {
+            nodes: Vec::new(),
+            closed,
+        }
+    }
+
+    pub fn add(&mut self, pt: impl Into<Point>, node_type: NodeType) {
+        let pt = pt.into();
+        self.nodes.push(Node { pt, node_type });
+    }
+
+    /// Rotate left by one, placing the first point at the end. This is because
+    /// it's what glyphs seems to expect.
+    pub fn rotate_left(&mut self, delta: usize) {
+        self.nodes.rotate_left(delta);
+    }
+
+    pub fn reverse(&mut self) {
+        self.nodes.reverse();
+    }
+}

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -36,7 +36,6 @@ pub struct Layer {
     pub paths: Option<Vec<Path>>,
     pub components: Option<Vec<Component>>,
     pub anchors: Option<Vec<Anchor>>,
-    pub guide_lines: Option<Vec<GuideLine>>,
     #[rest]
     pub other_stuff: BTreeMap<String, Plist>,
 }

--- a/glyphs-reader/src/from_plist.rs
+++ b/glyphs-reader/src/from_plist.rs
@@ -1,0 +1,60 @@
+pub use plist_derive::FromPlist;
+
+use crate::plist::Plist;
+
+pub trait FromPlist {
+    // Consider using result type; just unwrap for now.
+    fn from_plist(plist: Plist) -> Self;
+}
+
+pub trait FromPlistOpt {
+    // Consider using result type; just unwrap for now.
+    fn from_plist(plist: Option<Plist>) -> Self;
+}
+
+impl FromPlist for String {
+    fn from_plist(plist: Plist) -> Self {
+        plist.into_string()
+    }
+}
+
+impl FromPlist for bool {
+    fn from_plist(plist: Plist) -> Self {
+        // TODO: maybe error or warn on values other than 0, 1
+        plist.as_i64().expect("expected integer") != 0
+    }
+}
+
+impl FromPlist for i64 {
+    fn from_plist(plist: Plist) -> Self {
+        plist.as_i64().expect("expected integer")
+    }
+}
+
+impl FromPlist for f64 {
+    fn from_plist(plist: Plist) -> Self {
+        plist.as_f64().expect("expected float")
+    }
+}
+
+impl<T: FromPlist> FromPlist for Vec<T> {
+    fn from_plist(plist: Plist) -> Self {
+        let mut result = Vec::new();
+        for element in plist.into_vec() {
+            result.push(FromPlist::from_plist(element));
+        }
+        result
+    }
+}
+
+impl<T: FromPlist> FromPlistOpt for T {
+    fn from_plist(plist: Option<Plist>) -> Self {
+        FromPlist::from_plist(plist.unwrap())
+    }
+}
+
+impl<T: FromPlist> FromPlistOpt for Option<T> {
+    fn from_plist(plist: Option<Plist>) -> Self {
+        plist.map(FromPlist::from_plist)
+    }
+}

--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -1,0 +1,11 @@
+//! Lightweight library for reading and writing Glyphs font files.
+
+mod font;
+mod from_plist;
+mod plist;
+mod to_plist;
+
+pub use font::{Component, Font, Glyph, Layer, Node, NodeType, Path};
+pub use from_plist::FromPlist;
+pub use plist::Plist;
+pub use to_plist::ToPlist;

--- a/glyphs-reader/src/to_plist.rs
+++ b/glyphs-reader/src/to_plist.rs
@@ -1,0 +1,57 @@
+pub use plist_derive::ToPlist;
+
+use crate::plist::Plist;
+
+pub trait ToPlist {
+    fn to_plist(self) -> Plist;
+}
+
+pub trait ToPlistOpt {
+    fn to_plist(self) -> Option<Plist>;
+}
+
+impl ToPlist for String {
+    fn to_plist(self) -> Plist {
+        self.into()
+    }
+}
+
+impl ToPlist for bool {
+    fn to_plist(self) -> Plist {
+        (self as i64).into()
+    }
+}
+
+impl ToPlist for i64 {
+    fn to_plist(self) -> Plist {
+        self.into()
+    }
+}
+
+impl ToPlist for f64 {
+    fn to_plist(self) -> Plist {
+        self.into()
+    }
+}
+
+impl<T: ToPlist> ToPlist for Vec<T> {
+    fn to_plist(self) -> Plist {
+        let mut result = Vec::new();
+        for element in self {
+            result.push(ToPlist::to_plist(element));
+        }
+        result.into()
+    }
+}
+
+impl<T: ToPlist> ToPlistOpt for T {
+    fn to_plist(self) -> Option<Plist> {
+        Some(ToPlist::to_plist(self))
+    }
+}
+
+impl<T: ToPlist> ToPlistOpt for Option<T> {
+    fn to_plist(self) -> Option<Plist> {
+        self.map(ToPlist::to_plist)
+    }
+}

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [dependencies]
 read-fonts = { git = 'https://github.com/googlefonts/fontations' }
 fontir = { version = "0.0.1", path = "../fontir" }
+glyphs-reader = { version = "0.0.1", path = "../glyphs-reader" }
 
 quick-xml = { version = "0.22.0", features = ["serialize"] }
 

--- a/glyphs2fontir/src/lib.rs
+++ b/glyphs2fontir/src/lib.rs
@@ -1,2 +1,1 @@
-mod openstep_plist;
 pub mod source;

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -78,7 +78,7 @@ fn glyph_states(font: &Font) -> Result<HashMap<String, StateSet>, Error> {
 
     for glyph in font.glyphs.iter() {
         let mut state = StateSet::new();
-        state.track_memory(glyph_identifier(&glyph.glyphname), Box::new(glyph))?;
+        state.track_memory(glyph_identifier(&glyph.glyphname), &glyph)?;
         glyph_states.insert(glyph.glyphname.clone(), state);
     }
 
@@ -91,12 +91,12 @@ impl GlyphsIrSource {
         // Naive mk1: if anything other than glyphs and date changes do a global rebuild
         // TODO experiment with actual glyphs saves to see what makes sense
         let mut state = StateSet::new();
-        state.track_memory("/font_master".to_string(), Box::new(&font.font_master))?;
+        state.track_memory("/font_master".to_string(), &font.font_master)?;
         for (key, plist) in font.other_stuff.iter() {
             if key == "date" {
                 continue;
             }
-            state.track_memory(format!("/{}", key), Box::new(plist))?;
+            state.track_memory(format!("/{}", key), &plist)?;
         }
         Ok(state)
     }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1,19 +1,16 @@
 use fontir::error::{Error, WorkError};
 use fontir::source::{Input, Paths, Source, Work};
 use fontir::stateset::StateSet;
+use glyphs_reader::{Font, FromPlist, Plist};
 use log::debug;
-use std::cmp::min;
 use std::collections::HashSet;
-use std::ops::Range;
 use std::path::Path;
 use std::{collections::HashMap, fs, path::PathBuf};
-
-use crate::openstep_plist::Plist;
 
 pub struct GlyphsIrSource {
     glyphs_file: PathBuf,
     ir_paths: Paths,
-    plist_cache: Option<PlistCache>,
+    cache: Option<Cache>,
 }
 
 impl GlyphsIrSource {
@@ -21,97 +18,85 @@ impl GlyphsIrSource {
         GlyphsIrSource {
             glyphs_file,
             ir_paths,
-            plist_cache: None,
+            cache: None,
         }
     }
 }
 
-struct PlistCache {
+struct Cache {
     global_metadata: StateSet,
-    _root_dict: HashMap<String, Plist>,
+    _font: Font,
 }
 
-impl PlistCache {
+impl Cache {
     fn is_valid_for(&self, global_metadata: &StateSet) -> bool {
         self.global_metadata == *global_metadata
     }
+}
+
+fn fix_glyphs_named_infinity(glyphs_file: &Path, plist: &mut Plist) -> Result<(), Error> {
+    let Plist::Dictionary(root_dict) = plist else {
+        return Err(Error::ParseError(glyphs_file.to_path_buf(), "Root must be a dict".to_string()));
+    };
+    if !root_dict.contains_key("glyphs") {
+        return Ok(());
+    }
+    let Plist::Array(glyphs) = root_dict.get_mut("glyphs").unwrap() else {
+        return Err(Error::ParseError(glyphs_file.to_path_buf(), "Must have a glyphs array".to_string()));
+    };
+    for glyph in glyphs.iter_mut() {
+        let Plist::Dictionary(glyph) = glyph else {
+            return Err(Error::ParseError(glyphs_file.to_path_buf(), "Glyph must be a dict".to_string()));
+        };
+        if !glyph.contains_key("glyphname") {
+            continue;
+        }
+        if let Plist::Float(..) = glyph.get("glyphname").unwrap() {
+            glyph.insert(
+                "glyphname".to_string(),
+                Plist::String("infinity".to_string()),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn read_glyphs_file(glyphs_file: &Path) -> Result<Font, Error> {
+    let raw_content = fs::read_to_string(glyphs_file)?;
+    let mut raw_content = Plist::parse(&raw_content)
+        .map_err(|e| Error::ParseError(glyphs_file.to_path_buf(), format!("{:#?}", e)))?;
+    fix_glyphs_named_infinity(glyphs_file, &mut raw_content)?;
+    Ok(Font::from_plist(raw_content))
 }
 
 fn glyph_identifier(glyph_name: &str) -> String {
     format!("/glyph/{glyph_name}")
 }
 
-fn read_glyphs_file(glyphs_file: &Path) -> Result<(HashMap<String, Plist>, String), Error> {
-    let raw_plist = fs::read_to_string(glyphs_file).map_err(Error::IoError)?;
-    let plist = Plist::parse(&raw_plist).unwrap();
-    let Plist::Dictionary(root_dict, _) = plist else {
-        return Err(Error::ParseError(glyphs_file.to_path_buf(), "Root is not a dict".to_string()));
-    };
-    Ok((root_dict, raw_plist))
-}
+fn glyph_states(font: &Font) -> Result<HashMap<String, StateSet>, Error> {
+    let mut glyph_states = HashMap::new();
 
-fn glyph_name(
-    glyphs_file: &Path,
-    glyph: &HashMap<String, Plist>,
-    range: &Range<usize>,
-    raw_plist: &str,
-) -> Result<String, Error> {
-    // In an exciting turn of events it appears there are unquoted names that parse as floats
-    Ok(match glyph.get("glyphname") {
-        Some(Plist::String(glyph_name, _)) => glyph_name.clone(),
-        Some(Plist::Float(_, r)) => String::from(raw_plist[r.start..r.end].trim()),
-        _ => {
-            let (s, e) = (range.start, min(range.start + 8, range.end));
-            let message = format!("Missing glyphname at {:#?}: {}", range, &raw_plist[s..e]);
-            debug!("Parse failed:\n{:#?}", glyph);
-            return Err(Error::ParseError(glyphs_file.to_path_buf(), message));
-        }
-    })
-}
-
-fn glyphs(
-    glyphs_file: &Path,
-    root_dict: &HashMap<String, Plist>,
-    raw_plist: &str,
-) -> Result<HashMap<String, StateSet>, Error> {
-    let Some(Plist::Array(raw_glyphs, _)) = root_dict.get("glyphs") else {
-        return Err(Error::ParseError(glyphs_file.to_path_buf(), "No glyphs array".to_string()));
-    };
-
-    let mut glyphs = HashMap::new();
-    for glyph in raw_glyphs {
-        let Plist::Dictionary(glyph, range) = glyph else {
-            return Err(Error::ParseError(glyphs_file.to_path_buf(), "Glyphs must be dicts".to_string()));
-        };
-        let glyph_name = glyph_name(glyphs_file, glyph, range, raw_plist)?;
-        debug!("Parse {}", &glyph_name);
-        let mut change_tracker = StateSet::new();
-        change_tracker.track_slice(
-            glyph_identifier(&glyph_name),
-            &raw_plist[range.start..range.end],
-        )?;
-        glyphs.insert(glyph_name, change_tracker);
+    for glyph in font.glyphs.iter() {
+        let mut state = StateSet::new();
+        state.track_memory(glyph_identifier(&glyph.glyphname), Box::new(glyph))?;
+        glyph_states.insert(glyph.glyphname.clone(), state);
     }
 
-    Ok(glyphs)
+    Ok(glyph_states)
 }
 
 impl GlyphsIrSource {
     // When things like upem may have changed forget incremental and rebuild the whole thing
-    fn global_rebuild_triggers(
-        &self,
-        root_dict: &HashMap<String, Plist>,
-        raw_plist: &str,
-    ) -> Result<StateSet, Error> {
+    fn global_rebuild_triggers(&self, font: &Font) -> Result<StateSet, Error> {
         // Naive mk1: if anything other than glyphs and date changes do a global rebuild
         // TODO experiment with actual glyphs saves to see what makes sense
         let mut state = StateSet::new();
-        for (key, plist) in root_dict {
-            if key == "glyphs" || key == "date" {
+        state.track_memory("/font_master".to_string(), Box::new(&font.font_master))?;
+        for (key, plist) in font.other_stuff.iter() {
+            if key == "date" {
                 continue;
             }
-            let r = plist.range();
-            state.track_slice(format!("/{}", key), &raw_plist[r.start..r.end])?;
+            state.track_memory(format!("/{}", key), Box::new(plist))?;
         }
         Ok(state)
     }
@@ -120,13 +105,13 @@ impl GlyphsIrSource {
 impl Source for GlyphsIrSource {
     fn inputs(&mut self) -> Result<Input, Error> {
         // We have to read the glyphs file then shred it to figure out if anything changed
-        let (root_dict, raw_plist) = read_glyphs_file(&self.glyphs_file)?;
+        let font = read_glyphs_file(&self.glyphs_file)?;
+        let glyphs = glyph_states(&font)?;
+        let global_metadata = self.global_rebuild_triggers(&font)?;
 
-        let glyphs = glyphs(&self.glyphs_file, &root_dict, &raw_plist)?;
-        let global_metadata = self.global_rebuild_triggers(&root_dict, &raw_plist)?;
-        self.plist_cache = Some(PlistCache {
+        self.cache = Some(Cache {
             global_metadata: global_metadata.clone(),
-            _root_dict: root_dict,
+            _font: font,
         });
 
         Ok(Input {
@@ -145,7 +130,7 @@ impl Source for GlyphsIrSource {
         // Do we have a plist cache?
         // TODO: consider just recomputing here instead of failing
         if !self
-            .plist_cache
+            .cache
             .as_ref()
             .map(|pc| pc.is_valid_for(&input.global_metadata))
             .unwrap_or(false)
@@ -199,15 +184,12 @@ impl Work<()> for GlyphIrWork {
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
-        f64::INFINITY,
         path::{Path, PathBuf},
     };
 
     use fontir::stateset::StateSet;
 
-    use crate::openstep_plist::Plist;
-
-    use super::{glyph_name, glyphs, read_glyphs_file};
+    use super::{glyph_states, read_glyphs_file};
 
     fn testdata_dir() -> PathBuf {
         let dir = Path::new("../resources/testdata");
@@ -215,10 +197,10 @@ mod tests {
         dir.to_path_buf()
     }
 
-    fn glyphs_in_file(filename: &str) -> HashMap<String, StateSet> {
+    fn glyph_state_for_file(filename: &str) -> HashMap<String, StateSet> {
         let glyphs_file = testdata_dir().join(filename);
-        let (root_dict, raw_plist) = read_glyphs_file(&glyphs_file).unwrap();
-        glyphs(&glyphs_file, &root_dict, &raw_plist).unwrap()
+        let font = read_glyphs_file(&glyphs_file).unwrap();
+        glyph_states(&font).unwrap()
     }
 
     #[test]
@@ -226,14 +208,14 @@ mod tests {
         let expected_keys = HashSet::from(["space", "hyphen", "exclam"]);
         assert_eq!(
             expected_keys,
-            glyphs_in_file("WghtVar.glyphs")
+            glyph_state_for_file("WghtVar.glyphs")
                 .keys()
                 .map(|k| k.as_str())
                 .collect::<HashSet<&str>>()
         );
         assert_eq!(
             expected_keys,
-            glyphs_in_file("WghtVar_HeavyHyphen.glyphs")
+            glyph_state_for_file("WghtVar_HeavyHyphen.glyphs")
                 .keys()
                 .map(|k| k.as_str())
                 .collect::<HashSet<&str>>()
@@ -244,8 +226,8 @@ mod tests {
     fn detect_changed_glyphs() {
         let keys = HashSet::from(["space", "hyphen", "exclam"]);
 
-        let g1 = glyphs_in_file("WghtVar.glyphs");
-        let g2 = glyphs_in_file("WghtVar_HeavyHyphen.glyphs");
+        let g1 = glyph_state_for_file("WghtVar.glyphs");
+        let g2 = glyph_state_for_file("WghtVar_HeavyHyphen.glyphs");
 
         let changed = keys
             .iter()
@@ -260,39 +242,11 @@ mod tests {
         assert_eq!(HashSet::from(["hyphen".to_string()]), changed);
     }
 
+    // unquoted infinity likes to parse as a float which is suboptimal for glyph names. Survive.
+    // Observed on Work Sans and Lexend.
     #[test]
-    fn access_glyph_name_string() {
-        let mut glyph = HashMap::new();
-        glyph.insert(
-            "glyphname".to_string(),
-            Plist::String("space".to_string(), 0..1),
-        );
-        assert_eq!(
-            "space",
-            glyph_name(
-                Path::new("f.glyphs"),
-                &glyph,
-                &(1usize..12usize),
-                "I'm a plist"
-            )
-            .unwrap()
-        );
-    }
-
-    // glyphname = infinity (unquoted) has a cool trick where it parses as a float
-    #[test]
-    fn access_glyph_name_float() {
-        let mut glyph = HashMap::new();
-        glyph.insert("glyphname".to_string(), Plist::Float(INFINITY, 12..20));
-        assert_eq!(
-            "infinity",
-            glyph_name(
-                Path::new("f.glyphs"),
-                &glyph,
-                &(1usize..12usize),
-                "glyphname = infinity"
-            )
-            .unwrap()
-        );
+    fn survive_unquoted_infinity() {
+        // Read a minimal glyphs file that reproduces the error
+        read_glyphs_file(&testdata_dir().join("infinity.glyphs")).unwrap();
     }
 }

--- a/resources/testdata/infinity.glyphs
+++ b/resources/testdata/infinity.glyphs
@@ -1,0 +1,9 @@
+{
+glyphs = (
+	{
+		glyphname = infinity;
+		layers = ();
+	}
+);
+fontMaster = ();
+}


### PR DESCRIPTION
Grab Raph's plist-derive glyphs-reading, tweak it to support Hash, and use hash on types to track fragments of Glyphs files instead of relying on slices of the raw string.

Fixes #23 .