### PR TITLE
Use updated converters on .designspace files

### DIFF
--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -112,8 +112,8 @@ pub fn temporary_design_to_user_conversion(coord: DesignCoord) -> UserCoord {
 
 impl DesignCoord {
     /// We do *not* provide From because we want conversion to be explicit
-    pub fn new(value: OrderedFloat<f32>) -> DesignCoord {
-        DesignCoord(value)
+    pub fn new(value: impl Into<OrderedFloat<f32>>) -> DesignCoord {
+        DesignCoord(value.into())
     }
 
     pub fn to_user(&self, converter: &CoordConverter) -> UserCoord {
@@ -127,8 +127,8 @@ impl DesignCoord {
 
 impl UserCoord {
     /// We do *not* provide From because we want conversion to be explicit
-    pub fn new(value: OrderedFloat<f32>) -> UserCoord {
-        UserCoord(value)
+    pub fn new(value: impl Into<OrderedFloat<f32>>) -> UserCoord {
+        UserCoord(value.into())
     }
 
     pub fn to_design(&self, converter: &CoordConverter) -> DesignCoord {
@@ -142,8 +142,8 @@ impl UserCoord {
 
 impl NormalizedCoord {
     /// We do *not* provide From because we want conversion to be explicit
-    pub fn new(value: OrderedFloat<f32>) -> NormalizedCoord {
-        NormalizedCoord(value)
+    pub fn new(value: impl Into<OrderedFloat<f32>>) -> NormalizedCoord {
+        NormalizedCoord(value.into())
     }
 
     pub fn to_design(&self, converter: &CoordConverter) -> DesignCoord {

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -51,10 +51,6 @@ pub struct CoordConverter {
 }
 
 impl CoordConverter {
-    pub fn nop() -> CoordConverter {
-        CoordConverter::new(Vec::new(), 0)
-    }
-
     /// Initialize a converter from the User:Design examples source files typically provide.
     pub fn new(mut mappings: Vec<(UserCoord, DesignCoord)>, default_idx: usize) -> CoordConverter {
         if mappings.is_empty() {
@@ -92,6 +88,18 @@ impl CoordConverter {
             design_to_normalized,
             normalized_to_design,
         }
+    }
+
+    /// Initialize a converter from just min/default/max user coords, e.g. a source with no mapping
+    pub fn unmapped(min: UserCoord, default: UserCoord, max: UserCoord) -> CoordConverter {
+        CoordConverter::new(
+            vec![
+                (min, DesignCoord::new(min.into_inner())),
+                (default, DesignCoord::new(default.into_inner())),
+                (max, DesignCoord::new(max.into_inner())),
+            ],
+            1,
+        )
     }
 }
 
@@ -197,33 +205,6 @@ mod tests {
             ],
             2,
         )
-    }
-
-    #[test]
-    pub fn nop() {
-        let converter = CoordConverter::nop();
-        assert_eq!(
-            OrderedFloat(0.0),
-            DesignCoord(0.0.into()).to_normalized(&converter).into_inner()
-        );
-        assert_eq!(
-            OrderedFloat(100.0),
-            DesignCoord(100.0.into())
-                .to_normalized(&converter)
-                .into_inner()
-        );
-        assert_eq!(
-            OrderedFloat(f32::MIN),
-            DesignCoord(f32::MIN.into())
-                .to_normalized(&converter)
-                .into_inner()
-        );
-        assert_eq!(
-            OrderedFloat(f32::MAX),
-            DesignCoord(f32::MAX.into())
-                .to_normalized(&converter)
-                .into_inner()
-        );
     }
 
     #[test]

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -2,7 +2,7 @@ use std::{error, io, path::PathBuf};
 
 use thiserror::Error;
 
-use crate::coords::UserLocation;
+use crate::coords::{NormalizedLocation, UserLocation};
 
 // TODO: eliminate dyn Error and collapse Error/WorkError
 
@@ -29,7 +29,12 @@ pub enum Error {
     #[error("Unexpected state encountered in a state set")]
     UnexpectedState,
     #[error("Duplicate location for {what}: {loc:?}")]
-    DuplicateUserSpaceLocation { what: String, loc: UserLocation },
+    DuplicateUserLocation { what: String, loc: UserLocation },
+    #[error("Duplicate location for {what}: {loc:?}")]
+    DuplicateNormalizedLocation {
+        what: String,
+        loc: NormalizedLocation,
+    },
     #[error("Global metadata very bad, very very bad")]
     InvalidGlobalMetadata,
     #[error("No default master in {0:?}")]

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -2,7 +2,9 @@ use std::{error, io, path::PathBuf};
 
 use thiserror::Error;
 
-use crate::ir::DesignSpaceLocation;
+use crate::coords::UserLocation;
+
+// TODO: eliminate dyn Error and collapse Error/WorkError
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -27,10 +29,7 @@ pub enum Error {
     #[error("Unexpected state encountered in a state set")]
     UnexpectedState,
     #[error("Duplicate location for {what}: {loc:?}")]
-    DuplicateLocation {
-        what: String,
-        loc: DesignSpaceLocation,
-    },
+    DuplicateUserSpaceLocation { what: String, loc: UserLocation },
     #[error("Global metadata very bad, very very bad")]
     InvalidGlobalMetadata,
     #[error("No default master in {0:?}")]
@@ -58,4 +57,6 @@ pub enum WorkError {
     FileExpected(PathBuf),
     #[error("Unable to parse {0:?}: {1}")]
     ParseError(PathBuf, String),
+    #[error("No default master in {0:?}")]
+    NoDefaultMaster(PathBuf),
 }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1,7 +1,7 @@
 //! Serde types for font IR.
 
 use crate::{
-    coords::{CoordConverter, InternalLocation, UserCoord, UserLocation},
+    coords::{CoordConverter, NormalizedLocation, UserCoord},
     error::Error,
     serde::StaticMetadataSerdeRepr,
 };
@@ -60,7 +60,7 @@ pub struct Axis {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Glyph {
     pub name: String,
-    pub sources: HashMap<InternalLocation, GlyphInstance>,
+    pub sources: HashMap<NormalizedLocation, GlyphInstance>,
 }
 
 impl Glyph {
@@ -73,11 +73,11 @@ impl Glyph {
 
     pub fn try_add_source(
         &mut self,
-        unique_location: &UserLocation,
+        unique_location: &NormalizedLocation,
         source: GlyphInstance,
     ) -> Result<(), Error> {
         if self.sources.contains_key(unique_location) {
-            return Err(Error::DuplicateUserSpaceLocation {
+            return Err(Error::DuplicateNormalizedLocation {
                 what: format!("glyph '{}' source", self.name),
                 loc: unique_location.clone(),
             });
@@ -152,7 +152,7 @@ mod tests {
     use ordered_float::OrderedFloat;
 
     use crate::{
-        coords::{CoordConverter, UserCoord},
+        coords::{CoordConverter, DesignCoord, UserCoord},
         ir::Axis,
     };
 
@@ -168,7 +168,23 @@ mod tests {
             default: user_coord(400_f32),
             max: user_coord(900_f32),
             hidden: false,
-            converter: CoordConverter::nop(),
+            converter: CoordConverter::new(
+                vec![
+                    (
+                        UserCoord::new(OrderedFloat(100.0)),
+                        DesignCoord::new(OrderedFloat(100.0)),
+                    ),
+                    (
+                        UserCoord::new(OrderedFloat(400.0)),
+                        DesignCoord::new(OrderedFloat(400.0)),
+                    ),
+                    (
+                        UserCoord::new(OrderedFloat(900.0)),
+                        DesignCoord::new(OrderedFloat(900.0)),
+                    ),
+                ],
+                1,
+            ),
         }
     }
 

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -152,7 +152,7 @@ mod tests {
     use ordered_float::OrderedFloat;
 
     use crate::{
-        coords::{CoordConverter, DesignCoord, UserCoord},
+        coords::{CoordConverter, UserCoord},
         ir::Axis,
     };
 
@@ -161,30 +161,18 @@ mod tests {
     }
 
     fn test_axis() -> Axis {
+        let min = user_coord(100.0);
+        let default = user_coord(400.0);
+        let max = user_coord(900.0);
+        let converter = CoordConverter::unmapped(min, default, max);
         Axis {
             name: String::from("Weight"),
             tag: String::from("wght"),
-            min: user_coord(100_f32),
-            default: user_coord(400_f32),
-            max: user_coord(900_f32),
+            min,
+            default,
+            max,
             hidden: false,
-            converter: CoordConverter::new(
-                vec![
-                    (
-                        UserCoord::new(OrderedFloat(100.0)),
-                        DesignCoord::new(OrderedFloat(100.0)),
-                    ),
-                    (
-                        UserCoord::new(OrderedFloat(400.0)),
-                        DesignCoord::new(OrderedFloat(400.0)),
-                    ),
-                    (
-                        UserCoord::new(OrderedFloat(900.0)),
-                        DesignCoord::new(OrderedFloat(900.0)),
-                    ),
-                ],
-                1,
-            ),
+            converter,
         }
     }
 

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -149,21 +149,16 @@ pub struct Affine2x3 {
 
 #[cfg(test)]
 mod tests {
-    use ordered_float::OrderedFloat;
 
     use crate::{
         coords::{CoordConverter, UserCoord},
         ir::Axis,
     };
 
-    fn user_coord(v: f32) -> UserCoord {
-        UserCoord::new(OrderedFloat(v))
-    }
-
     fn test_axis() -> Axis {
-        let min = user_coord(100.0);
-        let default = user_coord(400.0);
-        let max = user_coord(900.0);
+        let min = UserCoord::new(100.0);
+        let default = UserCoord::new(400.0);
+        let max = UserCoord::new(900.0);
         let converter = CoordConverter::unmapped(min, default, max);
         Axis {
             name: String::from("Weight"),

--- a/fontir/src/piecewise_linear_map.rs
+++ b/fontir/src/piecewise_linear_map.rs
@@ -6,10 +6,10 @@
 
 use ordered_float::OrderedFloat;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PiecewiseLinearMap {
-    from: Vec<OrderedFloat<f32>>, // sorted, ||'s to
-    to: Vec<OrderedFloat<f32>>,   // sorted, ||'s from
+    pub(crate) from: Vec<OrderedFloat<f32>>, // sorted, ||'s to
+    pub(crate) to: Vec<OrderedFloat<f32>>,   // sorted, ||'s from
 }
 
 impl PiecewiseLinearMap {

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use filetime::FileTime;
-use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -21,12 +20,7 @@ impl From<CoordConverterSerdeRepr> for CoordConverter {
         let examples = from
             .user_to_design
             .into_iter()
-            .map(|(u, d)| {
-                (
-                    UserCoord::new(OrderedFloat(u)),
-                    DesignCoord::new(OrderedFloat(d)),
-                )
-            })
+            .map(|(u, d)| (UserCoord::new(u), DesignCoord::new(d)))
             .collect();
         CoordConverter::new(examples, from.default_idx)
     }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -28,7 +28,7 @@ impl From<CoordConverterSerdeRepr> for CoordConverter {
                 )
             })
             .collect();
-        CoordConverter::from_user_to_design_examples(examples, from.default_idx)
+        CoordConverter::new(examples, from.default_idx)
     }
 }
 

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -1,12 +1,52 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use filetime::FileTime;
+use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    coords::{CoordConverter, DesignCoord, UserCoord},
     ir::{Axis, StaticMetadata},
     stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
 };
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoordConverterSerdeRepr {
+    default_idx: usize,
+    user_to_design: Vec<(f32, f32)>,
+}
+
+impl From<CoordConverterSerdeRepr> for CoordConverter {
+    fn from(from: CoordConverterSerdeRepr) -> Self {
+        let examples = from
+            .user_to_design
+            .into_iter()
+            .map(|(u, d)| {
+                (
+                    UserCoord::new(OrderedFloat(u)),
+                    DesignCoord::new(OrderedFloat(d)),
+                )
+            })
+            .collect();
+        CoordConverter::from_user_to_design_examples(examples, from.default_idx)
+    }
+}
+
+impl From<CoordConverter> for CoordConverterSerdeRepr {
+    fn from(from: CoordConverter) -> Self {
+        let user_to_design = from
+            .user_to_design
+            .from
+            .iter()
+            .zip(from.user_to_design.to)
+            .map(|(u, d)| (u.into_inner(), d.into_inner()))
+            .collect();
+        CoordConverterSerdeRepr {
+            default_idx: from.default_idx,
+            user_to_design,
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StaticMetadataSerdeRepr {

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -202,7 +202,7 @@ impl Work for StaticMetadataWork {
                 let default = UserCoord::new(default);
 
                 // TODO process .glpyhs coordinate conversions
-                let converter = CoordConverter::nop();
+                let converter = CoordConverter::unmapped(min, default, max);
 
                 Axis {
                     name: a.name.clone(),

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1,3 +1,4 @@
+use fontir::coords::{CoordConverter, UserCoord};
 use fontir::error::{Error, WorkError};
 use fontir::ir;
 use fontir::ir::{Axis, StaticMetadata};
@@ -195,6 +196,14 @@ impl Work for StaticMetadataWork {
                     .unwrap();
                 let default = OrderedFloat::<f32>(defaults[idx].into_inner() as f32);
 
+                // Given in user
+                let min = UserCoord::new(min);
+                let max = UserCoord::new(max);
+                let default = UserCoord::new(default);
+
+                // TODO process .glpyhs coordinate conversions
+                let converter = CoordConverter::nop();
+
                 Axis {
                     name: a.name.clone(),
                     tag: a.tag.clone(),
@@ -202,6 +211,7 @@ impl Work for StaticMetadataWork {
                     min,
                     default,
                     max,
+                    converter,
                 }
             })
             .collect();

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use fontir::{
-    coords::{DesignLocation, InternalLocation, UserCoord},
+    coords::{DesignLocation, NormalizedLocation, UserCoord},
     error::{Error, WorkError},
     ir::{Axis, StaticMetadata},
     orchestration::Context,
@@ -433,16 +433,21 @@ impl Work for GlyphIrWork {
         let axes: HashMap<_, _> = static_metadata.axes.iter().map(|a| (&a.name, a)).collect();
         let mut glif_files = HashMap::new();
         for (path, design_locations) in self.glif_files.iter() {
-            let internal_locations: Vec<InternalLocation> = design_locations
+            let normalized_locations: Vec<NormalizedLocation> = design_locations
                 .iter()
                 .map(|design_location| {
                     design_location
                         .iter()
-                        .map(|(an, dl)| (an.clone(), dl.to_user(&axes.get(an).unwrap().converter)))
+                        .map(|(an, dl)| {
+                            (
+                                an.clone(),
+                                dl.to_normalized(&axes.get(an).unwrap().converter),
+                            )
+                        })
                         .collect()
                 })
                 .collect();
-            glif_files.insert(path, internal_locations);
+            glif_files.insert(path, normalized_locations);
         }
 
         let glyph_ir = to_ir_glyph(&self.glyph_name, &glif_files)

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -14,7 +14,6 @@ use fontir::{
 };
 use log::{debug, warn};
 use norad::designspace::{self, DesignSpaceDocument};
-use ordered_float::OrderedFloat;
 
 use crate::toir::{to_design_location, to_ir_axis, to_ir_glyph};
 
@@ -331,7 +330,7 @@ fn default_master(designspace: &DesignSpaceDocument) -> Option<(usize, &designsp
             let converter = &axes.get(&a.name).unwrap().converter;
             (
                 a.name.clone(),
-                UserCoord::new(OrderedFloat(a.default)).to_design(converter),
+                UserCoord::new(a.default).to_design(converter),
             )
         })
         .collect();
@@ -469,7 +468,6 @@ mod tests {
         source::{Input, Source},
     };
     use norad::designspace;
-    use ordered_float::OrderedFloat;
 
     use crate::toir::to_design_location;
 
@@ -536,7 +534,7 @@ mod tests {
             .or_default()
             .push(DesignLocation::from([(
                 axis.to_string(),
-                DesignCoord::new(OrderedFloat(pos)),
+                DesignCoord::new(pos),
             )]));
     }
 
@@ -603,7 +601,7 @@ mod tests {
         let (source, _) = test_source();
         let ds = source.load_designspace().unwrap();
         let mut expected = DesignLocation::new();
-        expected.insert("Weight".to_string(), DesignCoord::new(OrderedFloat(400.0)));
+        expected.insert("Weight".to_string(), DesignCoord::new(400.0));
         assert_eq!(
             expected,
             to_design_location(&default_master(&ds).unwrap().1.location)

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -73,8 +73,15 @@ pub fn to_ir_axis(axis: &designspace::Axis) -> ir::Axis {
             .iter()
             .map(|map| (UserCoord::new(map.input), DesignCoord::new(map.output)))
             .collect();
+        // # mappings is generally small, repeated linear probing is fine
         let default_idx = examples.iter().position(|(u, _)| *u == default).expect(
             "We currently require that you have a mapping for the default if you have mappings",
+        );
+        examples.iter().position(|(u, _)| *u == min).expect(
+            "We currently require that you have a mapping for the min if you have mappings",
+        );
+        examples.iter().position(|(u, _)| *u == max).expect(
+            "We currently require that you have a mapping for the max if you have mappings",
         );
         CoordConverter::new(examples, default_idx)
     } else {

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -6,19 +6,13 @@ use fontir::{
     ir,
 };
 use norad::designspace::{self, Dimension};
-use ordered_float::OrderedFloat;
 
 use crate::error::Error;
 
 pub(crate) fn to_design_location(loc: &[Dimension]) -> DesignLocation {
     // TODO: what if Dimension uses uservalue? - new in DS5.0
     loc.iter()
-        .map(|d| {
-            (
-                d.name.clone(),
-                DesignCoord::new(OrderedFloat(d.xvalue.unwrap())),
-            )
-        })
+        .map(|d| (d.name.clone(), DesignCoord::new(d.xvalue.unwrap())))
         .collect()
 }
 
@@ -69,20 +63,15 @@ fn to_ir_glyph_instance(glyph: &norad::Glyph) -> ir::GlyphInstance {
 
 pub fn to_ir_axis(axis: &designspace::Axis) -> ir::Axis {
     // <https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#axis-element>
-    let min = UserCoord::new(axis.minimum.unwrap().into());
-    let default = UserCoord::new(axis.default.into());
-    let max = UserCoord::new(axis.maximum.unwrap().into());
+    let min = UserCoord::new(axis.minimum.unwrap());
+    let default = UserCoord::new(axis.default);
+    let max = UserCoord::new(axis.maximum.unwrap());
 
     // <https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#map-element>
     let converter = if let Some(mappings) = &axis.map {
         let examples: Vec<_> = mappings
             .iter()
-            .map(|map| {
-                (
-                    UserCoord::new(OrderedFloat(map.input)),
-                    DesignCoord::new(OrderedFloat(map.output)),
-                )
-            })
+            .map(|map| (UserCoord::new(map.input), DesignCoord::new(map.output)))
             .collect();
         let default_idx = examples.iter().position(|(u, _)| *u == default).expect(
             "We currently require that you have a mapping for the default if you have mappings",

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use fontir::{
-    coords::{CoordConverter, DesignCoord, DesignLocation, UserCoord, UserLocation},
+    coords::{CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
     ir,
 };
 use norad::designspace::{self, Dimension};
@@ -87,9 +87,9 @@ pub fn to_ir_axis(axis: &designspace::Axis) -> ir::Axis {
         let default_idx = examples.iter().position(|(u, _)| *u == default).expect(
             "We currently require that you have a mapping for the default if you have mappings",
         );
-        CoordConverter::from_user_to_design_examples(examples, default_idx)
+        CoordConverter::new(examples, default_idx)
     } else {
-        CoordConverter::nop()
+        CoordConverter::unmapped(min, default, max)
     };
     ir::Axis {
         name: axis.name.clone(),
@@ -104,7 +104,7 @@ pub fn to_ir_axis(axis: &designspace::Axis) -> ir::Axis {
 
 pub fn to_ir_glyph<S>(
     glyph_name: S,
-    glif_files: &HashMap<&PathBuf, Vec<UserLocation>>,
+    glif_files: &HashMap<&PathBuf, Vec<NormalizedLocation>>,
 ) -> Result<ir::Glyph, Error>
 where
     S: Into<String>,


### PR DESCRIPTION
Begin to plumb actual unit types, established in #56, into system. Store a converter in StaticMetadata, serializing it in the standard user:design form (https://github.com/googlefonts/fontmake-rs/blob/main/resources/text/units.md#user--design).

Builds on https://github.com/googlefonts/fontmake-rs/pull/43. Step toward https://github.com/googlefonts/fontmake-rs/issues/22.

Clean copy of #47, this time against the units branch which hopefully addresses the core problems.