### PR TITLE
Use an enum to distinguish Path from Component, populate for Glyphs 2 and 3

### DIFF
--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -2,7 +2,7 @@ use std::{error, io, path::PathBuf};
 
 use thiserror::Error;
 
-use crate::coords::{DesignCoord, NormalizedLocation, UserLocation};
+use crate::coords::{DesignCoord, NormalizedCoord, NormalizedLocation, UserLocation};
 
 // TODO: eliminate dyn Error and collapse Error/WorkError
 
@@ -80,4 +80,10 @@ pub enum WorkError {
     NoMasterForGlyph { master: String, glyph: String },
     #[error("Failed to add glyph source: {0}")]
     AddGlyphSource(String),
+    #[error("{glyph_name} undefined on {axis} at required position {pos:?}")]
+    GlyphUndefAtNormalizedPosition {
+        glyph_name: String,
+        axis: String,
+        pos: NormalizedCoord,
+    },
 }

--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -6,7 +6,7 @@ mod from_plist;
 mod plist;
 mod to_plist;
 
-pub use font::{Axis, Component, Font, FontMaster, Layer, Node, NodeType, Path, RawGlyph};
+pub use font::{Axis, Component, Font, FontMaster, Glyph, Layer, Node, NodeType, Path};
 pub use from_plist::FromPlist;
 pub use plist::Plist;
 pub use to_plist::ToPlist;

--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -6,7 +6,7 @@ mod from_plist;
 mod plist;
 mod to_plist;
 
-pub use font::{Axis, Component, Font, FontMaster, Glyph, Layer, Node, NodeType, Path};
+pub use font::{Axis, Component, Font, FontMaster, Layer, Node, NodeType, Path, RawGlyph};
 pub use from_plist::FromPlist;
 pub use plist::Plist;
 pub use to_plist::ToPlist;

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -302,16 +302,15 @@ mod tests {
 
     #[test]
     fn find_glyphs() {
-        let expected_keys = HashSet::from(["space", "hyphen", "exclam"]);
         assert_eq!(
-            expected_keys,
+            HashSet::from(["space", "hyphen", "exclam", "manual-component"]),
             glyph_state_for_file(&glyphs3_dir(), "WghtVar.glyphs")
                 .keys()
                 .map(|k| k.as_str())
                 .collect::<HashSet<&str>>()
         );
         assert_eq!(
-            expected_keys,
+            HashSet::from(["space", "hyphen", "exclam"]),
             glyph_state_for_file(&glyphs3_dir(), "WghtVar_HeavyHyphen.glyphs")
                 .keys()
                 .map(|k| k.as_str())
@@ -372,7 +371,7 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         assert_eq!(
-            vec!["space", "exclam", "hyphen"],
+            vec!["space", "exclam", "hyphen", "manual-component"],
             context.get_static_metadata().glyph_order
         );
     }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -230,7 +230,7 @@ impl Work for GlyphIrWork {
 
             // TODO actually populate fields
             let glyph_instance = GlyphInstance {
-                width: 0_f64,
+                width: instance.width.into_inner(),
                 height: None,
                 contours: Vec::new(),
                 components: Vec::new(),

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -211,7 +211,7 @@ impl Work for GlyphIrWork {
 
         // Glyphs have layers that match up with masters, and masters have locations
         let mut axis_positions: HashMap<String, HashSet<NormalizedCoord>> = HashMap::new();
-        for instance in glyph.instances.iter() {
+        for instance in glyph.layers.iter() {
             let Some(master_idx) = font_info.master_indices.get(instance.layer_id.as_str()) else {
                 return Err(WorkError::NoMasterForGlyph {
                     master: instance.layer_id.clone(),

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -174,6 +174,22 @@ struct GlyphIrWork {
     font_info: Arc<FontInfo>,
 }
 
+fn check_pos(
+    glyph_name: &str,
+    positions: &HashSet<NormalizedCoord>,
+    axis: &ir::Axis,
+    pos: &NormalizedCoord,
+) -> Result<(), WorkError> {
+    if !positions.contains(pos) {
+        return Err(WorkError::GlyphUndefAtNormalizedPosition {
+            glyph_name: glyph_name.to_string(),
+            axis: axis.tag.clone(),
+            pos: *pos,
+        });
+    }
+    Ok(())
+}
+
 impl Work for GlyphIrWork {
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         debug!("Generate IR for {}", self.glyph_name);
@@ -195,15 +211,10 @@ impl Work for GlyphIrWork {
 
         // Glyphs have layers that match up with masters, and masters have locations
         let mut axis_positions: HashMap<String, HashSet<NormalizedCoord>> = HashMap::new();
-        for layer in glyph.layers.iter() {
-            let Some(master_idx) = font_info.master_indices.get(layer.layer_id.as_str()) else {
-                // If the layer has an associatedMasterId this is fine, if not ... not
-                if layer.associated_master_id.is_some() {
-                    continue;
-                }
-
+        for instance in glyph.instances.iter() {
+            let Some(master_idx) = font_info.master_indices.get(instance.layer_id.as_str()) else {
                 return Err(WorkError::NoMasterForGlyph {
-                    master: layer.layer_id.clone(),
+                    master: instance.layer_id.clone(),
                     glyph: self.glyph_name.clone(),
                 });
             };
@@ -243,15 +254,9 @@ impl Work for GlyphIrWork {
             let max = axis.max.to_normalized(&axis.converter);
             let default = axis.max.to_normalized(&axis.converter);
             let positions = axis_positions.get(&axis.tag).unwrap();
-            if !positions.contains(&min) {
-                panic!("{} is undefined at {} min", self.glyph_name, axis.tag);
-            }
-            if !positions.contains(&max) {
-                panic!("{} is undefined at {} max", self.glyph_name, axis.tag);
-            }
-            if !positions.contains(&default) {
-                panic!("{} is undefined at {} default", self.glyph_name, axis.tag);
-            }
+            check_pos(&self.glyph_name, positions, axis, &min)?;
+            check_pos(&self.glyph_name, positions, axis, &default)?;
+            check_pos(&self.glyph_name, positions, axis, &max)?;
         }
 
         context.set_glyph_ir(gid, ir_glyph);
@@ -269,6 +274,7 @@ mod tests {
 
     use fontir::{
         coords::{CoordConverter, DesignCoord, NormalizedCoord, UserCoord},
+        error::WorkError,
         ir::{self, Glyph},
         orchestration::{Context, WorkIdentifier},
         source::{Paths, Source},
@@ -436,23 +442,27 @@ mod tests {
         (source, context)
     }
 
-    fn build_glyphs<'a>(source: &impl Source, context: &Context, glyph_names: Vec<&'a String>) {
+    fn build_glyphs<'a>(
+        source: &impl Source,
+        context: &Context,
+        glyph_names: Vec<&'a String>,
+    ) -> Result<(), WorkError> {
         for glyph_name in glyph_names {
             let static_metadata = context.get_static_metadata();
             let glyph_id = static_metadata.glyph_id(glyph_name).unwrap();
 
-            source
+            let work_items = source
                 .create_glyph_ir_work(&HashSet::from([glyph_name.as_str()]), context)
-                .unwrap()
-                .iter()
-                .for_each(|work| {
-                    let task_context = context.copy_for_work(
-                        WorkIdentifier::GlyphIr(glyph_id),
-                        Some(HashSet::from([WorkIdentifier::StaticMetadata])),
-                    );
-                    work.exec(&task_context).unwrap();
-                });
+                .unwrap();
+            for work in work_items.iter() {
+                let task_context = context.copy_for_work(
+                    WorkIdentifier::GlyphIr(glyph_id),
+                    Some(HashSet::from([WorkIdentifier::StaticMetadata])),
+                );
+                work.exec(&task_context)?;
+            }
         }
+        Ok(())
     }
 
     fn glyph_ir(context: &Context, glyph_name: &String) -> Arc<Glyph> {
@@ -466,7 +476,7 @@ mod tests {
         let glyph_name = "space".to_string();
         let (source, context) =
             build_static_metadata(glyphs2_dir().join("WghtVar_AxisMappings.glyphs"));
-        build_glyphs(&source, &context, vec![&glyph_name]); // we dont' care about geometry
+        build_glyphs(&source, &context, vec![&glyph_name]).unwrap(); // we dont' care about geometry
 
         assert_eq!(
             HashSet::from([
@@ -482,11 +492,17 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "min-undefined is undefined at wght min")]
     fn glyph_must_define_min() {
         let glyph_name = "min-undefined".to_string();
         let (source, context) =
             build_static_metadata(glyphs2_dir().join("WghtVar_AxisMappings.glyphs"));
-        build_glyphs(&source, &context, vec![&glyph_name]);
+        let result = build_glyphs(&source, &context, vec![&glyph_name]);
+        assert!(result.is_err());
+        let Err(WorkError::GlyphUndefAtNormalizedPosition { glyph_name, axis, pos }) =  result else {
+            panic!("Wrong error");
+        };
+        assert_eq!("min-undefined", glyph_name);
+        assert_eq!("wght", axis);
+        assert_eq!(NormalizedCoord::new(-1.0), pos);
     }
 }

--- a/resources/testdata/glyphs2/WghtVar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar.glyphs
@@ -148,6 +148,39 @@ width = 600;
 }
 );
 unicode = 002D;
+},
+{
+glyphname = manual-component;
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+components = (
+{
+name = hyphen;
+transform = "{1, 0, 0, 1, 0, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = m01;
+width = 600;
+},
+{
+components = (
+{
+name = hyphen;
+transform = "{1, 0, 0, 1, 0, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 003D;
 }
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs3/WghtVar.glyphs
+++ b/resources/testdata/glyphs3/WghtVar.glyphs
@@ -170,6 +170,39 @@ width = 600;
 }
 );
 unicode = 45;
+},
+{
+glyphname = manual-component;
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+pos = (0, 100);
+ref = hyphen;
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+pos = (0, 100);
+ref = hyphen;
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+}
+);
+unicode = 61;
 }
 );
 metrics = (

--- a/smoke_test/smoke_test.py
+++ b/smoke_test/smoke_test.py
@@ -7,13 +7,21 @@ import sys
 from typing import Tuple
 
 _TRY_ME = (
+    # Glyphs 2
     ("https://github.com/Omnibus-Type/Texturina", ("sources/Texturina.glyphs", "sources/Texturina-Italic.glyphs")),
-
+    # Glyphs 3
+    ("https://github.com/googlefonts/lexend", ("sources/Lexend.glyphs",)),
+    # .designspace + UFO
     ("https://github.com/xconsau/KumbhSans", ("sources/KumbhSans.designspace",)),
 )
 
+def curr_dir() -> Path:
+    return Path(".").resolve()
+
+
 def repo_dir(repo_url) -> Path:
-    return Path(__file__).parent / "build" / repo_url.split("/")[-1].lower()
+    return curr_dir() / "build" / repo_url.split("/")[-1].lower()
+
 
 def fontc_command(source) -> Tuple[str, ...]:
     return (
@@ -23,8 +31,9 @@ def fontc_command(source) -> Tuple[str, ...]:
         "fontc",
         "--",
         "--source",
-        str(source.resolve().relative_to(Path(".").resolve()))
+        str(source)
     )
+
 
 def run(cmd):
     print("  " + " ".join(str(c) for c in cmd))
@@ -39,7 +48,9 @@ def run(cmd):
 
 def main(argv):
     for (repo_url, source_files) in _TRY_ME:
-        clone_dir = repo_dir(repo_url)
+        clone_dir = repo_dir(repo_url).relative_to(curr_dir())
+        print(f"{repo_url} in {clone_dir}")
+        
         if (clone_dir / ".git").is_dir():
             git_cmd = ("git", "-C", clone_dir, "pull")
         else:
@@ -48,11 +59,10 @@ def main(argv):
         if run(git_cmd) != 0:
             continue
 
-        for source_file in source_files:
-            print(f"{repo_url} in {clone_dir}")
+        for source_file in source_files:            
             source_file = clone_dir / source_file
             if not source_file.is_file():
-                print("  ", source_file, "FAIL, no such file")
+                print(f"  {source_file} FAIL, no such file")
                 continue
 
             if run(fontc_command(source_file)) != 0:


### PR DESCRIPTION
Manual component generated based on examination of Texturina (Glyphs 2, https://github.com/Omnibus-Type/Texturina, sources/Texturina.glyphs) and Lexend (Glyphs 3, https://github.com/googlefonts/lexend, sources/ofl/lexendgiga/sources/Lexend.glyphs) plus ofc https://github.com/schriftgestalt/GlyphsSDK/blob/Glyphs3/GlyphsFileFormat/GlyphsFileFormatv3.md#differences-between-version-2.

Step toward #27. Builds on #60, which is hopefully in good shape now.