### PR TITLE
Push Glyphs axes => StaticMetadata using Context

### DIFF
--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use fontc::Error;
 use fontir::{
     error::WorkError,
-    orchestration::Context,
+    orchestration::{Context, WorkIdentifier},
     source::{DeleteWork, Input, Paths, Source, Work},
     stateset::StateSet,
 };
@@ -25,6 +25,11 @@ struct Args {
     /// A designspace, ufo, or glyphs file
     #[arg(short, long)]
     source: PathBuf,
+
+    /// Whether to write IR to disk. Must be true if you want incremental compilation.
+    #[arg(short, long)]
+    #[clap(default_value = "true")]
+    emit_ir: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -97,22 +102,19 @@ fn init(build_dir: &Path, args: Args) -> Result<(Config, Input), io::Error> {
     Ok((config, ir_input))
 }
 
-fn ir_source(source: &Path, paths: Paths) -> Result<Box<dyn Source>, Error> {
+fn ir_source(source: &Path) -> Result<Box<dyn Source>, Error> {
     let ext = source
         .extension()
         .and_then(OsStr::to_str)
         .ok_or_else(|| Error::UnrecognizedSource(source.to_path_buf()))?;
     match ext {
-        "designspace" => Ok(Box::from(DesignSpaceIrSource::new(
-            source.to_path_buf(),
-            paths,
-        ))),
-        "glyphs" => Ok(Box::from(GlyphsIrSource::new(source.to_path_buf(), paths))),
+        "designspace" => Ok(Box::from(DesignSpaceIrSource::new(source.to_path_buf()))),
+        "glyphs" => Ok(Box::from(GlyphsIrSource::new(source.to_path_buf()))),
         _ => Err(Error::UnrecognizedSource(source.to_path_buf())),
     }
 }
 
-fn finish_successfully(context: CompileContext) -> Result<(), Error> {
+fn finish_successfully(context: ChangeDetector) -> Result<(), Error> {
     let current_sources =
         serde_yaml::to_string(&context.current_inputs).map_err(Error::YamlSerError)?;
     fs::write(context.paths.ir_input_file(), current_sources).map_err(Error::IoError)
@@ -122,7 +124,7 @@ fn global_change(current_inputs: &Input, prev_inputs: &Input) -> bool {
     current_inputs.global_metadata != prev_inputs.global_metadata
 }
 
-fn glyphs_changed(context: &CompileContext) -> HashSet<&str> {
+fn glyphs_changed(context: &ChangeDetector) -> HashSet<&str> {
     if global_change(&context.current_inputs, &context.prev_inputs) {
         return context
             .current_inputs
@@ -157,35 +159,55 @@ fn glyphs_deleted<'a>(current_inputs: &Input, prev_inputs: &'a Input) -> HashSet
         .collect()
 }
 
+fn add_static_metadata_work(
+    change_detector: &mut ChangeDetector,
+    context: &Context,
+    work: &mut Vec<Box<dyn Work>>,
+) -> Result<(), Error> {
+    let context = context.copy_for_work(WorkIdentifier::StaticMetadata, None);
+    work.push(
+        change_detector
+            .ir_source
+            .create_static_metadata_work(&context)?,
+    );
+    Ok(())
+}
+
 fn add_glyph_work(
-    context: &mut CompileContext,
+    config: &Config,
+    change_detector: &mut ChangeDetector,
+    context: &Context,
     work: &mut Vec<Box<dyn Work>>,
 ) -> Result<(), Error> {
     // Destroy IR for deleted glyphs
     work.extend(
-        glyphs_deleted(&context.current_inputs, &context.prev_inputs)
-            .iter()
-            .map(|glyph_name| DeleteWork::create(context.paths.glyph_ir_file(glyph_name))),
+        glyphs_deleted(
+            &change_detector.current_inputs,
+            &change_detector.prev_inputs,
+        )
+        .iter()
+        .map(|glyph_name| DeleteWork::create(change_detector.paths.glyph_ir_file(glyph_name))),
     );
 
     // Generate IR for changed glyphs
-    let glyphs_changed = glyphs_changed(context);
-    let glyph_work = context
+    let glyphs_changed = glyphs_changed(change_detector);
+    let glyph_work = change_detector
         .ir_source
-        .create_glyph_ir_work(&glyphs_changed, &context.current_inputs)?;
+        .create_glyph_ir_work(&glyphs_changed, context)?;
+    if config.args.emit_ir {}
     work.extend(glyph_work);
 
     Ok(())
 }
 
-fn do_work(work: Vec<Box<dyn Work>>) -> Result<(), Error> {
+fn do_work(context: &Context, work: Vec<Box<dyn Work>>) -> Result<(), Error> {
     let work_units = work.len();
     debug!("{} work units to execute", work_units);
-    let root_context = Context::new_root();
+
     // TODO: https://github.com/googlefonts/fontmake-rs/pull/26 style execution w/task-specific contexts
     let errors: Vec<WorkError> = work
         .into_par_iter()
-        .filter_map(|work| work.exec(&root_context).err())
+        .filter_map(|work| work.exec(context).err())
         .collect();
     for error in errors.iter() {
         warn!("{:#?}", error);
@@ -203,29 +225,32 @@ fn do_work(work: Vec<Box<dyn Work>>) -> Result<(), Error> {
     Ok(())
 }
 
-struct CompileContext {
+struct ChangeDetector {
     paths: Paths,
     ir_source: Box<dyn Source>,
     prev_inputs: Input,
     current_inputs: Input,
 }
 
-impl CompileContext {
-    fn new(paths: Paths, args: Args) -> Result<CompileContext, Error> {
+impl ChangeDetector {
+    fn new(paths: Paths, args: Args) -> Result<(Config, ChangeDetector), Error> {
         let build_dir = require_dir(paths.build_dir())?;
         require_dir(paths.glyph_ir_dir())?;
         let (config, prev_inputs) = init(&build_dir, args).map_err(Error::IoError)?;
 
         // What sources are we dealing with?
-        let mut ir_source = ir_source(&config.args.source, paths.clone())?;
+        let mut ir_source = ir_source(&config.args.source)?;
         let current_inputs = ir_source.inputs().map_err(Error::FontIrError)?;
 
-        Ok(CompileContext {
-            paths,
-            ir_source,
-            prev_inputs,
-            current_inputs,
-        })
+        Ok((
+            config,
+            ChangeDetector {
+                paths,
+                ir_source,
+                prev_inputs,
+                current_inputs,
+            },
+        ))
     }
 }
 
@@ -233,22 +258,33 @@ fn main() -> Result<(), Error> {
     env_logger::init();
 
     let paths = Paths::new(Path::new("build"));
-    let mut context = CompileContext::new(paths, Args::parse())?;
+    let (config, mut change_detector) = ChangeDetector::new(paths.clone(), Args::parse())?;
+    let context = Context::new_root(
+        config.args.emit_ir,
+        paths,
+        change_detector.current_inputs.clone(),
+    );
 
     // TODO: consider making a more explicit model of a graph
     // TODO: Rayon focuses on CPU-bound tasks but we are doing IO too
     // perhaps we should do the IO first, e.g. read (but not parse) inputs, etc?
 
+    // TODO: enter metadata work onto threadpool, proper dependencies
+    // Pending proper graph processing just run it first
+    let mut work: Vec<Box<dyn Work>> = Vec::new();
+    add_static_metadata_work(&mut change_detector, &context, &mut work)?;
+    do_work(&context, work)?;
+
     // Accumulate work for the parts of IR that trivially parallelize
     let mut work: Vec<Box<dyn Work>> = Vec::new();
 
-    add_glyph_work(&mut context, &mut work)?;
+    add_glyph_work(&config, &mut change_detector, &context, &mut work)?;
 
     // Try to do the work
-    do_work(work)?;
+    do_work(&context, work)?;
 
     // Goodness, it all seems to have worked
-    finish_successfully(context)?;
+    finish_successfully(change_detector)?;
     Ok(())
 }
 
@@ -266,8 +302,8 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::{
-        add_glyph_work, config_file, finish_successfully, glyphs_changed, glyphs_deleted, init,
-        Args, CompileContext, Config,
+        add_glyph_work, add_static_metadata_work, config_file, finish_successfully, glyphs_changed,
+        glyphs_deleted, init, Args, ChangeDetector, Config,
     };
 
     fn testdata_dir() -> PathBuf {
@@ -278,13 +314,20 @@ mod tests {
         path
     }
 
+    fn test_args(source: &str) -> Args {
+        Args {
+            source: testdata_dir().join(source),
+            emit_ir: true,
+        }
+    }
+
     struct TestCompile {
         glyphs_changed: HashSet<String>,
         glyphs_deleted: HashSet<String>,
     }
 
     impl TestCompile {
-        fn new(context: &CompileContext) -> TestCompile {
+        fn new(context: &ChangeDetector) -> TestCompile {
             TestCompile {
                 glyphs_changed: glyphs_changed(context)
                     .iter()
@@ -302,9 +345,8 @@ mod tests {
     fn init_captures_state() {
         let temp_dir = tempdir().unwrap();
         let build_dir = temp_dir.path();
-        let args = Args {
-            source: testdata_dir().join("wght_var.designspace"),
-        };
+        let args = test_args("wght_var.designspace");
+
         init(build_dir, args.clone()).unwrap();
         let config_file = config_file(build_dir);
         let paths = Paths::new(build_dir);
@@ -323,9 +365,7 @@ mod tests {
     fn detect_compiler_change() {
         let temp_dir = tempdir().unwrap();
         let build_dir = temp_dir.path();
-        let args = Args {
-            source: testdata_dir().join("wght_var.designspace"),
-        };
+        let args = test_args("wght_var.designspace");
         init(build_dir, args.clone()).unwrap();
 
         let compiler_location = std::env::current_exe().unwrap();
@@ -341,24 +381,27 @@ mod tests {
     }
 
     fn compile(build_dir: &Path, source: &str) -> TestCompile {
-        let args = Args {
-            source: testdata_dir().join(source),
-        };
+        let args = test_args(source);
         let paths = Paths::new(build_dir);
-        let mut context = CompileContext::new(paths, args).unwrap();
-        let result = TestCompile::new(&context);
+        let (config, mut change_detector) = ChangeDetector::new(paths.clone(), args).unwrap();
+        let work_context = Context::new_root(
+            config.args.emit_ir,
+            paths,
+            change_detector.current_inputs.clone(),
+        );
+        let result = TestCompile::new(&change_detector);
 
         let mut work = Vec::new();
 
-        add_glyph_work(&mut context, &mut work).unwrap();
+        add_static_metadata_work(&mut change_detector, &work_context, &mut work).unwrap();
+        add_glyph_work(&config, &mut change_detector, &work_context, &mut work).unwrap();
 
         // Try to do the work
-        let root_context = Context::new_root();
         for work_item in work {
-            work_item.exec(&root_context).unwrap();
+            work_item.exec(&work_context).unwrap();
         }
 
-        finish_successfully(context).unwrap();
+        finish_successfully(change_detector).unwrap();
         result
     }
 

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -46,4 +46,6 @@ pub enum WorkError {
     YamlSerError(#[from] serde_yaml::Error),
     #[error("No axes are defined")]
     NoAxisDefinitions,
+    #[error("Axis definitions are inconsistent")]
+    InconsistentAxisDefinitions,
 }

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     FileExpected(PathBuf),
     #[error("IO failure")]
     IoError(#[from] io::Error),
-    #[error("Unable to parse")]
+    #[error("Unable to parse {0:?}: {1}")]
     ParseError(PathBuf, String),
     #[error("Illegible source")]
     UnableToLoadSource(Box<dyn error::Error>),
@@ -33,6 +33,8 @@ pub enum Error {
     },
     #[error("Global metadata very bad, very very bad")]
     InvalidGlobalMetadata,
+    #[error("No default master in {0:?}")]
+    NoDefaultMaster(PathBuf),
 }
 
 /// An async work error, hence one that must be Send
@@ -52,4 +54,8 @@ pub enum WorkError {
     InconsistentAxisDefinitions(String),
     #[error("I am the glyph with gid, {0}")]
     NoGlyphIdForName(String),
+    #[error("File expected: {0:?}")]
+    FileExpected(PathBuf),
+    #[error("Unable to parse {0:?}: {1}")]
+    ParseError(PathBuf, String),
 }

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -31,6 +31,8 @@ pub enum Error {
         what: String,
         loc: DesignSpaceLocation,
     },
+    #[error("Global metadata very bad, very very bad")]
+    InvalidGlobalMetadata,
 }
 
 /// An async work error, hence one that must be Send
@@ -47,5 +49,7 @@ pub enum WorkError {
     #[error("No axes are defined")]
     NoAxisDefinitions,
     #[error("Axis definitions are inconsistent")]
-    InconsistentAxisDefinitions,
+    InconsistentAxisDefinitions(String),
+    #[error("I am the glyph with gid, {0}")]
+    NoGlyphIdForName(String),
 }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1,11 +1,11 @@
-//! Serde types for font IR. See TODO:PublicLink.
+//! Serde types for font IR.
 
 use crate::error::Error;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
-///Global font info that cannot vary.
+/// Global font info that cannot vary.
 ///
 /// For example, upem, axis definitions, etc, as distinct from
 /// metadata that varies across design space such as ascender/descender.
@@ -13,6 +13,15 @@ use std::collections::{BTreeMap, HashMap};
 pub struct StaticMetadata {
     pub axes: Vec<Axis>,
     pub glyph_order: Vec<String>,
+}
+
+impl StaticMetadata {
+    pub fn glyph_id(&self, name: &str) -> Option<u32> {
+        self.glyph_order
+            .iter()
+            .position(|gn| gn == name)
+            .map(|pos| pos as u32)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -11,8 +11,8 @@ use std::collections::{BTreeMap, HashMap};
 /// metadata that varies across design space such as ascender/descender.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct StaticMetadata {
-    axes: Vec<Axis>,
-    glyph_order: Vec<String>,
+    pub axes: Vec<Axis>,
+    pub glyph_order: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -14,7 +14,7 @@ use crate::ir;
 // Unique identifier of work. If there are no fields work is unique.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum WorkIdentifier {
-    GlobalMetadata,
+    StaticMetadata,
     GlyphIr(u32),
     FinishIr,
 }
@@ -97,15 +97,15 @@ impl Context {
     }
 
     pub fn get_static_metadata(&self) -> Arc<ir::StaticMetadata> {
-        self.check_read_access(&WorkIdentifier::GlobalMetadata);
+        self.check_read_access(&WorkIdentifier::StaticMetadata);
         let rl = self.static_metadata.item.read();
         rl.as_ref().expect(MISSING_DATA).clone()
     }
 
-    pub fn set_static_metadata(&self, global_metadata: ir::StaticMetadata) {
-        self.check_write_access(&WorkIdentifier::GlobalMetadata);
+    pub fn set_static_metadata(&self, static_metadata: ir::StaticMetadata) {
+        self.check_write_access(&WorkIdentifier::StaticMetadata);
         let mut wl = self.static_metadata.item.write();
-        *wl = Some(Arc::from(global_metadata));
+        *wl = Some(Arc::from(static_metadata));
     }
 
     pub fn get_glyph_ir(&self, glyph_order: u32) -> Arc<ir::Glyph> {

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 // Unique identifier of work. If there are no fields work is unique.
+// Meant to be small and cheap to copy around.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum WorkIdentifier {
     StaticMetadata,
@@ -147,16 +148,16 @@ impl Context {
         *wl = Some(Arc::from(static_metadata));
     }
 
-    pub fn get_glyph_ir(&self, glyph_order: u32) -> Arc<ir::Glyph> {
-        self.check_read_access(&WorkIdentifier::GlyphIr(glyph_order));
+    pub fn get_glyph_ir(&self, glyph_id: u32) -> Arc<ir::Glyph> {
+        self.check_read_access(&WorkIdentifier::GlyphIr(glyph_id));
         let rl = self.glyph_ir.item.read();
-        rl.get(&glyph_order).expect(MISSING_DATA).clone()
+        rl.get(&glyph_id).expect(MISSING_DATA).clone()
     }
 
-    pub fn set_glyph_ir(&self, glyph_order: u32, ir: ir::Glyph) {
-        self.check_write_access(&WorkIdentifier::GlyphIr(glyph_order));
+    pub fn set_glyph_ir(&self, glyph_id: u32, ir: ir::Glyph) {
+        self.check_write_access(&WorkIdentifier::GlyphIr(glyph_id));
         self.maybe_persist(&self.paths.glyph_ir_file(&ir.name), &ir);
         let mut wl = self.glyph_ir.item.write();
-        wl.insert(glyph_order, Arc::from(ir));
+        wl.insert(glyph_id, Arc::from(ir));
     }
 }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -4,12 +4,19 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    fs::File,
+    io::BufWriter,
+    path::Path,
     sync::Arc,
 };
 
 use parking_lot::RwLock;
+use serde::Serialize;
 
-use crate::ir;
+use crate::{
+    ir,
+    source::{Input, Paths},
+};
 
 // Unique identifier of work. If there are no fields work is unique.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -27,6 +34,15 @@ const MISSING_DATA: &str = "Missing data, dependency management failed us?";
 /// access with spawned tasks. Copies with access control are created to detect bad
 /// execution order / mistakes, not to block actual bad actors.
 pub struct Context {
+    // If set IR will be emitted to disk when written into Context
+    emit_ir: bool,
+
+    paths: Arc<Paths>,
+
+    // The input we're working on. Note that change detection may mean we only process
+    // a subset of the full input.
+    pub input: Arc<Input>,
+
     // If present, the one and only key you are allowed to write to
     // Otherwise you totally get to write whatever you like
     write_mask: Option<WorkIdentifier>,
@@ -55,8 +71,11 @@ impl<T: Default> Cache<T> {
 }
 
 impl Context {
-    pub fn new_root() -> Context {
+    pub fn new_root(emit_ir: bool, paths: Paths, input: Input) -> Context {
         Context {
+            emit_ir,
+            paths: Arc::from(paths),
+            input: Arc::from(input),
             write_mask: None,
             read_mask: None,
             static_metadata: Cache::new(),
@@ -69,11 +88,14 @@ impl Context {
     pub fn copy_for_work(
         &self,
         work_id: WorkIdentifier,
-        dependencies: HashSet<WorkIdentifier>,
+        dependencies: Option<HashSet<WorkIdentifier>>,
     ) -> Context {
         Context {
+            emit_ir: self.emit_ir,
+            paths: self.paths.clone(),
+            input: self.input.clone(),
             write_mask: Some(work_id),
-            read_mask: Some(dependencies),
+            read_mask: dependencies.or_else(|| Some(HashSet::new())),
             static_metadata: self.static_metadata.clone(),
             glyph_ir: self.glyph_ir.clone(),
         }
@@ -96,6 +118,22 @@ impl Context {
         }
     }
 
+    fn maybe_persist<V>(&self, file: &Path, content: &V)
+    where
+        V: ?Sized + Serialize,
+    {
+        if !self.emit_ir {
+            return;
+        }
+        let raw_file = File::create(file)
+            .map_err(|e| panic!("Unable to write {:?} {}", file, e))
+            .unwrap();
+        let buf_io = BufWriter::new(raw_file);
+        serde_yaml::to_writer(buf_io, &content)
+            .map_err(|e| panic!("Unable to serialize to {:?}: {}", file, e))
+            .unwrap();
+    }
+
     pub fn get_static_metadata(&self) -> Arc<ir::StaticMetadata> {
         self.check_read_access(&WorkIdentifier::StaticMetadata);
         let rl = self.static_metadata.item.read();
@@ -104,6 +142,7 @@ impl Context {
 
     pub fn set_static_metadata(&self, static_metadata: ir::StaticMetadata) {
         self.check_write_access(&WorkIdentifier::StaticMetadata);
+        self.maybe_persist(&self.paths.static_metadata_ir_file(), &static_metadata);
         let mut wl = self.static_metadata.item.write();
         *wl = Some(Arc::from(static_metadata));
     }
@@ -116,6 +155,7 @@ impl Context {
 
     pub fn set_glyph_ir(&self, glyph_order: u32, ir: ir::Glyph) {
         self.check_write_access(&WorkIdentifier::GlyphIr(glyph_order));
+        self.maybe_persist(&self.paths.glyph_ir_file(&ir.name), &ir);
         let mut wl = self.glyph_ir.item.write();
         wl.insert(glyph_order, Arc::from(ir));
     }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -3,7 +3,31 @@ use std::{collections::HashMap, path::PathBuf};
 use filetime::FileTime;
 use serde::{Deserialize, Serialize};
 
-use crate::stateset::{FileState, MemoryState, State, StateIdentifier, StateSet};
+use crate::{
+    ir::{Axis, StaticMetadata},
+    stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
+};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct StaticMetadataSerdeRepr {
+    pub axes: Vec<Axis>,
+    pub glyph_order: Vec<String>,
+}
+
+impl From<StaticMetadataSerdeRepr> for StaticMetadata {
+    fn from(from: StaticMetadataSerdeRepr) -> Self {
+        StaticMetadata::new(from.axes, from.glyph_order)
+    }
+}
+
+impl From<StaticMetadata> for StaticMetadataSerdeRepr {
+    fn from(from: StaticMetadata) -> Self {
+        StaticMetadataSerdeRepr {
+            axes: from.axes,
+            glyph_order: from.glyph_order,
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct StateSetSerdeRepr {

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -53,6 +53,11 @@ pub trait Source {
     /// Mut to permit caching.
     fn inputs(&mut self) -> Result<Input, Error>;
 
+    /// Create a function that could be called to generate [crate::ir::StaticMetadata].
+    ///
+    /// When run work should update [Context] with new [crate::ir::StaticMetadata].
+    fn create_static_metadata_work(&self, context: &Context) -> Result<Box<dyn Work>, Error>;
+
     /// Create a function that could be called to generate IR for glyphs.
     ///
     /// Batched because some formats require IO to figure out the work.

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -64,7 +64,7 @@ pub trait Source {
     fn create_glyph_ir_work(
         &self,
         glyph_names: &HashSet<&str>,
-        input: &Input,
+        context: &Context,
     ) -> Result<Vec<Box<dyn Work>>, Error>;
 }
 
@@ -94,6 +94,10 @@ impl Paths {
 
     pub fn ir_input_file(&self) -> &Path {
         &self.ir_input_file
+    }
+
+    pub fn static_metadata_ir_file(&self) -> PathBuf {
+        self.build_dir.join("static_metadata.yml")
     }
 
     pub fn glyph_ir_dir(&self) -> &Path {

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -33,7 +33,7 @@ pub struct Font {
     pub default_master_idx: usize,
     pub glyphs: BTreeMap<String, Glyph>,
     pub glyph_order: Vec<String>,
-    pub codepoints: BTreeMap<String, Vec<u32>>,
+    pub codepoints: BTreeMap<Vec<u32>, String>,
 }
 
 // The font you get directly from a plist, minimally modified
@@ -621,8 +621,8 @@ fn parse_glyph_order(raw_font: &RawFont) -> Vec<String> {
     glyph_order
 }
 
-fn parse_codepoints(raw_font: &mut RawFont, radix: u32) -> BTreeMap<String, Vec<u32>> {
-    let mut cp_by_name = BTreeMap::new();
+fn parse_codepoints(raw_font: &mut RawFont, radix: u32) -> BTreeMap<Vec<u32>, String> {
+    let mut cp_to_name = BTreeMap::new();
     for glyph in raw_font.glyphs.iter_mut() {
         if let Some(Plist::String(val)) = glyph.other_stuff.remove("unicode") {
             let codepoints = val
@@ -630,10 +630,10 @@ fn parse_codepoints(raw_font: &mut RawFont, radix: u32) -> BTreeMap<String, Vec<
                 .into_iter()
                 .map(|v| i64::from_str_radix(v, radix).unwrap() as u32)
                 .collect();
-            cp_by_name.insert(glyph.glyphname.clone(), codepoints);
+            cp_to_name.insert(codepoints, glyph.glyphname.clone());
         };
     }
-    cp_by_name
+    cp_to_name
 }
 
 fn default_master_idx(raw_font: &RawFont) -> usize {
@@ -817,28 +817,28 @@ mod tests {
     #[test]
     fn understand_v2_style_unquoted_hex_unicode() {
         let font = Font::load(&glyphs2_dir().join("Unicode-UnquotedHex.glyphs")).unwrap();
-        assert_eq!(vec![0x1234], font.codepoints["name"]);
+        assert_eq!("name", font.codepoints[&vec![0x1234]]);
         assert_eq!(1, font.glyphs.len());
     }
 
     #[test]
     fn understand_v2_style_quoted_hex_unicode_sequence() {
         let font = Font::load(&glyphs2_dir().join("Unicode-QuotedHexSequence.glyphs")).unwrap();
-        assert_eq!(vec![0x2044, 0x200D, 0x2215], font.codepoints["name"]);
+        assert_eq!("name", font.codepoints[&vec![0x2044, 0x200D, 0x2215]]);
         assert_eq!(1, font.glyphs.len());
     }
 
     #[test]
     fn understand_v3_style_unquoted_decimal_unicode() {
         let font = Font::load(&glyphs3_dir().join("Unicode-UnquotedDec.glyphs")).unwrap();
-        assert_eq!(vec![182], font.codepoints["name"]);
+        assert_eq!("name", font.codepoints[&vec![182]]);
         assert_eq!(1, font.glyphs.len());
     }
 
     #[test]
     fn understand_v3_style_unquoted_decimal_unicode_sequence() {
         let font = Font::load(&glyphs3_dir().join("Unicode-UnquotedDecSequence.glyphs")).unwrap();
-        assert_eq!(vec![1619, 1764], font.codepoints["name"]);
+        assert_eq!("name", font.codepoints[&vec![1619, 1764]]);
         assert_eq!(1, font.glyphs.len());
     }
 

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -666,12 +666,11 @@ impl Font {
     pub fn default_master_idx(&self) -> usize {
         // https://github.com/googlefonts/fontmake-rs/issues/44
         custom_param(&self.other_stuff, "Variable Font Origin")
-            .map(|(_, param)| match param {
-                Plist::Dictionary(dict) => dict.get("value"),
-                _ => None,
-            })
-            .map(|value| {
-                let Some(Plist::String(origin)) = value else {
+            .map(|(_, param)| {
+                let Plist::Dictionary(dict) = param else {
+                    return 0;
+                };
+                let Some(Plist::String(origin)) = dict.get("value") else {
                     warn!("Incomprehensible Variable Font Origin");
                     return 0;
                 };
@@ -680,9 +679,9 @@ impl Font {
                     .enumerate()
                     .find(|(_, master)| &master.id == origin)
                     .map(|(idx, _)| idx)
-                    .unwrap_or_default()
+                    .unwrap_or(0)
             })
-            .unwrap_or_default()
+            .unwrap_or(0)
     }
 }
 

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -21,6 +21,8 @@ env_logger = "0.9.0"
 
 thiserror = "1.0.37"
 
+ordered-float = "3.4.0"
+
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -208,7 +208,7 @@ impl Work for StaticMetadataWork {
             .collect();
 
         let glyph_order = font.glyphs.iter().map(|g| g.glyphname.clone()).collect();
-        context.set_static_metadata(StaticMetadata { axes, glyph_order });
+        context.set_static_metadata(StaticMetadata::new(axes, glyph_order));
         Ok(())
     }
 }

--- a/resources/testdata/WghtVar-Bold.ufo/glyphs/bonus_bar.glif
+++ b/resources/testdata/WghtVar-Bold.ufo/glyphs/bonus_bar.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bonus_bar" format="2">
+  <advance width="551"/>
+  <unicode hex="007F"/>
+  <outline>
+    <contour>
+      <point x="222" y="-227" type="line"/>
+      <point x="329" y="-227" type="line"/>
+      <point x="329" y="757" type="line"/>
+      <point x="222" y="757" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/WghtVar-Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/WghtVar-Bold.ufo/glyphs/contents.plist
@@ -6,5 +6,8 @@
     <string>bar.glif</string>
     <key>plus</key>
     <string>plus.glif</string>
+    <!-- should be eliminated as it does not exist in default master -->
+    <key>bonus_bar</key>
+    <string>bonus_bar.glif</string>
   </dict>
 </plist>

--- a/resources/testdata/WghtVar-Regular.ufo/lib.plist
+++ b/resources/testdata/WghtVar-Regular.ufo/lib.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>plus</string>
+      <!-- bar is deliberately omitted -->
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/glyphs3/WghtVar_3master_CustomOrigin.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_3master_CustomOrigin.glyphs
@@ -1,0 +1,269 @@
+{
+.appVersion = "3148";
+.formatVersion = 3;
+DisplayStrings = (
+"-",
+"!"
+);
+axes = (
+{
+hidden = 1;
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Variable Font Origin";
+value = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+},
+{
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+200
+);
+iconName = Light;
+id = "3EF7A796-1DDB-47F3-B4E9-E96F9C072618";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Thin;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-09 01:38:15 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+},
+{
+layerId = "3EF7A796-1DDB-47F3-B4E9-E96F9C072618";
+width = 600;
+}
+);
+unicode = 32;
+},
+{
+glyphname = exclam;
+lastChange = "2022-12-09 01:39:12 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,183,l),
+(414,585,l),
+(178,585,l),
+(238,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,0,l),
+(354,107,l),
+(238,107,l),
+(238,0,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,176,l),
+(434,605,l),
+(159,605,l),
+(228,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,-20,l),
+(364,94,l),
+(228,94,l),
+(228,-20,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "3EF7A796-1DDB-47F3-B4E9-E96F9C072618";
+shapes = (
+{
+closed = 1;
+nodes = (
+(339,173,l),
+(384,551,l),
+(209,551,l),
+(253,172,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(339,1,l),
+(339,101,l),
+(253,101,l),
+(253,1,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 33;
+},
+{
+glyphname = hyphen;
+lastChange = "2022-12-09 01:38:09 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,250,l),
+(470,250,l),
+(470,330,l),
+(131,330,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,224,l),
+(508,224,l),
+(508,356,l),
+(92,356,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "3EF7A796-1DDB-47F3-B4E9-E96F9C072618";
+shapes = (
+{
+closed = 1;
+nodes = (
+(163,265,l),
+(438,265,l),
+(438,315,l),
+(163,315,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = (45,46);
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs3/WghtVar_GlyphOrder.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_GlyphOrder.glyphs
@@ -17,7 +17,7 @@ name = glyphOrder;
 value = (
 hyphen,
 space,
-exclam
+not-a-valid-name
 );
 }
 );

--- a/resources/testdata/glyphs3/WghtVar_GlyphOrder.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_GlyphOrder.glyphs
@@ -75,43 +75,6 @@ name = Bold;
 );
 glyphs = (
 {
-glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
-layers = (
-{
-layerId = m01;
-shapes = (
-{
-closed = 1;
-nodes = (
-(131,250,l),
-(470,250,l),
-(470,330,l),
-(131,330,l)
-);
-}
-);
-width = 600;
-},
-{
-layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
-shapes = (
-{
-closed = 1;
-nodes = (
-(92,224,l),
-(508,224,l),
-(508,356,l),
-(92,356,l)
-);
-}
-);
-width = 600;
-}
-);
-unicode = 45;
-},
-{
 glyphname = space;
 lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
@@ -159,27 +122,40 @@ layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 shapes = (
 {
 closed = 1;
-nodes = (
-(364,176,l),
-(434,605,l),
-(159,605,l),
-(228,174,l)
-);
-},
-{
-closed = 1;
-nodes = (
-(364,-20,l),
-(364,94,l),
-(228,94,l),
-(228,-20,l)
-);
+nodes = ();
 }
 );
 width = 600;
 }
 );
 unicode = 33;
+},
+{
+glyphname = hyphen;
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = ();
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = ();
+}
+);
+width = 600;
+}
+);
+unicode = 45;
 }
 );
 metrics = (

--- a/resources/testdata/glyphs3/WghtVar_GlyphOrder.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_GlyphOrder.glyphs
@@ -1,0 +1,205 @@
+{
+.appVersion = "3148";
+.formatVersion = 3;
+DisplayStrings = (
+"-",
+"!"
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = glyphOrder;
+value = (
+hyphen,
+space,
+exclam
+);
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+},
+{
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = hyphen;
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,250,l),
+(470,250,l),
+(470,330,l),
+(131,330,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,224,l),
+(508,224,l),
+(508,356,l),
+(92,356,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 45;
+},
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+},
+{
+glyphname = exclam;
+lastChange = "2022-12-01 05:10:49 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,183,l),
+(414,585,l),
+(178,585,l),
+(238,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,0,l),
+(354,107,l),
+(238,107,l),
+(238,0,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,176,l),
+(434,605,l),
+(159,605,l),
+(228,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,-20,l),
+(364,94,l),
+(228,94,l),
+(228,-20,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 33;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -296,24 +296,20 @@ struct StaticMetadataWork {
 impl Work for StaticMetadataWork {
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         debug!("Static metadata for {:#?}", self.designspace_file);
-
-        context.set_static_metadata(StaticMetadata {
-            axes: self
-                .designspace
-                .axes
-                .iter()
-                .map(|a| Axis {
-                    name: a.name.clone(),
-                    tag: a.tag.clone(),
-                    hidden: a.hidden,
-                    min: a.minimum.unwrap().into(),
-                    default: a.default.into(),
-                    max: a.maximum.unwrap().into(),
-                })
-                .collect(),
-            glyph_order: (*self.glyph_order).clone(),
-        });
-
+        let axes = self
+            .designspace
+            .axes
+            .iter()
+            .map(|a| Axis {
+                name: a.name.clone(),
+                tag: a.tag.clone(),
+                hidden: a.hidden,
+                min: a.minimum.unwrap().into(),
+                default: a.default.into(),
+                max: a.maximum.unwrap().into(),
+            })
+            .collect();
+        context.set_static_metadata(StaticMetadata::new(axes, (*self.glyph_order).clone()));
         Ok(())
     }
 }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -193,6 +193,10 @@ impl Source for DesignSpaceIrSource {
         })
     }
 
+    fn create_static_metadata_work(&self, context: &Context) -> Result<Box<dyn Work>, Error> {
+        todo!()
+    }
+
     fn create_glyph_ir_work(
         &self,
         glyph_names: &HashSet<&str>,


### PR DESCRIPTION
Begin moving towards graph orchestration akin to that shown in #26.

* Use Context to manage access to data; work reads from and publishes to it.
* Allow writing IR to disk to be turned off.
* Make pushing to Context do the write to disk if it is enabled.
* Teach glyphs and ufo 2ir to write static metadata
   * As a result of this realize you have no idea how to set VF origin in Glyphs so add that; fixes #44.
* Put the hook in for glyphs2ir to write glyphs but don't do anything useful from it

Builds on #42. Step toward #27. 