### PR TITLE
Add wiring for backend tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "fontdrasil",
+    "fontbe",
     "fontir",
     "glyphs-reader",
     "glyphs2fontir",

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fontc"
+name = "fontbe"
 version = "0.0.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -11,24 +11,25 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontbe = { version = "0.0.1", path = "../fontbe" }
+fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontir = { version = "0.0.1", path = "../fontir" }
-glyphs2fontir = { version = "0.0.1", path = "../glyphs2fontir" }
-ufo2fontir = { version = "0.0.1", path = "../ufo2fontir" }
-bitflags = "1.3"
+
 serde = {version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.14"
-bincode = "1.3.3"
-filetime = "0.2.18"
-clap = { version = "4.0.32", features = ["derive"] }
+
+thiserror = "1.0.37"
+ordered-float = { version = "3.4.0", features = ["serde"] }
+indexmap = "1.9.2"
+
 log = "0.4"
 env_logger = "0.9.0"
-thiserror = "1.0.37"
 
-rayon = "1.6.0"
-crossbeam-channel = "0.5.6"
+parking_lot = "0.12.1"
 
-indexmap = "1.9.2"
+read-fonts = "0.0.5"
+write-fonts = "0.0.5"
+fea-rs = "0.1.0"
+smol_str = "0.1.18"
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -1,0 +1,4 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {}

--- a/fontbe/src/lib.rs
+++ b/fontbe/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod error;
+pub mod orchestration;
+pub mod paths;

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -7,8 +7,10 @@ use write_fonts::FontBuilder;
 
 use crate::{error::Error, paths::Paths};
 
-// Unique identifier of work. If there are no fields work is unique.
-// Meant to be small and cheap to copy around.
+/// Unique identifier of work.
+///
+/// If there are no fields work is unique.
+/// Meant to be small and cheap to copy around.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WorkIdentifier {
     Features,

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -3,6 +3,7 @@
 use std::{collections::HashSet, fs, path::Path, sync::Arc};
 
 use fontdrasil::orchestration::{Acl, Cache, Work, MISSING_DATA};
+use fontir::orchestration::{Context as FeContext, WorkIdentifier as FeWorkIdentifier};
 use write_fonts::FontBuilder;
 
 use crate::{error::Error, paths::Paths};
@@ -18,8 +19,6 @@ pub enum WorkIdentifier {
     GlyphMerge,
     FinalMerge,
 }
-
-use fontir::orchestration::{Context as FeContext, WorkIdentifier as FeWorkIdentifier};
 
 // Identifies work of any type, FE, BE, ... future optimization passes, w/e.
 // Useful because BE work can very reasonably depend on FE work

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -1,0 +1,150 @@
+//! Helps coordinate the graph execution for BE
+
+use std::{collections::HashSet, fs, path::Path, sync::Arc};
+
+use fontdrasil::orchestration::{Acl, Cache, Work, MISSING_DATA};
+use write_fonts::FontBuilder;
+
+use crate::{error::Error, paths::Paths};
+
+// Unique identifier of work. If there are no fields work is unique.
+// Meant to be small and cheap to copy around.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum WorkIdentifier {
+    Features,
+    Glyph(String),
+    GlyphMerge,
+    FinalMerge,
+}
+
+use fontir::orchestration::{Context as FeContext, WorkIdentifier as FeWorkIdentifier};
+
+// Identifies work of any type, FE, BE, ... future optimization passes, w/e.
+// Useful because BE work can very reasonably depend on FE work
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AnyWorkId {
+    Fe(FeWorkIdentifier),
+    Be(WorkIdentifier),
+}
+
+impl AnyWorkId {
+    pub fn unwrap_be(&self) -> &WorkIdentifier {
+        match self {
+            AnyWorkId::Fe(..) => panic!("Not a BE identifier"),
+            AnyWorkId::Be(id) => id,
+        }
+    }
+
+    pub fn unwrap_fe(&self) -> &FeWorkIdentifier {
+        match self {
+            AnyWorkId::Fe(id) => id,
+            AnyWorkId::Be(..) => panic!("Not a FE identifier"),
+        }
+    }
+}
+
+impl From<FeWorkIdentifier> for AnyWorkId {
+    fn from(id: FeWorkIdentifier) -> Self {
+        AnyWorkId::Fe(id)
+    }
+}
+
+impl From<WorkIdentifier> for AnyWorkId {
+    fn from(id: WorkIdentifier) -> Self {
+        AnyWorkId::Be(id)
+    }
+}
+
+pub type BeWork = dyn Work<Context, Error> + Send;
+
+/// Read/write access to data for async work.
+///
+/// Intent is a root orchestrator creates a context and share copies with restricted
+/// access with spawned tasks. Copies with access control are created to detect bad
+/// execution order / mistakes, not to block actual bad actors.
+pub struct Context {
+    // If set artifacts prior to final binary will be emitted to disk when written into Context
+    emit_ir: bool,
+
+    paths: Arc<Paths>,
+
+    // The final, fully populated, read-only FE context
+    pub ir: Arc<FeContext>,
+
+    acl: Acl<AnyWorkId>,
+
+    // work results we've completed or restored from disk
+    // We create individual caches so we can return typed results from get fns
+    features: Cache<Option<Arc<Vec<u8>>>>,
+}
+
+impl Context {
+    pub fn new_root(emit_ir: bool, paths: Paths, ir: &fontir::orchestration::Context) -> Context {
+        Context {
+            emit_ir,
+            paths: Arc::from(paths),
+            ir: Arc::from(ir.read_only()),
+            acl: Acl::read_only(),
+            features: Cache::new(),
+        }
+    }
+
+    pub fn copy_for_work(
+        &self,
+        work_id: WorkIdentifier,
+        dependencies: Option<HashSet<AnyWorkId>>,
+    ) -> Context {
+        Context {
+            emit_ir: self.emit_ir,
+            paths: self.paths.clone(),
+            ir: self.ir.clone(),
+            acl: Acl::read_write(dependencies.unwrap_or_default(), work_id.into()),
+            features: self.features.clone(),
+        }
+    }
+}
+
+impl Context {
+    fn maybe_persist(&self, file: &Path, content: &[u8]) {
+        if !self.emit_ir {
+            return;
+        }
+        fs::write(file, content)
+            .map_err(|e| panic!("Unable to write {:?} {}", file, e))
+            .unwrap();
+    }
+
+    fn restore(&self, file: &Path) -> Vec<u8> {
+        fs::read(file)
+            .map_err(|e| panic!("Unable to read {:?} {}", file, e))
+            .unwrap()
+    }
+
+    fn set_cached_features(&self, font: Vec<u8>) {
+        let mut wl = self.features.item.write().unwrap();
+        *wl = Some(Arc::from(font));
+    }
+
+    pub fn get_features(&self) -> Arc<Vec<u8>> {
+        let id = WorkIdentifier::Features;
+        self.acl.check_read_access(&id.clone().into());
+        {
+            let rl = self.features.item.read().unwrap();
+            if rl.is_some() {
+                return rl.as_ref().unwrap().clone();
+            }
+        }
+        let font = self.restore(&self.paths.target_file(&id));
+        self.set_cached_features(font);
+        let rl = self.features.item.read().unwrap();
+        rl.as_ref().expect(MISSING_DATA).clone()
+    }
+
+    pub fn set_features(&self, mut font: FontBuilder) {
+        let id = WorkIdentifier::Features;
+        self.acl.check_write_access(&id.clone().into());
+        let font = font.build();
+        self.maybe_persist(&self.paths.target_file(&id), &font);
+        self.set_cached_features(font);
+    }
+}

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -1,0 +1,41 @@
+//! Where to emit BE work when written to filesystem
+
+use std::path::{Path, PathBuf};
+
+use fontdrasil::orchestration::glyph_file;
+
+use crate::orchestration::WorkIdentifier;
+
+#[derive(Debug, Clone)]
+pub struct Paths {
+    build_dir: PathBuf,
+    glyph_dir: PathBuf,
+}
+
+impl Paths {
+    pub fn new(build_dir: &Path) -> Paths {
+        let glyph_dir = build_dir.join("glyphs");
+        let build_dir = build_dir.to_path_buf();
+        Paths {
+            build_dir,
+            glyph_dir,
+        }
+    }
+
+    pub fn build_dir(&self) -> &Path {
+        &self.build_dir
+    }
+
+    fn glyph_file(&self, name: &str) -> PathBuf {
+        self.glyph_dir.join(glyph_file(name, ".ttf"))
+    }
+
+    pub fn target_file(&self, id: &WorkIdentifier) -> PathBuf {
+        match id {
+            WorkIdentifier::Features => self.build_dir.join("features.ttf"),
+            WorkIdentifier::Glyph(name) => self.glyph_file(name),
+            WorkIdentifier::GlyphMerge => self.build_dir.join("all_glyphs.ttf"),
+            WorkIdentifier::FinalMerge => self.build_dir.join("font.ttf"),
+        }
+    }
+}

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use fontdrasil::orchestration::glyph_file;
+use fontdrasil::paths::glyph_file;
 
 use crate::orchestration::WorkIdentifier;
 

--- a/fontc/src/error.rs
+++ b/fontc/src/error.rs
@@ -1,5 +1,6 @@
 use std::{io, path::PathBuf};
 
+use fontbe::orchestration::AnyWorkId;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -17,5 +18,5 @@ pub enum Error {
     #[error("Does not exist")]
     FileExpected(PathBuf),
     #[error("At least one work item failed")]
-    TasksFailed,
+    TasksFailed(Vec<(AnyWorkId, String)>),
 }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1,3 +1,4 @@
 //! A font compiler with aspirations of being fast and safe.
 mod error;
 pub use error::Error;
+pub mod work;

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -162,20 +162,20 @@ impl ChangeDetector {
         self.current_inputs
             .glyphs
             .iter()
-            .filter(
-                |(glyph_name, curr_state)| match self.prev_inputs.glyphs.get(*glyph_name) {
+            .filter_map(
+                |(glyph_name, curr_state)| match self.prev_inputs.glyphs.get(glyph_name) {
                     Some(prev_state) => {
                         // If the input changed or the output doesn't exist a rebuild is probably in order
-                        prev_state != *curr_state
+                        (prev_state != curr_state
                             || !self
                                 .ir_paths
                                 .target_file(&FeWorkIdentifier::Glyph(glyph_name.to_string()))
-                                .exists()
+                                .exists())
+                        .then(|| glyph_name.as_str())
                     }
-                    None => true,
+                    None => Some(glyph_name.as_str()),
                 },
             )
-            .map(|(glyph_name, _)| glyph_name.as_str())
             .collect()
     }
 

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -171,7 +171,7 @@ impl ChangeDetector {
                                 .ir_paths
                                 .target_file(&FeWorkIdentifier::Glyph(glyph_name.to_string()))
                                 .exists())
-                        .then(|| glyph_name.as_str())
+                        .then_some(glyph_name.as_str())
                     }
                     None => Some(glyph_name.as_str()),
                 },

--- a/fontc/src/work.rs
+++ b/fontc/src/work.rs
@@ -1,0 +1,115 @@
+//! Helps fontc manage workloads that span FE and BE.
+//!
+//! Basically enums that can be a FeWhatever or a BeWhatever.
+
+use std::{collections::HashSet, fmt::Display};
+
+use fontbe::{
+    error::Error as BeError,
+    orchestration::{AnyWorkId, BeWork, Context as BeContext},
+};
+use fontir::{
+    error::WorkError as FeError,
+    orchestration::{Context as FeContext, IrWork},
+};
+
+#[derive(Debug)]
+pub enum AnyWorkError {
+    Fe(FeError),
+    Be(BeError),
+}
+
+impl From<BeError> for AnyWorkError {
+    fn from(e: BeError) -> Self {
+        AnyWorkError::Be(e)
+    }
+}
+
+impl From<FeError> for AnyWorkError {
+    fn from(e: FeError) -> Self {
+        AnyWorkError::Fe(e)
+    }
+}
+
+impl Display for AnyWorkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AnyWorkError::Be(e) => e.fmt(f),
+            AnyWorkError::Fe(e) => e.fmt(f),
+        }
+    }
+}
+
+// Work of any type, FE, BE, ... some future pass, w/e
+pub enum AnyWork {
+    Fe(Box<IrWork>),
+    Be(Box<BeWork>),
+}
+
+impl From<Box<IrWork>> for AnyWork {
+    fn from(work: Box<IrWork>) -> Self {
+        AnyWork::Fe(work)
+    }
+}
+
+impl From<Box<BeWork>> for AnyWork {
+    fn from(work: Box<BeWork>) -> Self {
+        AnyWork::Be(work)
+    }
+}
+
+impl AnyWork {
+    pub fn exec(&self, context: AnyContext) -> Result<(), AnyWorkError> {
+        match self {
+            AnyWork::Be(work) => work.exec(context.unwrap_be()).map_err(|e| e.into()),
+            AnyWork::Fe(work) => work.exec(context.unwrap_fe()).map_err(|e| e.into()),
+        }
+    }
+}
+
+pub enum AnyContext {
+    Fe(FeContext),
+    Be(BeContext),
+}
+
+impl AnyContext {
+    pub fn for_work(
+        fe_root: &FeContext,
+        be_root: &BeContext,
+        id: &AnyWorkId,
+        happens_after: HashSet<AnyWorkId>,
+    ) -> AnyContext {
+        match id {
+            AnyWorkId::Be(id) => {
+                AnyContext::Be(be_root.copy_for_work(id.clone(), Some(happens_after)))
+            }
+            AnyWorkId::Fe(id) => AnyContext::Fe(
+                fe_root.copy_for_work(
+                    id.clone(),
+                    Some(
+                        happens_after
+                            .into_iter()
+                            .map(|a| a.unwrap_fe().clone())
+                            .collect(),
+                    ),
+                ),
+            ),
+        }
+    }
+}
+
+impl AnyContext {
+    pub fn unwrap_be(&self) -> &BeContext {
+        match self {
+            AnyContext::Fe(..) => panic!("Not a BE context"),
+            AnyContext::Be(ctx) => ctx,
+        }
+    }
+
+    pub fn unwrap_fe(&self) -> &FeContext {
+        match self {
+            AnyContext::Fe(ctx) => ctx,
+            AnyContext::Be(..) => panic!("Not a FE context"),
+        }
+    }
+}

--- a/fontdrasil/src/lib.rs
+++ b/fontdrasil/src/lib.rs
@@ -1,2 +1,3 @@
+//! Helper library for code that is of value to FE and BE of font compilation.
 pub mod orchestration;
 pub mod paths;


### PR DESCRIPTION
Make fontc use AnyWork, AnyWorkId, etc so it can accomodate FE and BE tasks with non-overlapping id spaces. Subset of changes from #76.