### PR TITLE
Remove unused fontations deps

### DIFF
--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -11,8 +11,6 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-font-types = { git = 'https://github.com/googlefonts/fontations' }
-read-fonts = { git = 'https://github.com/googlefonts/fontations' }
 fontir = { version = "0.0.1", path = "../fontir" }
 glyphs2fontir = { version = "0.0.1", path = "../glyphs2fontir" }
 ufo2fontir = { version = "0.0.1", path = "../ufo2fontir" }

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -11,8 +11,6 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-font-types = { git = 'https://github.com/googlefonts/fontations' }
-read-fonts = { git = 'https://github.com/googlefonts/fontations' }
 bitflags = "1.3"
 serde = {version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.14"

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-read-fonts = { git = 'https://github.com/googlefonts/fontations' }
 fontir = { version = "0.0.1", path = "../fontir" }
 glyphs-reader = { version = "0.0.1", path = "../glyphs-reader" }
 

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-read-fonts = { git = 'https://github.com/googlefonts/fontations' }
 fontir = { version = "0.0.1", path = "../fontir" }
 
 norad = "0.8.0"


### PR DESCRIPTION
I'm sure we'll add them back in time as proper deps but we don't need them right now. This gets us to git-clean for #17.