### PR TITLE
Copy WorkIdentifier which primarily means a Copy GlyphName

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use fea_rs::{Diagnostic, GlyphMap, GlyphName};
+use fea_rs::{Diagnostic, GlyphMap, GlyphName as FeaRsGlyphName};
 use log::{debug, trace, warn};
 use write_fonts::FontBuilder;
 
@@ -102,7 +102,10 @@ impl Work<Context, Error> for FeatureWork {
         if glyph_order.is_empty() {
             warn!("Glyph order is empty; feature compile improbable");
         }
-        let glyph_map = glyph_order.iter().map(Into::<GlyphName>::into).collect();
+        let glyph_map = glyph_order
+            .iter()
+            .map(|n| Into::<FeaRsGlyphName>::into(n.as_str()))
+            .collect();
         let font = self.compile(fea_file, glyph_map)?;
         context.set_features(font);
         Ok(())

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -33,7 +33,7 @@ impl Paths {
     pub fn target_file(&self, id: &WorkIdentifier) -> PathBuf {
         match id {
             WorkIdentifier::Features => self.build_dir.join("features.ttf"),
-            WorkIdentifier::Glyph(name) => self.glyph_file(name),
+            WorkIdentifier::Glyph(name) => self.glyph_file(name.as_str()),
             WorkIdentifier::GlyphMerge => self.build_dir.join("all_glyphs.ttf"),
             WorkIdentifier::FinalMerge => self.build_dir.join("font.ttf"),
         }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
+fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontbe = { version = "0.0.1", path = "../fontbe" }
 fontir = { version = "0.0.1", path = "../fontir" }
 glyphs2fontir = { version = "0.0.1", path = "../glyphs2fontir" }

--- a/fontc/src/work.rs
+++ b/fontc/src/work.rs
@@ -76,24 +76,15 @@ impl AnyContext {
     pub fn for_work(
         fe_root: &FeContext,
         be_root: &BeContext,
-        id: &AnyWorkId,
+        id: AnyWorkId,
         happens_after: HashSet<AnyWorkId>,
     ) -> AnyContext {
         match id {
-            AnyWorkId::Be(id) => {
-                AnyContext::Be(be_root.copy_for_work(id.clone(), Some(happens_after)))
-            }
-            AnyWorkId::Fe(id) => AnyContext::Fe(
-                fe_root.copy_for_work(
-                    id.clone(),
-                    Some(
-                        happens_after
-                            .into_iter()
-                            .map(|a| a.unwrap_fe().clone())
-                            .collect(),
-                    ),
-                ),
-            ),
+            AnyWorkId::Be(id) => AnyContext::Be(be_root.copy_for_work(id, Some(happens_after))),
+            AnyWorkId::Fe(id) => AnyContext::Fe(fe_root.copy_for_work(
+                id,
+                Some(happens_after.into_iter().map(|a| a.unwrap_fe()).collect()),
+            )),
         }
     }
 }

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -11,8 +11,10 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-typenum = "1.16.0"
-arraystring = "0.3.0"
+
+parking_lot = "0.12.1"
+once_cell = "1.17.0"
+indexmap = "1.9.2"
 
 serde = {version = "1.0", features = ["derive"] }
 

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -11,6 +11,10 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
+typenum = "1.16.0"
+arraystring = "0.3.0"
+
+serde = {version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/fontdrasil/src/lib.rs
+++ b/fontdrasil/src/lib.rs
@@ -1,3 +1,4 @@
 //! Helper library for code that is of value to FE and BE of font compilation.
 pub mod orchestration;
 pub mod paths;
+pub mod types;

--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -20,7 +20,7 @@ pub trait Work<C, E> {
 /// because the result of mistaken concurrent access can be confusing to track down.
 pub struct AccessControlList<I>
 where
-    I: Eq + Hash + Debug,
+    I: Copy + Eq + Hash + Debug,
 {
     // If present, the one and only key you are allowed to write to
     // None means we're read-only
@@ -31,7 +31,7 @@ where
     read_mask: Option<HashSet<I>>,
 }
 
-impl<I: Eq + Hash + Debug> AccessControlList<I> {
+impl<I: Copy + Eq + Hash + Debug> AccessControlList<I> {
     pub fn read_only() -> AccessControlList<I> {
         AccessControlList {
             write_mask: None,
@@ -47,20 +47,20 @@ impl<I: Eq + Hash + Debug> AccessControlList<I> {
     }
 }
 
-impl<I: Eq + Hash + Debug> AccessControlList<I> {
-    pub fn check_read_access(&self, id: &I) {
+impl<I: Copy + Eq + Hash + Debug> AccessControlList<I> {
+    pub fn check_read_access(&self, id: I) {
         if !self
             .read_mask
             .as_ref()
-            .map(|mask| mask.contains(id))
+            .map(|mask| mask.contains(&id))
             .unwrap_or(true)
         {
             panic!("Illegal access");
         }
     }
 
-    pub fn check_write_access(&self, id: &I) {
-        if self.write_mask.as_ref() != Some(id) {
+    pub fn check_write_access(&self, id: I) {
+        if self.write_mask.as_ref() != Some(&id) {
             panic!("Illegal access to {:?}", id);
         }
     }

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -2,6 +2,8 @@
 //!
 //! Particularly types where it's nice for FE and BE to match.
 
+use std::fmt::{Display, Debug};
+
 use arraystring::ArrayString;
 use serde::{Deserialize, Serialize};
 
@@ -49,7 +51,7 @@ enum StackString {
     L32(ArrayString<typenum::U32>),
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(from = "GlyphNameSerdeRepr", into = "GlyphNameSerdeRepr")]
 pub struct GlyphName(StackString);
 
@@ -149,6 +151,18 @@ impl From<&str> for GlyphName {
             32 => GlyphName(StackString::L32(ArrayString::from_str_truncate(value))),
             _ => panic!("StackString cannot accomodate {}", value),
         }
+    }
+}
+
+impl Debug for GlyphName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Display for GlyphName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -2,99 +2,73 @@
 //!
 //! Particularly types where it's nice for FE and BE to match.
 
-use std::fmt::{Display, Debug};
+use std::{
+    fmt::{Debug, Display},
+    sync::Arc,
+};
 
-use arraystring::ArrayString;
+use indexmap::IndexSet;
+use once_cell::sync::OnceCell;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
-// A Copy stack-allocated string
+#[derive(Default)]
+struct BigStrings {
+    strings: IndexSet<String>,
+}
+
+impl BigStrings {
+    fn get(&self, str: &str) -> Option<usize> {
+        self.strings.get_index_of(str)
+    }
+
+    fn resolve(&self, tok: usize) -> &String {
+        self.strings
+            .get_index(tok)
+            .expect("We should only resolve what we previously inserted")
+    }
+
+    fn get_or_insert(&mut self, str: &str) -> usize {
+        if self.strings.insert(str.to_string()) {
+            self.strings.len() - 1 // we're the new tail
+        } else {
+            self.get(str).unwrap()
+        }
+    }
+}
+
+static BIG_STRINGS: OnceCell<Arc<RwLock<BigStrings>>> = OnceCell::new();
+
+// Unique identifier of a glyph, stack friendly.
 //
-// Using this for *long* strings is a bad idea but for glyph names, which are usually short,
-// it should be fine.
-//
-// Wasn't sure how to loop in macro_rules so I used python, e.g.
-// python -c 'for i in range(1, 33): print(f"    L{i}(ArrayString<typenum::U{i}>),")'
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum StackString {
-    L0(ArrayString<typenum::U1>), // U0 doesn't compile
-    L1(ArrayString<typenum::U1>),
-    L2(ArrayString<typenum::U2>),
-    L3(ArrayString<typenum::U3>),
-    L4(ArrayString<typenum::U4>),
-    L5(ArrayString<typenum::U5>),
-    L6(ArrayString<typenum::U6>),
-    L7(ArrayString<typenum::U7>),
-    L8(ArrayString<typenum::U8>),
-    L9(ArrayString<typenum::U9>),
-    L10(ArrayString<typenum::U10>),
-    L11(ArrayString<typenum::U11>),
-    L12(ArrayString<typenum::U12>),
-    L13(ArrayString<typenum::U13>),
-    L14(ArrayString<typenum::U14>),
-    L15(ArrayString<typenum::U15>),
-    L16(ArrayString<typenum::U16>),
-    L17(ArrayString<typenum::U17>),
-    L18(ArrayString<typenum::U18>),
-    L19(ArrayString<typenum::U19>),
-    L20(ArrayString<typenum::U20>),
-    L21(ArrayString<typenum::U21>),
-    L22(ArrayString<typenum::U22>),
-    L23(ArrayString<typenum::U23>),
-    L24(ArrayString<typenum::U24>),
-    L25(ArrayString<typenum::U25>),
-    L26(ArrayString<typenum::U26>),
-    L27(ArrayString<typenum::U27>),
-    L28(ArrayString<typenum::U28>),
-    L29(ArrayString<typenum::U29>),
-    L30(ArrayString<typenum::U30>),
-    L31(ArrayString<typenum::U31>),
-    L32(ArrayString<typenum::U32>),
+// >90% of glyph names are <= 16 bytes so we take those directly and spill anything larger
+// into a string interner.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum StringRepr {
+    Small(u8, [u8; 16]),
+    Big(usize),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(from = "GlyphNameSerdeRepr", into = "GlyphNameSerdeRepr")]
-pub struct GlyphName(StackString);
+pub struct GlyphName(StringRepr);
 
 impl GlyphName {
-    pub const MAX_LENGTH: usize = 32;
-
-    // Wasn't sure how to loop in macro_rules so I used python, e.g.
-    // python -c 'for i in range(1, 33): print(f"                        StackString::L{i}(a) => a.as_str(),")'
     pub fn as_str(&self) -> &str {
         match &self.0 {
-            StackString::L0(..) => "",
-            StackString::L1(a) => a.as_str(),
-            StackString::L2(a) => a.as_str(),
-            StackString::L3(a) => a.as_str(),
-            StackString::L4(a) => a.as_str(),
-            StackString::L5(a) => a.as_str(),
-            StackString::L6(a) => a.as_str(),
-            StackString::L7(a) => a.as_str(),
-            StackString::L8(a) => a.as_str(),
-            StackString::L9(a) => a.as_str(),
-            StackString::L10(a) => a.as_str(),
-            StackString::L11(a) => a.as_str(),
-            StackString::L12(a) => a.as_str(),
-            StackString::L13(a) => a.as_str(),
-            StackString::L14(a) => a.as_str(),
-            StackString::L15(a) => a.as_str(),
-            StackString::L16(a) => a.as_str(),
-            StackString::L17(a) => a.as_str(),
-            StackString::L18(a) => a.as_str(),
-            StackString::L19(a) => a.as_str(),
-            StackString::L20(a) => a.as_str(),
-            StackString::L21(a) => a.as_str(),
-            StackString::L22(a) => a.as_str(),
-            StackString::L23(a) => a.as_str(),
-            StackString::L24(a) => a.as_str(),
-            StackString::L25(a) => a.as_str(),
-            StackString::L26(a) => a.as_str(),
-            StackString::L27(a) => a.as_str(),
-            StackString::L28(a) => a.as_str(),
-            StackString::L29(a) => a.as_str(),
-            StackString::L30(a) => a.as_str(),
-            StackString::L31(a) => a.as_str(),
-            StackString::L32(a) => a.as_str(),
+            StringRepr::Small(len, content) => unsafe {
+                // safe because it was populated from a validated str
+                std::str::from_utf8_unchecked(&content[0..*len as usize])
+            },
+            StringRepr::Big(tok) => {
+                let rl = BIG_STRINGS
+                    .get()
+                    .expect("This object cannot exist without an interner existing")
+                    .read();
+                let str = rl.resolve(*tok).as_ref();
+                // safe because we never deallocate big strings
+                unsafe { std::mem::transmute::<&str, &'static str>(str) }
+            }
         }
     }
 }
@@ -115,41 +89,24 @@ impl From<&str> for GlyphName {
     // Wasn't sure how to loop in macro_rules so I used python, e.g.
     // python -c 'for i in range(1, 33): print(f"            {i} => GlyphName(StackString::L{i}(ArrayString::from_str_truncate(value))),")'
     fn from(value: &str) -> Self {
-        match value.len() {
-            0 => GlyphName(StackString::L0(ArrayString::from_str_truncate(" "))),
-            1 => GlyphName(StackString::L1(ArrayString::from_str_truncate(value))),
-            2 => GlyphName(StackString::L2(ArrayString::from_str_truncate(value))),
-            3 => GlyphName(StackString::L3(ArrayString::from_str_truncate(value))),
-            4 => GlyphName(StackString::L4(ArrayString::from_str_truncate(value))),
-            5 => GlyphName(StackString::L5(ArrayString::from_str_truncate(value))),
-            6 => GlyphName(StackString::L6(ArrayString::from_str_truncate(value))),
-            7 => GlyphName(StackString::L7(ArrayString::from_str_truncate(value))),
-            8 => GlyphName(StackString::L8(ArrayString::from_str_truncate(value))),
-            9 => GlyphName(StackString::L9(ArrayString::from_str_truncate(value))),
-            10 => GlyphName(StackString::L10(ArrayString::from_str_truncate(value))),
-            11 => GlyphName(StackString::L11(ArrayString::from_str_truncate(value))),
-            12 => GlyphName(StackString::L12(ArrayString::from_str_truncate(value))),
-            13 => GlyphName(StackString::L13(ArrayString::from_str_truncate(value))),
-            14 => GlyphName(StackString::L14(ArrayString::from_str_truncate(value))),
-            15 => GlyphName(StackString::L15(ArrayString::from_str_truncate(value))),
-            16 => GlyphName(StackString::L16(ArrayString::from_str_truncate(value))),
-            17 => GlyphName(StackString::L17(ArrayString::from_str_truncate(value))),
-            18 => GlyphName(StackString::L18(ArrayString::from_str_truncate(value))),
-            19 => GlyphName(StackString::L19(ArrayString::from_str_truncate(value))),
-            20 => GlyphName(StackString::L20(ArrayString::from_str_truncate(value))),
-            21 => GlyphName(StackString::L21(ArrayString::from_str_truncate(value))),
-            22 => GlyphName(StackString::L22(ArrayString::from_str_truncate(value))),
-            23 => GlyphName(StackString::L23(ArrayString::from_str_truncate(value))),
-            24 => GlyphName(StackString::L24(ArrayString::from_str_truncate(value))),
-            25 => GlyphName(StackString::L25(ArrayString::from_str_truncate(value))),
-            26 => GlyphName(StackString::L26(ArrayString::from_str_truncate(value))),
-            27 => GlyphName(StackString::L27(ArrayString::from_str_truncate(value))),
-            28 => GlyphName(StackString::L28(ArrayString::from_str_truncate(value))),
-            29 => GlyphName(StackString::L29(ArrayString::from_str_truncate(value))),
-            30 => GlyphName(StackString::L30(ArrayString::from_str_truncate(value))),
-            31 => GlyphName(StackString::L31(ArrayString::from_str_truncate(value))),
-            32 => GlyphName(StackString::L32(ArrayString::from_str_truncate(value))),
-            _ => panic!("StackString cannot accomodate {}", value),
+        if value.len() > 16 {
+            let interner = BIG_STRINGS.get_or_init(|| Arc::from(RwLock::new(Default::default())));
+            {
+                let rl = interner.read();
+                if let Some(tok) = rl.get(value) {
+                    return GlyphName(StringRepr::Big(tok));
+                }
+            }
+
+            let mut wl = interner.write();
+
+            // Someone might have written this when we let down the read lock so don't blindly insert
+            let tok = wl.get_or_insert(value);
+            GlyphName(StringRepr::Big(tok))
+        } else {
+            let mut content = [0u8; 16];
+            content[0..value.len()].copy_from_slice(value.as_bytes());
+            GlyphName(StringRepr::Small(value.len() as u8, content))
         }
     }
 }

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -1,0 +1,172 @@
+//! Basic types useful for font compilation.
+//!
+//! Particularly types where it's nice for FE and BE to match.
+
+use arraystring::ArrayString;
+use serde::{Deserialize, Serialize};
+
+// A Copy stack-allocated string
+//
+// Using this for *long* strings is a bad idea but for glyph names, which are usually short,
+// it should be fine.
+//
+// Wasn't sure how to loop in macro_rules so I used python, e.g.
+// python -c 'for i in range(1, 33): print(f"    L{i}(ArrayString<typenum::U{i}>),")'
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum StackString {
+    L0(ArrayString<typenum::U1>), // U0 doesn't compile
+    L1(ArrayString<typenum::U1>),
+    L2(ArrayString<typenum::U2>),
+    L3(ArrayString<typenum::U3>),
+    L4(ArrayString<typenum::U4>),
+    L5(ArrayString<typenum::U5>),
+    L6(ArrayString<typenum::U6>),
+    L7(ArrayString<typenum::U7>),
+    L8(ArrayString<typenum::U8>),
+    L9(ArrayString<typenum::U9>),
+    L10(ArrayString<typenum::U10>),
+    L11(ArrayString<typenum::U11>),
+    L12(ArrayString<typenum::U12>),
+    L13(ArrayString<typenum::U13>),
+    L14(ArrayString<typenum::U14>),
+    L15(ArrayString<typenum::U15>),
+    L16(ArrayString<typenum::U16>),
+    L17(ArrayString<typenum::U17>),
+    L18(ArrayString<typenum::U18>),
+    L19(ArrayString<typenum::U19>),
+    L20(ArrayString<typenum::U20>),
+    L21(ArrayString<typenum::U21>),
+    L22(ArrayString<typenum::U22>),
+    L23(ArrayString<typenum::U23>),
+    L24(ArrayString<typenum::U24>),
+    L25(ArrayString<typenum::U25>),
+    L26(ArrayString<typenum::U26>),
+    L27(ArrayString<typenum::U27>),
+    L28(ArrayString<typenum::U28>),
+    L29(ArrayString<typenum::U29>),
+    L30(ArrayString<typenum::U30>),
+    L31(ArrayString<typenum::U31>),
+    L32(ArrayString<typenum::U32>),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(from = "GlyphNameSerdeRepr", into = "GlyphNameSerdeRepr")]
+pub struct GlyphName(StackString);
+
+impl GlyphName {
+    pub const MAX_LENGTH: usize = 32;
+
+    // Wasn't sure how to loop in macro_rules so I used python, e.g.
+    // python -c 'for i in range(1, 33): print(f"                        StackString::L{i}(a) => a.as_str(),")'
+    pub fn as_str(&self) -> &str {
+        match &self.0 {
+            StackString::L0(..) => "",
+            StackString::L1(a) => a.as_str(),
+            StackString::L2(a) => a.as_str(),
+            StackString::L3(a) => a.as_str(),
+            StackString::L4(a) => a.as_str(),
+            StackString::L5(a) => a.as_str(),
+            StackString::L6(a) => a.as_str(),
+            StackString::L7(a) => a.as_str(),
+            StackString::L8(a) => a.as_str(),
+            StackString::L9(a) => a.as_str(),
+            StackString::L10(a) => a.as_str(),
+            StackString::L11(a) => a.as_str(),
+            StackString::L12(a) => a.as_str(),
+            StackString::L13(a) => a.as_str(),
+            StackString::L14(a) => a.as_str(),
+            StackString::L15(a) => a.as_str(),
+            StackString::L16(a) => a.as_str(),
+            StackString::L17(a) => a.as_str(),
+            StackString::L18(a) => a.as_str(),
+            StackString::L19(a) => a.as_str(),
+            StackString::L20(a) => a.as_str(),
+            StackString::L21(a) => a.as_str(),
+            StackString::L22(a) => a.as_str(),
+            StackString::L23(a) => a.as_str(),
+            StackString::L24(a) => a.as_str(),
+            StackString::L25(a) => a.as_str(),
+            StackString::L26(a) => a.as_str(),
+            StackString::L27(a) => a.as_str(),
+            StackString::L28(a) => a.as_str(),
+            StackString::L29(a) => a.as_str(),
+            StackString::L30(a) => a.as_str(),
+            StackString::L31(a) => a.as_str(),
+            StackString::L32(a) => a.as_str(),
+        }
+    }
+}
+
+impl From<&String> for GlyphName {
+    fn from(value: &String) -> Self {
+        value.as_str().into()
+    }
+}
+
+impl From<String> for GlyphName {
+    fn from(value: String) -> Self {
+        value.as_str().into()
+    }
+}
+
+impl From<&str> for GlyphName {
+    // Wasn't sure how to loop in macro_rules so I used python, e.g.
+    // python -c 'for i in range(1, 33): print(f"            {i} => GlyphName(StackString::L{i}(ArrayString::from_str_truncate(value))),")'
+    fn from(value: &str) -> Self {
+        match value.len() {
+            0 => GlyphName(StackString::L0(ArrayString::from_str_truncate(" "))),
+            1 => GlyphName(StackString::L1(ArrayString::from_str_truncate(value))),
+            2 => GlyphName(StackString::L2(ArrayString::from_str_truncate(value))),
+            3 => GlyphName(StackString::L3(ArrayString::from_str_truncate(value))),
+            4 => GlyphName(StackString::L4(ArrayString::from_str_truncate(value))),
+            5 => GlyphName(StackString::L5(ArrayString::from_str_truncate(value))),
+            6 => GlyphName(StackString::L6(ArrayString::from_str_truncate(value))),
+            7 => GlyphName(StackString::L7(ArrayString::from_str_truncate(value))),
+            8 => GlyphName(StackString::L8(ArrayString::from_str_truncate(value))),
+            9 => GlyphName(StackString::L9(ArrayString::from_str_truncate(value))),
+            10 => GlyphName(StackString::L10(ArrayString::from_str_truncate(value))),
+            11 => GlyphName(StackString::L11(ArrayString::from_str_truncate(value))),
+            12 => GlyphName(StackString::L12(ArrayString::from_str_truncate(value))),
+            13 => GlyphName(StackString::L13(ArrayString::from_str_truncate(value))),
+            14 => GlyphName(StackString::L14(ArrayString::from_str_truncate(value))),
+            15 => GlyphName(StackString::L15(ArrayString::from_str_truncate(value))),
+            16 => GlyphName(StackString::L16(ArrayString::from_str_truncate(value))),
+            17 => GlyphName(StackString::L17(ArrayString::from_str_truncate(value))),
+            18 => GlyphName(StackString::L18(ArrayString::from_str_truncate(value))),
+            19 => GlyphName(StackString::L19(ArrayString::from_str_truncate(value))),
+            20 => GlyphName(StackString::L20(ArrayString::from_str_truncate(value))),
+            21 => GlyphName(StackString::L21(ArrayString::from_str_truncate(value))),
+            22 => GlyphName(StackString::L22(ArrayString::from_str_truncate(value))),
+            23 => GlyphName(StackString::L23(ArrayString::from_str_truncate(value))),
+            24 => GlyphName(StackString::L24(ArrayString::from_str_truncate(value))),
+            25 => GlyphName(StackString::L25(ArrayString::from_str_truncate(value))),
+            26 => GlyphName(StackString::L26(ArrayString::from_str_truncate(value))),
+            27 => GlyphName(StackString::L27(ArrayString::from_str_truncate(value))),
+            28 => GlyphName(StackString::L28(ArrayString::from_str_truncate(value))),
+            29 => GlyphName(StackString::L29(ArrayString::from_str_truncate(value))),
+            30 => GlyphName(StackString::L30(ArrayString::from_str_truncate(value))),
+            31 => GlyphName(StackString::L31(ArrayString::from_str_truncate(value))),
+            32 => GlyphName(StackString::L32(ArrayString::from_str_truncate(value))),
+            _ => panic!("StackString cannot accomodate {}", value),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct GlyphNameSerdeRepr {
+    name: String,
+}
+
+impl From<GlyphName> for GlyphNameSerdeRepr {
+    fn from(value: GlyphName) -> Self {
+        GlyphNameSerdeRepr {
+            name: value.as_str().to_string(),
+        }
+    }
+}
+
+impl From<GlyphNameSerdeRepr> for GlyphName {
+    fn from(value: GlyphNameSerdeRepr) -> Self {
+        value.name.into()
+    }
+}

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -25,9 +25,9 @@ pub enum Error {
     UnableToLoadSource(Box<dyn error::Error>),
     #[error("Missing layer")]
     NoSuchLayer(String),
-    #[error("No files associated with glyph")]
+    #[error("No files associated with glyph {0}")]
     NoStateForGlyph(GlyphName),
-    #[error("No design space location(s) associated with glyph")]
+    #[error("No design space location(s) associated with glyph {0}")]
     NoLocationsForGlyph(GlyphName),
     #[error("Asked to create work for something other than the last input we created")]
     UnableToCreateGlyphIrWork,
@@ -85,7 +85,7 @@ pub enum WorkError {
     NoMasterForGlyph { master: String, glyph: GlyphName },
     #[error("Failed to add glyph source: {0}")]
     AddGlyphSource(String),
-    #[error("{glyph_name:?} undefined on {axis} at required position {pos:?}")]
+    #[error("{glyph_name} undefined on {axis} at required position {pos:?}")]
     GlyphUndefAtNormalizedPosition {
         glyph_name: GlyphName,
         axis: String,

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -1,5 +1,6 @@
 use std::{error, io, path::PathBuf};
 
+use fontdrasil::types::GlyphName;
 use thiserror::Error;
 
 use crate::coords::{DesignCoord, NormalizedCoord, NormalizedLocation, UserLocation};
@@ -25,9 +26,9 @@ pub enum Error {
     #[error("Missing layer")]
     NoSuchLayer(String),
     #[error("No files associated with glyph")]
-    NoStateForGlyph(String),
+    NoStateForGlyph(GlyphName),
     #[error("No design space location(s) associated with glyph")]
-    NoLocationsForGlyph(String),
+    NoLocationsForGlyph(GlyphName),
     #[error("Asked to create work for something other than the last input we created")]
     UnableToCreateGlyphIrWork,
     #[error("Unexpected state encountered in a state set")]
@@ -58,8 +59,8 @@ pub enum WorkError {
     IoError(#[from] io::Error),
     // I can't use Box(<dyn error::Error>) here because it's not Send, but
     // if I convert error to string I lose the backtrace... What to do?
-    #[error("Conversion of glyph '{0}' to IR failed: {1}")]
-    GlyphIrWorkError(String, String),
+    #[error("Conversion of glyph '{0:?}' to IR failed: {1}")]
+    GlyphIrWorkError(GlyphName, String),
     #[error("yaml error")]
     YamlSerError(#[from] serde_yaml::Error),
     #[error("No axes are defined")]
@@ -68,8 +69,8 @@ pub enum WorkError {
     InconsistentAxisDefinitions(String),
     #[error("I am the glyph with gid, {0}")]
     NoGlyphIdForName(String),
-    #[error("No Glyph for name {0}")]
-    NoGlyphForName(String),
+    #[error("No Glyph for name {0:?}")]
+    NoGlyphForName(GlyphName),
     #[error("File expected: {0:?}")]
     FileExpected(PathBuf),
     #[error("Expected to match: {0:?}, {1:?}")]
@@ -80,13 +81,13 @@ pub enum WorkError {
     ParseError(PathBuf, String),
     #[error("No default master in {0:?}")]
     NoDefaultMaster(PathBuf),
-    #[error("No master {master} exists. Referenced by glyph {glyph}.")]
-    NoMasterForGlyph { master: String, glyph: String },
+    #[error("No master {master} exists. Referenced by glyph {glyph:?}.")]
+    NoMasterForGlyph { master: String, glyph: GlyphName },
     #[error("Failed to add glyph source: {0}")]
     AddGlyphSource(String),
-    #[error("{glyph_name} undefined on {axis} at required position {pos:?}")]
+    #[error("{glyph_name:?} undefined on {axis} at required position {pos:?}")]
     GlyphUndefAtNormalizedPosition {
-        glyph_name: String,
+        glyph_name: GlyphName,
         axis: String,
         pos: NormalizedCoord,
     },

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -5,6 +5,7 @@ use crate::{
     error::Error,
     serde::{GlyphSerdeRepr, StaticMetadataSerdeRepr},
 };
+use fontdrasil::types::GlyphName;
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -20,17 +21,17 @@ use std::{
 #[serde(from = "StaticMetadataSerdeRepr", into = "StaticMetadataSerdeRepr")]
 pub struct StaticMetadata {
     pub axes: Vec<Axis>,
-    pub glyph_order: IndexSet<String>,
+    pub glyph_order: IndexSet<GlyphName>,
 }
 
 impl StaticMetadata {
-    pub fn new(axes: Vec<Axis>, glyph_order: IndexSet<String>) -> StaticMetadata {
+    pub fn new(axes: Vec<Axis>, glyph_order: IndexSet<GlyphName>) -> StaticMetadata {
         StaticMetadata { axes, glyph_order }
     }
 }
 
 impl StaticMetadata {
-    pub fn glyph_id(&self, name: &String) -> Option<u32> {
+    pub fn glyph_id(&self, name: &GlyphName) -> Option<u32> {
         self.glyph_order.get_index_of(name).map(|i| i as u32)
     }
 }
@@ -74,12 +75,12 @@ impl Features {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(from = "GlyphSerdeRepr", into = "GlyphSerdeRepr")]
 pub struct Glyph {
-    pub name: String,
+    pub name: GlyphName,
     pub sources: HashMap<NormalizedLocation, GlyphInstance>,
 }
 
 impl Glyph {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: GlyphName) -> Self {
         Self {
             name,
             sources: HashMap::new(),
@@ -93,7 +94,7 @@ impl Glyph {
     ) -> Result<(), Error> {
         if self.sources.contains_key(unique_location) {
             return Err(Error::DuplicateNormalizedLocation {
-                what: format!("glyph '{}' source", self.name),
+                what: format!("glyph '{}' source", self.name.as_str()),
                 loc: unique_location.clone(),
             });
         }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -9,7 +9,10 @@ use std::{
     sync::Arc,
 };
 
-use fontdrasil::orchestration::{AccessControlList, Work, MISSING_DATA};
+use fontdrasil::{
+    orchestration::{AccessControlList, Work, MISSING_DATA},
+    types::GlyphName,
+};
 use parking_lot::RwLock;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -17,11 +20,11 @@ use crate::{error::WorkError, ir, paths::Paths, source::Input};
 
 // Unique identifier of work. If there are no fields work is unique.
 // Meant to be small and cheap to copy around.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WorkIdentifier {
     StaticMetadata,
-    Glyph(String),
-    GlyphIrDelete(String),
+    Glyph(GlyphName),
+    GlyphIrDelete(),
     Features,
 }
 
@@ -47,7 +50,7 @@ pub struct Context {
     // work results we've completed or restored from disk
     // We create individual caches so we can return typed results from get fns
     static_metadata: Arc<RwLock<Option<Arc<ir::StaticMetadata>>>>,
-    glyph_ir: Arc<RwLock<HashMap<String, Arc<ir::Glyph>>>>,
+    glyph_ir: Arc<RwLock<HashMap<GlyphName, Arc<ir::Glyph>>>>,
     feature_ir: Arc<RwLock<Option<Arc<ir::Features>>>>,
 }
 
@@ -130,38 +133,38 @@ impl Context {
 
     pub fn get_static_metadata(&self) -> Arc<ir::StaticMetadata> {
         let id = WorkIdentifier::StaticMetadata;
-        self.acl.check_read_access(&id);
+        self.acl.check_read_access(id);
         {
             let rl = self.static_metadata.read();
             if rl.is_some() {
                 return rl.as_ref().unwrap().clone();
             }
         }
-        self.set_cached_static_metadata(self.restore(&self.paths.target_file(&id)));
+        self.set_cached_static_metadata(self.restore(&self.paths.target_file(id)));
         let rl = self.static_metadata.read();
         rl.as_ref().expect(MISSING_DATA).clone()
     }
 
     pub fn set_static_metadata(&self, ir: ir::StaticMetadata) {
         let id = WorkIdentifier::StaticMetadata;
-        self.acl.check_write_access(&id);
-        self.maybe_persist(&self.paths.target_file(&id), &ir);
+        self.acl.check_write_access(id);
+        self.maybe_persist(&self.paths.target_file(id), &ir);
         self.set_cached_static_metadata(ir);
     }
 
-    pub fn get_glyph_ir(&self, glyph_name: &str) -> Arc<ir::Glyph> {
-        let id = WorkIdentifier::Glyph(glyph_name.to_string());
-        self.acl.check_read_access(&id);
+    pub fn get_glyph_ir(&self, glyph_name: GlyphName) -> Arc<ir::Glyph> {
+        let id = WorkIdentifier::Glyph(glyph_name);
+        self.acl.check_read_access(id);
         let rl = self.glyph_ir.read();
-        rl.get(glyph_name).expect(MISSING_DATA).clone()
+        rl.get(&glyph_name).expect(MISSING_DATA).clone()
     }
 
-    pub fn set_glyph_ir(&self, glyph_name: &str, ir: ir::Glyph) {
-        let id = WorkIdentifier::Glyph(glyph_name.to_string());
-        self.acl.check_write_access(&id);
-        self.maybe_persist(&self.paths.target_file(&id), &ir);
+    pub fn set_glyph_ir(&self, glyph_name: GlyphName, ir: ir::Glyph) {
+        let id = WorkIdentifier::Glyph(glyph_name);
+        self.acl.check_write_access(id);
+        self.maybe_persist(&self.paths.target_file(id), &ir);
         let mut wl = self.glyph_ir.write();
-        wl.insert(glyph_name.to_string(), Arc::from(ir));
+        wl.insert(glyph_name, Arc::from(ir));
     }
 
     fn set_cached_features(&self, ir: ir::Features) {
@@ -171,22 +174,22 @@ impl Context {
 
     pub fn get_features(&self) -> Arc<ir::Features> {
         let id = WorkIdentifier::Features;
-        self.acl.check_read_access(&id);
+        self.acl.check_read_access(id);
         {
             let rl = self.feature_ir.read();
             if rl.is_some() {
                 return rl.as_ref().unwrap().clone();
             }
         }
-        self.set_cached_features(self.restore(&self.paths.target_file(&id)));
+        self.set_cached_features(self.restore(&self.paths.target_file(id)));
         let rl = self.feature_ir.read();
         rl.as_ref().expect(MISSING_DATA).clone()
     }
 
     pub fn set_features(&self, ir: ir::Features) {
         let id = WorkIdentifier::Features;
-        self.acl.check_write_access(&id);
-        self.maybe_persist(&self.paths.target_file(&id), &ir);
+        self.acl.check_write_access(id);
+        self.maybe_persist(&self.paths.target_file(id), &ir);
         self.set_cached_features(ir);
     }
 }

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -41,11 +41,11 @@ impl Paths {
         self.glyph_ir_dir.join(glyph_file(name, ".yml"))
     }
 
-    pub fn target_file(&self, id: &WorkIdentifier) -> PathBuf {
+    pub fn target_file(&self, id: WorkIdentifier) -> PathBuf {
         match id {
             WorkIdentifier::StaticMetadata => self.build_dir.join("static_metadata.yml"),
-            WorkIdentifier::Glyph(name) => self.glyph_ir_file(name),
-            WorkIdentifier::GlyphIrDelete(name) => self.glyph_ir_file(name),
+            WorkIdentifier::Glyph(name) => self.glyph_ir_file(name.as_str()),
+            WorkIdentifier::GlyphIrDelete() => self.build_dir.join("delete.yml"),
             WorkIdentifier::Features => self.build_dir.join("features.yml"),
         }
     }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -50,7 +50,10 @@ pub struct StaticMetadataSerdeRepr {
 
 impl From<StaticMetadataSerdeRepr> for StaticMetadata {
     fn from(from: StaticMetadataSerdeRepr) -> Self {
-        StaticMetadata::new(from.axes, from.glyph_order.into_iter().collect())
+        StaticMetadata::new(
+            from.axes,
+            from.glyph_order.into_iter().map(|s| s.into()).collect(),
+        )
     }
 }
 
@@ -58,7 +61,11 @@ impl From<StaticMetadata> for StaticMetadataSerdeRepr {
     fn from(from: StaticMetadata) -> Self {
         StaticMetadataSerdeRepr {
             axes: from.axes,
-            glyph_order: from.glyph_order.into_iter().collect(),
+            glyph_order: from
+                .glyph_order
+                .into_iter()
+                .map(|n| n.as_str().to_string())
+                .collect(),
         }
     }
 }
@@ -79,7 +86,7 @@ pub struct GlyphSerdeRepr {
 impl From<GlyphSerdeRepr> for Glyph {
     fn from(from: GlyphSerdeRepr) -> Self {
         Glyph {
-            name: from.name,
+            name: from.name.into(),
             sources: from
                 .instances
                 .into_iter()
@@ -92,7 +99,7 @@ impl From<GlyphSerdeRepr> for Glyph {
 impl From<Glyph> for GlyphSerdeRepr {
     fn from(from: Glyph) -> Self {
         GlyphSerdeRepr {
-            name: from.name,
+            name: from.name.as_str().to_string(),
             instances: from
                 .sources
                 .into_iter()

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -6,7 +6,7 @@ use indexmap::IndexSet;
 use log::debug;
 use serde::{Deserialize, Serialize};
 
-use fontdrasil::orchestration::Work;
+use fontdrasil::{orchestration::Work, types::GlyphName};
 
 use crate::{
     error::{Error, WorkError},
@@ -56,7 +56,7 @@ pub trait Source {
     /// When run work should update [Context] with [crate::ir::Glyph] for the glyph name.
     fn create_glyph_ir_work(
         &self,
-        glyph_names: &IndexSet<&str>,
+        glyph_names: &IndexSet<GlyphName>,
         input: &Input,
     ) -> Result<Vec<Box<IrWork>>, Error>;
 
@@ -74,7 +74,7 @@ pub struct Input {
     pub static_metadata: StateSet,
 
     /// The input(s) that inform glyph IR construction, grouped by gyph name
-    pub glyphs: HashMap<String, StateSet>,
+    pub glyphs: HashMap<GlyphName, StateSet>,
 
     /// The input(s) that inform feature IR construction
     pub features: StateSet,
@@ -121,7 +121,7 @@ mod tests {
             .unwrap();
 
         let mut glyphs = HashMap::new();
-        glyphs.insert("space".to_string(), glyph);
+        glyphs.insert("space".into(), glyph);
 
         let mut features = StateSet::new();
         features

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -352,6 +352,9 @@ mod tests {
         let g1 = glyph_state_for_file(&glyphs3_dir(), "WghtVar.glyphs");
         let g2 = glyph_state_for_file(&glyphs3_dir(), "WghtVar_HeavyHyphen.glyphs");
 
+        eprintln!("G1\n{:#?}", g1);
+        eprintln!("G2\n{:#?}", g2);
+
         let changed = keys
             .into_iter()
             .filter(|key| g1.get(key).unwrap() == g2.get(key).unwrap())

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1,4 +1,5 @@
 use fontdrasil::orchestration::Work;
+use fontdrasil::types::GlyphName;
 use fontir::coords::NormalizedCoord;
 use fontir::error::{Error, WorkError};
 use fontir::ir::{self, GlyphInstance, StaticMetadata};
@@ -43,13 +44,13 @@ fn glyph_identifier(glyph_name: &str) -> String {
     format!("/glyph/{glyph_name}")
 }
 
-fn glyph_states(font: &Font) -> Result<HashMap<String, StateSet>, Error> {
+fn glyph_states(font: &Font) -> Result<HashMap<GlyphName, StateSet>, Error> {
     let mut glyph_states = HashMap::new();
 
     for (glyphname, glyph) in font.glyphs.iter() {
         let mut state = StateSet::new();
         state.track_memory(glyph_identifier(glyphname), glyph)?;
-        glyph_states.insert(glyphname.clone(), state);
+        glyph_states.insert(glyphname.into(), state);
     }
 
     Ok(glyph_states)
@@ -127,7 +128,7 @@ impl Source for GlyphsIrSource {
 
     fn create_glyph_ir_work(
         &self,
-        glyph_names: &IndexSet<&str>,
+        glyph_names: &IndexSet<GlyphName>,
         input: &Input,
     ) -> Result<Vec<Box<IrWork>>, fontir::error::Error> {
         self.check_static_metadata(&input.static_metadata)?;
@@ -136,9 +137,10 @@ impl Source for GlyphsIrSource {
 
         let mut work: Vec<Box<IrWork>> = Vec::new();
         for glyph_name in glyph_names {
-            work.push(Box::from(
-                self.create_work_for_one_glyph(glyph_name, cache.font_info.clone())?,
-            ));
+            work.push(Box::from(self.create_work_for_one_glyph(
+                *glyph_name,
+                cache.font_info.clone(),
+            )?));
         }
         Ok(work)
     }
@@ -153,10 +155,9 @@ impl Source for GlyphsIrSource {
 impl GlyphsIrSource {
     fn create_work_for_one_glyph(
         &self,
-        glyph_name: &str,
+        glyph_name: GlyphName,
         font_info: Arc<FontInfo>,
     ) -> Result<GlyphIrWork, Error> {
-        let glyph_name = glyph_name.to_string();
         Ok(GlyphIrWork {
             glyph_name,
             font_info,
@@ -175,7 +176,7 @@ impl Work<Context, WorkError> for StaticMetadataWork {
         debug!("Static metadata for {}", font.family_name);
         context.set_static_metadata(StaticMetadata::new(
             font_info.axes.clone(),
-            font.glyph_order.iter().cloned().collect(),
+            font.glyph_order.iter().map(|s| s.into()).collect(),
         ));
         Ok(())
     }
@@ -192,19 +193,19 @@ impl Work<Context, WorkError> for FeatureWork {
 }
 
 struct GlyphIrWork {
-    glyph_name: String,
+    glyph_name: GlyphName,
     font_info: Arc<FontInfo>,
 }
 
 fn check_pos(
-    glyph_name: &str,
+    glyph_name: GlyphName,
     positions: &HashSet<NormalizedCoord>,
     axis: &ir::Axis,
     pos: &NormalizedCoord,
 ) -> Result<(), WorkError> {
     if !positions.contains(pos) {
         return Err(WorkError::GlyphUndefAtNormalizedPosition {
-            glyph_name: glyph_name.to_string(),
+            glyph_name,
             axis: axis.tag.clone(),
             pos: *pos,
         });
@@ -214,7 +215,7 @@ fn check_pos(
 
 impl Work<Context, WorkError> for GlyphIrWork {
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
-        trace!("Generate IR for {}", self.glyph_name);
+        trace!("Generate IR for {}", self.glyph_name.as_str());
         let font_info = self.font_info.as_ref();
         let font = &font_info.font;
 
@@ -223,10 +224,10 @@ impl Work<Context, WorkError> for GlyphIrWork {
 
         let glyph = font
             .glyphs
-            .get(&self.glyph_name)
-            .ok_or_else(|| WorkError::NoGlyphForName(self.glyph_name.clone()))?;
+            .get(self.glyph_name.as_str())
+            .ok_or_else(|| WorkError::NoGlyphForName(self.glyph_name))?;
 
-        let mut ir_glyph = ir::Glyph::new(self.glyph_name.clone());
+        let mut ir_glyph = ir::Glyph::new(self.glyph_name);
 
         // Glyphs have layers that match up with masters, and masters have locations
         let mut axis_positions: HashMap<String, HashSet<NormalizedCoord>> = HashMap::new();
@@ -234,7 +235,7 @@ impl Work<Context, WorkError> for GlyphIrWork {
             let Some(master_idx) = font_info.master_indices.get(instance.layer_id.as_str()) else {
                 return Err(WorkError::NoMasterForGlyph {
                     master: instance.layer_id.clone(),
-                    glyph: self.glyph_name.clone(),
+                    glyph: self.glyph_name,
                 });
             };
             let master = &font.font_master[*master_idx];
@@ -259,10 +260,8 @@ impl Work<Context, WorkError> for GlyphIrWork {
                 .try_add_source(location, glyph_instance)
                 .map_err(|e| {
                     WorkError::AddGlyphSource(format!(
-                        "Unable to add source to {} at {:?}: {}",
-                        self.glyph_name.clone(),
-                        location,
-                        e
+                        "Unable to add source to {:?} at {:?}: {}",
+                        self.glyph_name, location, e
                     ))
                 })?;
         }
@@ -273,12 +272,12 @@ impl Work<Context, WorkError> for GlyphIrWork {
             let max = axis.max.to_normalized(&axis.converter);
             let default = axis.max.to_normalized(&axis.converter);
             let positions = axis_positions.get(&axis.name).unwrap();
-            check_pos(&self.glyph_name, positions, axis, &min)?;
-            check_pos(&self.glyph_name, positions, axis, &default)?;
-            check_pos(&self.glyph_name, positions, axis, &max)?;
+            check_pos(self.glyph_name, positions, axis, &min)?;
+            check_pos(self.glyph_name, positions, axis, &default)?;
+            check_pos(self.glyph_name, positions, axis, &max)?;
         }
 
-        context.set_glyph_ir(&self.glyph_name, ir_glyph);
+        context.set_glyph_ir(self.glyph_name, ir_glyph);
         Ok(())
     }
 }
@@ -290,6 +289,7 @@ mod tests {
         path::{Path, PathBuf},
     };
 
+    use fontdrasil::types::GlyphName;
     use fontir::{
         coords::{CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord},
         error::WorkError,
@@ -320,7 +320,7 @@ mod tests {
         testdata_dir().join("glyphs3")
     }
 
-    fn glyph_state_for_file(dir: &Path, filename: &str) -> HashMap<String, StateSet> {
+    fn glyph_state_for_file(dir: &Path, filename: &str) -> HashMap<GlyphName, StateSet> {
         let glyphs_file = dir.join(filename);
         let font = Font::load(&glyphs_file).unwrap();
         glyph_states(&font).unwrap()
@@ -346,22 +346,17 @@ mod tests {
 
     #[test]
     fn detect_changed_glyphs() {
-        let keys = HashSet::from(["space", "hyphen", "exclam"]);
+        let keys: HashSet<GlyphName> =
+            HashSet::from(["space".into(), "hyphen".into(), "exclam".into()]);
 
         let g1 = glyph_state_for_file(&glyphs3_dir(), "WghtVar.glyphs");
         let g2 = glyph_state_for_file(&glyphs3_dir(), "WghtVar_HeavyHyphen.glyphs");
 
         let changed = keys
-            .iter()
-            .filter_map(|key| {
-                let key = key.to_string();
-                if g1.get(&key).unwrap() == g2.get(&key).unwrap() {
-                    return None;
-                }
-                Some(key)
-            })
-            .collect::<HashSet<String>>();
-        assert_eq!(HashSet::from(["hyphen".to_string()]), changed);
+            .into_iter()
+            .filter(|key| g1.get(key).unwrap() == g2.get(key).unwrap())
+            .collect();
+        assert_eq!(HashSet::<GlyphName>::from(["hyphen".into()]), changed);
     }
 
     fn context_for(glyphs_file: PathBuf) -> (impl Source, Context) {
@@ -396,9 +391,9 @@ mod tests {
                 .map(|a| &a.tag)
                 .collect::<Vec<_>>()
         );
-        let expected: IndexSet<String> = vec!["space", "exclam", "hyphen", "manual-component"]
+        let expected: IndexSet<GlyphName> = vec!["space", "exclam", "hyphen", "manual-component"]
             .iter()
-            .map(|s| s.to_string())
+            .map(|s| (*s).into())
             .collect();
         assert_eq!(expected, context.get_static_metadata().glyph_order);
     }
@@ -463,18 +458,18 @@ mod tests {
         (source, context)
     }
 
-    fn build_glyphs<'a>(
+    fn build_glyphs(
         source: &impl Source,
         context: &Context,
-        glyph_names: Vec<&'a String>,
+        glyph_names: Vec<GlyphName>,
     ) -> Result<(), WorkError> {
         for glyph_name in glyph_names.iter() {
             let work_items = source
-                .create_glyph_ir_work(&IndexSet::from([glyph_name.as_str()]), &context.input)
+                .create_glyph_ir_work(&IndexSet::from([*glyph_name]), &context.input)
                 .unwrap();
             for work in work_items.iter() {
                 let task_context = context.copy_for_work(
-                    WorkIdentifier::Glyph(glyph_name.to_string()),
+                    WorkIdentifier::Glyph(*glyph_name),
                     Some(HashSet::from([WorkIdentifier::StaticMetadata])),
                 );
                 work.exec(&task_context)?;
@@ -485,10 +480,10 @@ mod tests {
 
     #[test]
     fn normalizes_glyph_locations() {
-        let glyph_name = "space".to_string();
+        let glyph_name: GlyphName = "space".into();
         let (source, context) =
             build_static_metadata(glyphs2_dir().join("WghtVar_AxisMappings.glyphs"));
-        build_glyphs(&source, &context, vec![&glyph_name]).unwrap(); // we dont' care about geometry
+        build_glyphs(&source, &context, vec![glyph_name]).unwrap(); // we dont' care about geometry
 
         assert_eq!(
             HashSet::from([
@@ -497,7 +492,7 @@ mod tests {
                 &NormalizedLocation::on_axis("Weight", NormalizedCoord::new(1.0)),
             ]),
             context
-                .get_glyph_ir(&glyph_name)
+                .get_glyph_ir(glyph_name)
                 .sources
                 .keys()
                 .collect::<HashSet<_>>()
@@ -506,15 +501,15 @@ mod tests {
 
     #[test]
     fn glyph_must_define_min() {
-        let glyph_name = "min-undefined".to_string();
+        let glyph_name = "min-undefined".into();
         let (source, context) =
             build_static_metadata(glyphs2_dir().join("WghtVar_AxisMappings.glyphs"));
-        let result = build_glyphs(&source, &context, vec![&glyph_name]);
+        let result = build_glyphs(&source, &context, vec![glyph_name]);
         assert!(result.is_err());
         let Err(WorkError::GlyphUndefAtNormalizedPosition { glyph_name, axis, pos }) =  result else {
             panic!("Wrong error");
         };
-        assert_eq!("min-undefined", glyph_name);
+        assert_eq!("min-undefined", glyph_name.as_str());
         assert_eq!("wght", axis);
         assert_eq!(NormalizedCoord::new(-1.0), pos);
     }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -352,12 +352,9 @@ mod tests {
         let g1 = glyph_state_for_file(&glyphs3_dir(), "WghtVar.glyphs");
         let g2 = glyph_state_for_file(&glyphs3_dir(), "WghtVar_HeavyHyphen.glyphs");
 
-        eprintln!("G1\n{:#?}", g1);
-        eprintln!("G2\n{:#?}", g2);
-
         let changed = keys
             .into_iter()
-            .filter(|key| g1.get(key).unwrap() == g2.get(key).unwrap())
+            .filter(|key| g1.get(key).unwrap() != g2.get(key).unwrap())
             .collect();
         assert_eq!(HashSet::<GlyphName>::from(["hyphen".into()]), changed);
     }

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use fontdrasil::types::GlyphName;
 use fontir::{
     coords::{CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
     ir,
@@ -98,14 +99,11 @@ pub fn to_ir_axis(axis: &designspace::Axis) -> ir::Axis {
     }
 }
 
-pub fn to_ir_glyph<S>(
-    glyph_name: S,
+pub fn to_ir_glyph(
+    glyph_name: GlyphName,
     glif_files: &HashMap<&PathBuf, Vec<NormalizedLocation>>,
-) -> Result<ir::Glyph, Error>
-where
-    S: Into<String>,
-{
-    let mut glyph = ir::Glyph::new(glyph_name.into());
+) -> Result<ir::Glyph, Error> {
+    let mut glyph = ir::Glyph::new(glyph_name);
     for (glif_file, locations) in glif_files {
         let norad_glyph = norad::Glyph::load(glif_file).map_err(Error::GlifLoadError)?;
         for location in locations {


### PR DESCRIPTION
fontdrasil/src/types.rs is the interesting part. We keep smaller glyph-names directly and keep a u32 that resolves to the string for longer ones.

I could not figure out how to handle this w/o unsafe.

@dfrg pointed out this complicates use of fontc as a library which, despite my enthusiasm for not having clone everywhere, seems like a deal breaker so I will close this and just s/String/SmolString and call it a day.