### PR TITLE
Parse unicode from glyphs files

### DIFF
--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -17,5 +17,7 @@ thiserror = "1.0.37"
 log = "0.4"
 env_logger = "0.9.0"
 
+regex = "1.7.0"
+
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -326,7 +326,7 @@ fn custom_param<'a>(
 }
 
 impl Font {
-    fn get_codepoints(&mut self, radix: u32) {
+    fn parse_codepoints(&mut self, radix: u32) {
         for glyph in self.glyphs.iter_mut() {
             if let Some(Plist::String(val)) = glyph.other_stuff.remove("unicode") {
                 let codepoints: Vec<i64> = val
@@ -546,7 +546,7 @@ impl Font {
             font.v2_to_v3()?;
             radix = 16;
         }
-        font.get_codepoints(radix);
+        font.parse_codepoints(radix);
 
         font.other_stuff.remove("date"); // exists purely to make diffs fail
         font.other_stuff.remove(".formatVersion"); // no longer relevent
@@ -646,7 +646,7 @@ mod tests {
     #[test]
     fn understand_v2_style_unquoted_hex_unicode() {
         let font = Font::load(&glyphs2_dir().join("Unicode-UnquotedHex.glyphs")).unwrap();
-        assert_eq!(Some(vec![0x3A2_i64]), font.glyphs[0].codepoints);
+        assert_eq!(Some(vec![0x1234_i64]), font.glyphs[0].codepoints);
         assert_eq!(1, font.glyphs.len());
     }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -69,7 +69,7 @@ impl GlyphsIrSource {
 impl Source for GlyphsIrSource {
     fn inputs(&mut self) -> Result<Input, Error> {
         // We have to read the glyphs file then shred it to figure out if anything changed
-        let font = Font::read_glyphs_file(&self.glyphs_file).map_err(|e| {
+        let font = Font::load(&self.glyphs_file).map_err(|e| {
             Error::ParseError(
                 self.glyphs_file.clone(),
                 format!("Unable to read glyphs file: {}", e),
@@ -175,7 +175,7 @@ mod tests {
 
     fn glyph_state_for_file(dir: &Path, filename: &str) -> HashMap<String, StateSet> {
         let glyphs_file = dir.join(filename);
-        let font = Font::read_glyphs_file(&glyphs_file).unwrap();
+        let font = Font::load(&glyphs_file).unwrap();
         glyph_states(&font).unwrap()
     }
 

--- a/resources/testdata/glyphs2/Unicode-QuotedHexSequence.glyphs
+++ b/resources/testdata/glyphs2/Unicode-QuotedHexSequence.glyphs
@@ -5,7 +5,7 @@ glyphs = (
 	{
 		glyphname = name;
 		layers = ();
-		unicode = "2044,2215";
+		unicode = "2044,200D,2215";
 	}
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs2/Unicode-QuotedHexSequence.glyphs
+++ b/resources/testdata/glyphs2/Unicode-QuotedHexSequence.glyphs
@@ -1,0 +1,12 @@
+{
+familyName = WghtVar;
+fontMaster = ();
+glyphs = (
+	{
+		glyphname = name;
+		layers = ();
+		unicode = "2044,2215";
+	}
+);
+unitsPerEm = 1000;
+}

--- a/resources/testdata/glyphs2/Unicode-UnquotedHex.glyphs
+++ b/resources/testdata/glyphs2/Unicode-UnquotedHex.glyphs
@@ -1,0 +1,12 @@
+{
+familyName = WghtVar;
+fontMaster = ();
+glyphs = (
+	{
+		glyphname = name;
+		layers = ();
+		unicode = 182;
+	}
+);
+unitsPerEm = 1000;
+}

--- a/resources/testdata/glyphs2/Unicode-UnquotedHex.glyphs
+++ b/resources/testdata/glyphs2/Unicode-UnquotedHex.glyphs
@@ -5,7 +5,7 @@ glyphs = (
 	{
 		glyphname = name;
 		layers = ();
-		unicode = 182;
+		unicode = 03A2;
 	}
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs2/Unicode-UnquotedHex.glyphs
+++ b/resources/testdata/glyphs2/Unicode-UnquotedHex.glyphs
@@ -5,7 +5,7 @@ glyphs = (
 	{
 		glyphname = name;
 		layers = ();
-		unicode = 03A2;
+		unicode = 1234;
 	}
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs3/Unicode-UnquotedDec.glyphs
+++ b/resources/testdata/glyphs3/Unicode-UnquotedDec.glyphs
@@ -1,0 +1,12 @@
+{
+familyName = WghtVar;
+fontMaster = ();
+glyphs = (
+	{
+		glyphname = name;
+		layers = ();
+		unicode = 182;
+	}
+);
+unitsPerEm = 1000;
+}

--- a/resources/testdata/glyphs3/Unicode-UnquotedDec.glyphs
+++ b/resources/testdata/glyphs3/Unicode-UnquotedDec.glyphs
@@ -1,4 +1,5 @@
 {
+.formatVersion = 3;
 familyName = WghtVar;
 fontMaster = ();
 glyphs = (

--- a/resources/testdata/glyphs3/Unicode-UnquotedDecSequence.glyphs
+++ b/resources/testdata/glyphs3/Unicode-UnquotedDecSequence.glyphs
@@ -1,0 +1,12 @@
+{
+familyName = WghtVar;
+fontMaster = ();
+glyphs = (
+	{
+		glyphname = name;
+		layers = ();
+		unicode = (1619,1764);
+	}
+);
+unitsPerEm = 1000;
+}

--- a/resources/testdata/glyphs3/Unicode-UnquotedDecSequence.glyphs
+++ b/resources/testdata/glyphs3/Unicode-UnquotedDecSequence.glyphs
@@ -1,4 +1,5 @@
 {
+.formatVersion = 3;
 familyName = WghtVar;
 fontMaster = ();
 glyphs = (


### PR DESCRIPTION
Add examples of all known codepoint formats in glyphs files and prove we can parse them. Fixes #34.

I wound up just bashing it with a regex to make it consistent as that lets me keep the logic simple.