### PR TITLE
Use SmolStr instead of String in WorkIdentifier::GlyphName

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -20,7 +20,7 @@ pub struct FeatureWork {
 impl FeatureWork {
     pub fn create(build_dir: &Path) -> Box<BeWork> {
         let build_dir = build_dir.to_path_buf();
-        Box::from(FeatureWork { build_dir })
+        Box::new(FeatureWork { build_dir })
     }
 }
 

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use fea_rs::{Diagnostic, GlyphMap, GlyphName};
+use fea_rs::{Diagnostic, GlyphMap, GlyphName as FeaRsGlyphName};
 use log::{debug, trace, warn};
 use write_fonts::FontBuilder;
 
@@ -102,7 +102,10 @@ impl Work<Context, Error> for FeatureWork {
         if glyph_order.is_empty() {
             warn!("Glyph order is empty; feature compile improbable");
         }
-        let glyph_map = glyph_order.iter().map(Into::<GlyphName>::into).collect();
+        let glyph_map = glyph_order
+            .iter()
+            .map(|n| Into::<FeaRsGlyphName>::into(n.as_str()))
+            .collect();
         let font = self.compile(fea_file, glyph_map)?;
         context.set_features(font);
         Ok(())

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -2,7 +2,10 @@
 
 use std::{collections::HashSet, fs, path::Path, sync::Arc};
 
-use fontdrasil::orchestration::{AccessControlList, Work, MISSING_DATA};
+use fontdrasil::{
+    orchestration::{AccessControlList, Work, MISSING_DATA},
+    types::GlyphName,
+};
 use fontir::orchestration::{Context as FeContext, WorkIdentifier as FeWorkIdentifier};
 use parking_lot::RwLock;
 use write_fonts::FontBuilder;
@@ -16,7 +19,7 @@ use crate::{error::Error, paths::Paths};
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WorkIdentifier {
     Features,
-    Glyph(String),
+    Glyph(GlyphName),
     GlyphMerge,
     FinalMerge,
 }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -6,7 +6,7 @@ use fontdrasil::{
     orchestration::{AccessControlList, Work, MISSING_DATA},
     types::GlyphName,
 };
-use fontir::orchestration::{Context as FeContext, WorkIdentifier as FeWorkIdentifier};
+use fontir::orchestration::{Context as FeContext, WorkId as FeWorkIdentifier};
 use parking_lot::RwLock;
 use write_fonts::FontBuilder;
 
@@ -17,7 +17,7 @@ use crate::{error::Error, paths::Paths};
 /// If there are no fields work is unique.
 /// Meant to be small and cheap to copy around.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum WorkIdentifier {
+pub enum WorkId {
     Features,
     Glyph(GlyphName),
     GlyphMerge,
@@ -29,11 +29,11 @@ pub enum WorkIdentifier {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AnyWorkId {
     Fe(FeWorkIdentifier),
-    Be(WorkIdentifier),
+    Be(WorkId),
 }
 
 impl AnyWorkId {
-    pub fn unwrap_be(&self) -> &WorkIdentifier {
+    pub fn unwrap_be(&self) -> &WorkId {
         match self {
             AnyWorkId::Fe(..) => panic!("Not a BE identifier"),
             AnyWorkId::Be(id) => id,
@@ -54,8 +54,8 @@ impl From<FeWorkIdentifier> for AnyWorkId {
     }
 }
 
-impl From<WorkIdentifier> for AnyWorkId {
-    fn from(id: WorkIdentifier) -> Self {
+impl From<WorkId> for AnyWorkId {
+    fn from(id: WorkId) -> Self {
         AnyWorkId::Be(id)
     }
 }
@@ -96,7 +96,7 @@ impl Context {
 
     pub fn copy_for_work(
         &self,
-        work_id: WorkIdentifier,
+        work_id: WorkId,
         dependencies: Option<HashSet<AnyWorkId>>,
     ) -> Context {
         Context {
@@ -131,7 +131,7 @@ impl Context {
     }
 
     pub fn get_features(&self) -> Arc<Vec<u8>> {
-        let id = WorkIdentifier::Features;
+        let id = WorkId::Features;
         self.acl.check_read_access(&id.clone().into());
         {
             let rl = self.features.read();
@@ -146,7 +146,7 @@ impl Context {
     }
 
     pub fn set_features(&self, mut font: FontBuilder) {
-        let id = WorkIdentifier::Features;
+        let id = WorkId::Features;
         self.acl.check_write_access(&id.clone().into());
         let font = font.build();
         self.maybe_persist(&self.paths.target_file(&id), &font);

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -33,7 +33,7 @@ impl Paths {
     pub fn target_file(&self, id: &WorkIdentifier) -> PathBuf {
         match id {
             WorkIdentifier::Features => self.build_dir.join("features.ttf"),
-            WorkIdentifier::Glyph(name) => self.glyph_file(name),
+            WorkIdentifier::Glyph(name) => self.glyph_file(name.as_str()),
             WorkIdentifier::GlyphMerge => self.build_dir.join("all_glyphs.ttf"),
             WorkIdentifier::FinalMerge => self.build_dir.join("font.ttf"),
         }

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use fontdrasil::paths::glyph_file;
 
-use crate::orchestration::WorkIdentifier;
+use crate::orchestration::WorkId;
 
 #[derive(Debug, Clone)]
 pub struct Paths {
@@ -30,12 +30,12 @@ impl Paths {
         self.glyph_dir.join(glyph_file(name, ".ttf"))
     }
 
-    pub fn target_file(&self, id: &WorkIdentifier) -> PathBuf {
+    pub fn target_file(&self, id: &WorkId) -> PathBuf {
         match id {
-            WorkIdentifier::Features => self.build_dir.join("features.ttf"),
-            WorkIdentifier::Glyph(name) => self.glyph_file(name.as_str()),
-            WorkIdentifier::GlyphMerge => self.build_dir.join("all_glyphs.ttf"),
-            WorkIdentifier::FinalMerge => self.build_dir.join("font.ttf"),
+            WorkId::Features => self.build_dir.join("features.ttf"),
+            WorkId::Glyph(name) => self.glyph_file(name.as_str()),
+            WorkId::GlyphMerge => self.build_dir.join("all_glyphs.ttf"),
+            WorkId::FinalMerge => self.build_dir.join("font.ttf"),
         }
     }
 }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
+fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontbe = { version = "0.0.1", path = "../fontbe" }
 fontir = { version = "0.0.1", path = "../fontir" }
 glyphs2fontir = { version = "0.0.1", path = "../glyphs2fontir" }

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -17,6 +17,7 @@ use fontc::{
     work::{AnyContext, AnyWork, AnyWorkError},
     Error,
 };
+use fontdrasil::types::GlyphName;
 use fontir::{
     orchestration::{Context as FeContext, WorkIdentifier as FeWorkIdentifier},
     paths::Paths as IrPaths,
@@ -168,14 +169,9 @@ impl ChangeDetector {
                 .is_file()
     }
 
-    fn glyphs_changed(&self) -> IndexSet<&str> {
+    fn glyphs_changed(&self) -> IndexSet<GlyphName> {
         if self.static_metadata_ir_change() {
-            return self
-                .current_inputs
-                .glyphs
-                .keys()
-                .map(|e| e.as_str())
-                .collect();
+            return self.current_inputs.glyphs.keys().cloned().collect();
         }
         self.current_inputs
             .glyphs
@@ -187,22 +183,23 @@ impl ChangeDetector {
                         (prev_state != curr_state
                             || !self
                                 .ir_paths
-                                .target_file(&FeWorkIdentifier::Glyph(glyph_name.to_string()))
+                                .target_file(&FeWorkIdentifier::Glyph(glyph_name.clone()))
                                 .exists())
-                        .then_some(glyph_name.as_str())
+                        .then_some(glyph_name)
                     }
-                    None => Some(glyph_name.as_str()),
+                    None => Some(glyph_name),
                 },
             )
+            .cloned()
             .collect()
     }
 
-    fn glyphs_deleted(&self) -> IndexSet<&str> {
+    fn glyphs_deleted(&self) -> IndexSet<GlyphName> {
         self.prev_inputs
             .glyphs
             .keys()
-            .filter(|glyph_name| !self.current_inputs.glyphs.contains_key(glyph_name.as_str()))
-            .map(|e| e.as_str())
+            .filter(|glyph_name| !self.current_inputs.glyphs.contains_key(glyph_name))
+            .cloned()
             .collect()
     }
 }
@@ -276,7 +273,7 @@ fn add_glyph_ir_jobs(
 ) -> Result<(), Error> {
     // Destroy IR for deleted glyphs. No dependencies.
     for glyph_name in change_detector.glyphs_deleted().iter() {
-        let id = FeWorkIdentifier::Glyph(glyph_name.to_string());
+        let id = FeWorkIdentifier::Glyph(glyph_name.clone());
         let path = change_detector.ir_paths.target_file(&id);
         workload.insert(
             id.into(),
@@ -293,7 +290,7 @@ fn add_glyph_ir_jobs(
         .ir_source
         .create_glyph_ir_work(&glyphs_changed, &change_detector.current_inputs)?;
     for (glyph_name, work) in glyphs_changed.iter().zip(glyph_work) {
-        let id = FeWorkIdentifier::Glyph(glyph_name.to_string());
+        let id = FeWorkIdentifier::Glyph(glyph_name.clone());
         let work = work.into();
         let dependencies = HashSet::from([FeWorkIdentifier::StaticMetadata.into()]);
 
@@ -548,11 +545,13 @@ mod tests {
         paths::Paths as BePaths,
     };
     use fontc::work::AnyContext;
+    use fontdrasil::types::GlyphName;
     use fontir::{
         orchestration::{Context as FeContext, WorkIdentifier as FeWorkIdentifier},
         paths::Paths as IrPaths,
         stateset::StateSet,
     };
+    use indexmap::IndexSet;
     use tempfile::tempdir;
 
     use crate::{
@@ -578,24 +577,16 @@ mod tests {
 
     struct TestCompile {
         work_completed: HashSet<AnyWorkId>,
-        glyphs_changed: HashSet<String>,
-        glyphs_deleted: HashSet<String>,
+        glyphs_changed: IndexSet<GlyphName>,
+        glyphs_deleted: IndexSet<GlyphName>,
     }
 
     impl TestCompile {
         fn new(change_detector: &ChangeDetector) -> TestCompile {
             TestCompile {
                 work_completed: HashSet::new(),
-                glyphs_changed: change_detector
-                    .glyphs_changed()
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect(),
-                glyphs_deleted: change_detector
-                    .glyphs_deleted()
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect(),
+                glyphs_changed: change_detector.glyphs_changed(),
+                glyphs_deleted: change_detector.glyphs_deleted(),
             }
         }
     }
@@ -722,8 +713,8 @@ mod tests {
             HashSet::from([
                 FeWorkIdentifier::StaticMetadata.into(),
                 FeWorkIdentifier::Features.into(),
-                FeWorkIdentifier::Glyph(String::from("bar")).into(),
-                FeWorkIdentifier::Glyph(String::from("plus")).into(),
+                FeWorkIdentifier::Glyph("bar".into()).into(),
+                FeWorkIdentifier::Glyph("plus".into()).into(),
                 BeWorkIdentifier::Features.into(),
             ]),
             result.work_completed
@@ -737,15 +728,15 @@ mod tests {
 
         let result = compile(build_dir, "wght_var.designspace");
         assert_eq!(
-            HashSet::from(["bar".to_string(), "plus".to_string()]),
+            IndexSet::from(["bar".into(), "plus".into()]),
             result.glyphs_changed
         );
-        assert_eq!(HashSet::from([]), result.glyphs_deleted);
+        assert_eq!(IndexSet::new(), result.glyphs_deleted);
 
         let result = compile(build_dir, "wght_var.designspace");
         assert_eq!(HashSet::new(), result.work_completed);
-        assert_eq!(HashSet::from([]), result.glyphs_changed);
-        assert_eq!(HashSet::from([]), result.glyphs_deleted);
+        assert_eq!(IndexSet::new(), result.glyphs_changed);
+        assert_eq!(IndexSet::new(), result.glyphs_deleted);
     }
 
     #[test]
@@ -761,7 +752,7 @@ mod tests {
 
         let result = compile(build_dir, "wght_var.designspace");
         assert_eq!(
-            HashSet::from([FeWorkIdentifier::Glyph(String::from("bar")).into(),]),
+            HashSet::from([FeWorkIdentifier::Glyph("bar".into()).into(),]),
             result.work_completed
         );
     }
@@ -773,18 +764,18 @@ mod tests {
 
         let result = compile(build_dir, "wght_var.designspace");
         assert_eq!(
-            HashSet::from(["bar".to_string(), "plus".to_string()]),
+            IndexSet::from(["bar".into(), "plus".into()]),
             result.glyphs_changed
         );
-        assert_eq!(HashSet::from([]), result.glyphs_deleted);
+        assert_eq!(IndexSet::new(), result.glyphs_deleted);
 
         let bar_ir = build_dir.join("glyph_ir/bar.yml");
         assert!(bar_ir.is_file(), "no file {:#?}", bar_ir);
         fs::remove_file(bar_ir).unwrap();
 
         let result = compile(build_dir, "wght_var.designspace");
-        assert_eq!(HashSet::from(["bar".to_string()]), result.glyphs_changed);
-        assert_eq!(HashSet::from([]), result.glyphs_deleted);
+        assert_eq!(IndexSet::from(["bar".into()]), result.glyphs_changed);
+        assert_eq!(IndexSet::new(), result.glyphs_deleted);
     }
 
     #[test]

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use crossbeam_channel::{Receiver, TryRecvError};
 use fontbe::{
     features::FeatureWork,
-    orchestration::{AnyWorkId, Context as BeContext, WorkIdentifier as BeWorkIdentifier},
+    orchestration::{AnyWorkId, Context as BeContext, WorkId as BeWorkIdentifier},
     paths::Paths as BePaths,
 };
 use fontc::{
@@ -19,7 +19,7 @@ use fontc::{
 };
 use fontdrasil::types::GlyphName;
 use fontir::{
-    orchestration::{Context as FeContext, WorkIdentifier as FeWorkIdentifier},
+    orchestration::{Context as FeContext, WorkId as FeWorkIdentifier},
     paths::Paths as IrPaths,
     source::{DeleteWork, Input, Source},
     stateset::StateSet,
@@ -131,8 +131,8 @@ fn ir_source(source: &Path) -> Result<Box<dyn Source>, Error> {
         .and_then(OsStr::to_str)
         .ok_or_else(|| Error::UnrecognizedSource(source.to_path_buf()))?;
     match ext {
-        "designspace" => Ok(Box::from(DesignSpaceIrSource::new(source.to_path_buf()))),
-        "glyphs" => Ok(Box::from(GlyphsIrSource::new(source.to_path_buf()))),
+        "designspace" => Ok(Box::new(DesignSpaceIrSource::new(source.to_path_buf()))),
+        "glyphs" => Ok(Box::new(GlyphsIrSource::new(source.to_path_buf()))),
         _ => Err(Error::UnrecognizedSource(source.to_path_buf())),
     }
 }
@@ -541,13 +541,13 @@ mod tests {
 
     use filetime::FileTime;
     use fontbe::{
-        orchestration::{AnyWorkId, Context as BeContext, WorkIdentifier as BeWorkIdentifier},
+        orchestration::{AnyWorkId, Context as BeContext, WorkId as BeWorkIdentifier},
         paths::Paths as BePaths,
     };
     use fontc::work::AnyContext;
     use fontdrasil::types::GlyphName;
     use fontir::{
-        orchestration::{Context as FeContext, WorkIdentifier as FeWorkIdentifier},
+        orchestration::{Context as FeContext, WorkId as FeWorkIdentifier},
         paths::Paths as IrPaths,
         stateset::StateSet,
     };

--- a/fontc/src/work.rs
+++ b/fontc/src/work.rs
@@ -77,17 +77,17 @@ impl AnyContext {
         fe_root: &FeContext,
         be_root: &BeContext,
         id: &AnyWorkId,
-        happens_after: HashSet<AnyWorkId>,
+        dependencies: HashSet<AnyWorkId>,
     ) -> AnyContext {
         match id {
             AnyWorkId::Be(id) => {
-                AnyContext::Be(be_root.copy_for_work(id.clone(), Some(happens_after)))
+                AnyContext::Be(be_root.copy_for_work(id.clone(), Some(dependencies)))
             }
             AnyWorkId::Fe(id) => AnyContext::Fe(
                 fe_root.copy_for_work(
                     id.clone(),
                     Some(
-                        happens_after
+                        dependencies
                             .into_iter()
                             .map(|a| a.unwrap_fe().clone())
                             .collect(),

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -11,9 +11,6 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-
-parking_lot = "0.12.1"
-
 smol_str = "0.1.14"
 
 serde = {version = "1.0", features = ["derive"] }

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -12,6 +12,12 @@ categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
 
+parking_lot = "0.12.1"
+
+smol_str = "0.1.14"
+
+serde = {version = "1.0", features = ["derive"] }
+
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"

--- a/fontdrasil/src/lib.rs
+++ b/fontdrasil/src/lib.rs
@@ -1,3 +1,4 @@
 //! Helper library for code that is of value to FE and BE of font compilation.
 pub mod orchestration;
 pub mod paths;
+pub mod types;

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -1,0 +1,51 @@
+//! Basic types useful for font compilation.
+//!
+//! Particularly types where it's nice for FE and BE to match.
+
+use std::fmt::{Debug, Display};
+
+use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct GlyphName(SmolStr);
+
+impl GlyphName {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn empty() -> GlyphName {
+        "".into()
+    }
+}
+
+impl From<&String> for GlyphName {
+    fn from(value: &String) -> Self {
+        GlyphName(value.into())
+    }
+}
+
+impl From<String> for GlyphName {
+    fn from(value: String) -> Self {
+        GlyphName(value.into())
+    }
+}
+
+impl From<&str> for GlyphName {
+    fn from(value: &str) -> Self {
+        GlyphName(value.into())
+    }
+}
+
+impl Debug for GlyphName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Display for GlyphName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -1,5 +1,6 @@
 use std::{error, io, path::PathBuf};
 
+use fontdrasil::types::GlyphName;
 use thiserror::Error;
 
 use crate::coords::{DesignCoord, NormalizedCoord, NormalizedLocation, UserLocation};
@@ -24,10 +25,10 @@ pub enum Error {
     UnableToLoadSource(Box<dyn error::Error>),
     #[error("Missing layer")]
     NoSuchLayer(String),
-    #[error("No files associated with glyph")]
-    NoStateForGlyph(String),
-    #[error("No design space location(s) associated with glyph")]
-    NoLocationsForGlyph(String),
+    #[error("No files associated with glyph {0}")]
+    NoStateForGlyph(GlyphName),
+    #[error("No design space location(s) associated with glyph {0}")]
+    NoLocationsForGlyph(GlyphName),
     #[error("Asked to create work for something other than the last input we created")]
     UnableToCreateGlyphIrWork,
     #[error("Unexpected state encountered in a state set")]
@@ -58,8 +59,8 @@ pub enum WorkError {
     IoError(#[from] io::Error),
     // I can't use Box(<dyn error::Error>) here because it's not Send, but
     // if I convert error to string I lose the backtrace... What to do?
-    #[error("Conversion of glyph '{0}' to IR failed: {1}")]
-    GlyphIrWorkError(String, String),
+    #[error("Conversion of glyph '{0:?}' to IR failed: {1}")]
+    GlyphIrWorkError(GlyphName, String),
     #[error("yaml error")]
     YamlSerError(#[from] serde_yaml::Error),
     #[error("No axes are defined")]
@@ -68,8 +69,8 @@ pub enum WorkError {
     InconsistentAxisDefinitions(String),
     #[error("I am the glyph with gid, {0}")]
     NoGlyphIdForName(String),
-    #[error("No Glyph for name {0}")]
-    NoGlyphForName(String),
+    #[error("No Glyph for name {0:?}")]
+    NoGlyphForName(GlyphName),
     #[error("File expected: {0:?}")]
     FileExpected(PathBuf),
     #[error("Expected to match: {0:?}, {1:?}")]
@@ -80,13 +81,13 @@ pub enum WorkError {
     ParseError(PathBuf, String),
     #[error("No default master in {0:?}")]
     NoDefaultMaster(PathBuf),
-    #[error("No master {master} exists. Referenced by glyph {glyph}.")]
-    NoMasterForGlyph { master: String, glyph: String },
+    #[error("No master {master} exists. Referenced by glyph {glyph:?}.")]
+    NoMasterForGlyph { master: String, glyph: GlyphName },
     #[error("Failed to add glyph source: {0}")]
     AddGlyphSource(String),
     #[error("{glyph_name} undefined on {axis} at required position {pos:?}")]
     GlyphUndefAtNormalizedPosition {
-        glyph_name: String,
+        glyph_name: GlyphName,
         axis: String,
         pos: NormalizedCoord,
     },

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -5,6 +5,7 @@ use crate::{
     error::Error,
     serde::{GlyphSerdeRepr, StaticMetadataSerdeRepr},
 };
+use fontdrasil::types::GlyphName;
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -20,17 +21,17 @@ use std::{
 #[serde(from = "StaticMetadataSerdeRepr", into = "StaticMetadataSerdeRepr")]
 pub struct StaticMetadata {
     pub axes: Vec<Axis>,
-    pub glyph_order: IndexSet<String>,
+    pub glyph_order: IndexSet<GlyphName>,
 }
 
 impl StaticMetadata {
-    pub fn new(axes: Vec<Axis>, glyph_order: IndexSet<String>) -> StaticMetadata {
+    pub fn new(axes: Vec<Axis>, glyph_order: IndexSet<GlyphName>) -> StaticMetadata {
         StaticMetadata { axes, glyph_order }
     }
 }
 
 impl StaticMetadata {
-    pub fn glyph_id(&self, name: &String) -> Option<u32> {
+    pub fn glyph_id(&self, name: &GlyphName) -> Option<u32> {
         self.glyph_order.get_index_of(name).map(|i| i as u32)
     }
 }
@@ -74,12 +75,12 @@ impl Features {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(from = "GlyphSerdeRepr", into = "GlyphSerdeRepr")]
 pub struct Glyph {
-    pub name: String,
+    pub name: GlyphName,
     pub sources: HashMap<NormalizedLocation, GlyphInstance>,
 }
 
 impl Glyph {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: GlyphName) -> Self {
         Self {
             name,
             sources: HashMap::new(),
@@ -93,7 +94,7 @@ impl Glyph {
     ) -> Result<(), Error> {
         if self.sources.contains_key(unique_location) {
             return Err(Error::DuplicateNormalizedLocation {
-                what: format!("glyph '{}' source", self.name),
+                what: format!("glyph '{}' source", self.name.as_str()),
                 loc: unique_location.clone(),
             });
         }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -21,10 +21,10 @@ use crate::{error::WorkError, ir, paths::Paths, source::Input};
 // Unique identifier of work. If there are no fields work is unique.
 // Meant to be small and cheap to copy around.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum WorkIdentifier {
+pub enum WorkId {
     StaticMetadata,
     Glyph(GlyphName),
-    GlyphIrDelete(),
+    GlyphIrDelete,
     Features,
 }
 
@@ -45,7 +45,7 @@ pub struct Context {
     // a subset of the full input.
     pub input: Arc<Input>,
 
-    acl: AccessControlList<WorkIdentifier>,
+    acl: AccessControlList<WorkId>,
 
     // work results we've completed or restored from disk
     // We create individual caches so we can return typed results from get fns
@@ -55,7 +55,7 @@ pub struct Context {
 }
 
 impl Context {
-    fn copy(&self, acl: AccessControlList<WorkIdentifier>) -> Context {
+    fn copy(&self, acl: AccessControlList<WorkId>) -> Context {
         Context {
             emit_ir: self.emit_ir,
             paths: self.paths.clone(),
@@ -79,11 +79,7 @@ impl Context {
         }
     }
 
-    pub fn copy_for_work(
-        &self,
-        work_id: WorkIdentifier,
-        dependencies: Option<HashSet<WorkIdentifier>>,
-    ) -> Context {
+    pub fn copy_for_work(&self, work_id: WorkId, dependencies: Option<HashSet<WorkId>>) -> Context {
         self.copy(AccessControlList::read_write(
             dependencies.unwrap_or_default(),
             work_id,
@@ -132,7 +128,7 @@ impl Context {
     }
 
     pub fn get_static_metadata(&self) -> Arc<ir::StaticMetadata> {
-        let id = WorkIdentifier::StaticMetadata;
+        let id = WorkId::StaticMetadata;
         self.acl.check_read_access(&id);
         {
             let rl = self.static_metadata.read();
@@ -146,21 +142,21 @@ impl Context {
     }
 
     pub fn set_static_metadata(&self, ir: ir::StaticMetadata) {
-        let id = WorkIdentifier::StaticMetadata;
+        let id = WorkId::StaticMetadata;
         self.acl.check_write_access(&id);
         self.maybe_persist(&self.paths.target_file(&id), &ir);
         self.set_cached_static_metadata(ir);
     }
 
     pub fn get_glyph_ir(&self, glyph_name: &GlyphName) -> Arc<ir::Glyph> {
-        let id = WorkIdentifier::Glyph(glyph_name.clone());
+        let id = WorkId::Glyph(glyph_name.clone());
         self.acl.check_read_access(&id);
         let rl = self.glyph_ir.read();
         rl.get(glyph_name).expect(MISSING_DATA).clone()
     }
 
     pub fn set_glyph_ir(&self, glyph_name: GlyphName, ir: ir::Glyph) {
-        let id = WorkIdentifier::Glyph(glyph_name.clone());
+        let id = WorkId::Glyph(glyph_name.clone());
         self.acl.check_write_access(&id);
         self.maybe_persist(&self.paths.target_file(&id), &ir);
         let mut wl = self.glyph_ir.write();
@@ -173,7 +169,7 @@ impl Context {
     }
 
     pub fn get_features(&self) -> Arc<ir::Features> {
-        let id = WorkIdentifier::Features;
+        let id = WorkId::Features;
         self.acl.check_read_access(&id);
         {
             let rl = self.feature_ir.read();
@@ -187,7 +183,7 @@ impl Context {
     }
 
     pub fn set_features(&self, ir: ir::Features) {
-        let id = WorkIdentifier::Features;
+        let id = WorkId::Features;
         self.acl.check_write_access(&id);
         self.maybe_persist(&self.paths.target_file(&id), &ir);
         self.set_cached_features(ir);

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -44,8 +44,8 @@ impl Paths {
     pub fn target_file(&self, id: &WorkIdentifier) -> PathBuf {
         match id {
             WorkIdentifier::StaticMetadata => self.build_dir.join("static_metadata.yml"),
-            WorkIdentifier::Glyph(name) => self.glyph_ir_file(name),
-            WorkIdentifier::GlyphIrDelete(name) => self.glyph_ir_file(name),
+            WorkIdentifier::Glyph(name) => self.glyph_ir_file(name.as_str()),
+            WorkIdentifier::GlyphIrDelete() => self.build_dir.join("delete.yml"),
             WorkIdentifier::Features => self.build_dir.join("features.yml"),
         }
     }

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use fontdrasil::paths::glyph_file;
 
-use crate::orchestration::WorkIdentifier;
+use crate::orchestration::WorkId;
 
 #[derive(Debug, Clone)]
 pub struct Paths {
@@ -41,12 +41,12 @@ impl Paths {
         self.glyph_ir_dir.join(glyph_file(name, ".yml"))
     }
 
-    pub fn target_file(&self, id: &WorkIdentifier) -> PathBuf {
+    pub fn target_file(&self, id: &WorkId) -> PathBuf {
         match id {
-            WorkIdentifier::StaticMetadata => self.build_dir.join("static_metadata.yml"),
-            WorkIdentifier::Glyph(name) => self.glyph_ir_file(name.as_str()),
-            WorkIdentifier::GlyphIrDelete() => self.build_dir.join("delete.yml"),
-            WorkIdentifier::Features => self.build_dir.join("features.yml"),
+            WorkId::StaticMetadata => self.build_dir.join("static_metadata.yml"),
+            WorkId::Glyph(name) => self.glyph_ir_file(name.as_str()),
+            WorkId::GlyphIrDelete => self.build_dir.join("delete.yml"),
+            WorkId::Features => self.build_dir.join("features.yml"),
         }
     }
 }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -50,7 +50,10 @@ pub struct StaticMetadataSerdeRepr {
 
 impl From<StaticMetadataSerdeRepr> for StaticMetadata {
     fn from(from: StaticMetadataSerdeRepr) -> Self {
-        StaticMetadata::new(from.axes, from.glyph_order.into_iter().collect())
+        StaticMetadata::new(
+            from.axes,
+            from.glyph_order.into_iter().map(|s| s.into()).collect(),
+        )
     }
 }
 
@@ -58,7 +61,11 @@ impl From<StaticMetadata> for StaticMetadataSerdeRepr {
     fn from(from: StaticMetadata) -> Self {
         StaticMetadataSerdeRepr {
             axes: from.axes,
-            glyph_order: from.glyph_order.into_iter().collect(),
+            glyph_order: from
+                .glyph_order
+                .into_iter()
+                .map(|n| n.as_str().to_string())
+                .collect(),
         }
     }
 }
@@ -79,7 +86,7 @@ pub struct GlyphSerdeRepr {
 impl From<GlyphSerdeRepr> for Glyph {
     fn from(from: GlyphSerdeRepr) -> Self {
         Glyph {
-            name: from.name,
+            name: from.name.into(),
             sources: from
                 .instances
                 .into_iter()
@@ -92,7 +99,7 @@ impl From<GlyphSerdeRepr> for Glyph {
 impl From<Glyph> for GlyphSerdeRepr {
     fn from(from: Glyph) -> Self {
         GlyphSerdeRepr {
-            name: from.name,
+            name: from.name.as_str().to_string(),
             instances: from
                 .sources
                 .into_iter()

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -21,7 +21,7 @@ pub struct DeleteWork {
 
 impl DeleteWork {
     pub fn create(path: PathBuf) -> Box<IrWork> {
-        Box::from(DeleteWork { path })
+        Box::new(DeleteWork { path })
     }
 }
 

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -6,7 +6,7 @@ use indexmap::IndexSet;
 use log::debug;
 use serde::{Deserialize, Serialize};
 
-use fontdrasil::orchestration::Work;
+use fontdrasil::{orchestration::Work, types::GlyphName};
 
 use crate::{
     error::{Error, WorkError},
@@ -56,7 +56,7 @@ pub trait Source {
     /// When run work should update [Context] with [crate::ir::Glyph] for the glyph name.
     fn create_glyph_ir_work(
         &self,
-        glyph_names: &IndexSet<&str>,
+        glyph_names: &IndexSet<GlyphName>,
         input: &Input,
     ) -> Result<Vec<Box<IrWork>>, Error>;
 
@@ -74,7 +74,7 @@ pub struct Input {
     pub static_metadata: StateSet,
 
     /// The input(s) that inform glyph IR construction, grouped by gyph name
-    pub glyphs: HashMap<String, StateSet>,
+    pub glyphs: HashMap<GlyphName, StateSet>,
 
     /// The input(s) that inform feature IR construction
     pub features: StateSet,
@@ -121,7 +121,7 @@ mod tests {
             .unwrap();
 
         let mut glyphs = HashMap::new();
-        glyphs.insert("space".to_string(), glyph);
+        glyphs.insert("space".into(), glyph);
 
         let mut features = StateSet::new();
         features

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -123,7 +123,7 @@ impl Source for GlyphsIrSource {
     fn create_static_metadata_work(&self, input: &Input) -> Result<Box<IrWork>, Error> {
         self.check_static_metadata(&input.static_metadata)?;
         let font_info = self.cache.as_ref().unwrap().font_info.clone();
-        Ok(Box::from(StaticMetadataWork { font_info }))
+        Ok(Box::new(StaticMetadataWork { font_info }))
     }
 
     fn create_glyph_ir_work(
@@ -137,7 +137,7 @@ impl Source for GlyphsIrSource {
 
         let mut work: Vec<Box<IrWork>> = Vec::new();
         for glyph_name in glyph_names {
-            work.push(Box::from(self.create_work_for_one_glyph(
+            work.push(Box::new(self.create_work_for_one_glyph(
                 glyph_name.clone(),
                 cache.font_info.clone(),
             )?));
@@ -148,7 +148,7 @@ impl Source for GlyphsIrSource {
     fn create_feature_ir_work(&self, input: &Input) -> Result<Box<IrWork>, Error> {
         self.check_static_metadata(&input.static_metadata)?;
 
-        Ok(Box::from(FeatureWork {}))
+        Ok(Box::new(FeatureWork {}))
     }
 }
 
@@ -294,7 +294,7 @@ mod tests {
         coords::{CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord},
         error::WorkError,
         ir,
-        orchestration::{Context, WorkIdentifier},
+        orchestration::{Context, WorkId},
         paths::Paths,
         source::Source,
         stateset::StateSet,
@@ -375,7 +375,7 @@ mod tests {
     #[test]
     fn static_metadata_ir() {
         let (source, context) = context_for(glyphs3_dir().join("WghtVar.glyphs"));
-        let task_context = context.copy_for_work(WorkIdentifier::StaticMetadata, None);
+        let task_context = context.copy_for_work(WorkId::StaticMetadata, None);
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -402,7 +402,7 @@ mod tests {
     fn static_metadata_ir_multi_axis() {
         // Caused index out of bounds due to transposed master and value indices
         let (source, context) = context_for(glyphs2_dir().join("BadIndexing.glyphs"));
-        let task_context = context.copy_for_work(WorkIdentifier::StaticMetadata, None);
+        let task_context = context.copy_for_work(WorkId::StaticMetadata, None);
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -413,7 +413,7 @@ mod tests {
     #[test]
     fn loads_axis_mappings_from_glyphs2() {
         let (source, context) = context_for(glyphs2_dir().join("WghtVar_AxisMappings.glyphs"));
-        let task_context = context.copy_for_work(WorkIdentifier::StaticMetadata, None);
+        let task_context = context.copy_for_work(WorkId::StaticMetadata, None);
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -449,7 +449,7 @@ mod tests {
 
     fn build_static_metadata(glyphs_file: PathBuf) -> (impl Source, Context) {
         let (source, context) = context_for(glyphs_file);
-        let task_context = context.copy_for_work(WorkIdentifier::StaticMetadata, None);
+        let task_context = context.copy_for_work(WorkId::StaticMetadata, None);
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -469,8 +469,8 @@ mod tests {
                 .unwrap();
             for work in work_items.iter() {
                 let task_context = context.copy_for_work(
-                    WorkIdentifier::Glyph(glyph_name.clone()),
-                    Some(HashSet::from([WorkIdentifier::StaticMetadata])),
+                    WorkId::Glyph(glyph_name.clone()),
+                    Some(HashSet::from([WorkId::StaticMetadata])),
                 );
                 work.exec(&task_context)?;
             }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use fontdrasil::orchestration::Work;
+use fontdrasil::{orchestration::Work, types::GlyphName};
 use fontir::{
     coords::{DesignLocation, NormalizedLocation, UserCoord},
     error::{Error, WorkError},
@@ -43,7 +43,7 @@ impl DesignSpaceIrSource {
 struct Cache {
     static_metadata: StateSet,
     locations: HashMap<PathBuf, Vec<DesignLocation>>,
-    glyph_names: Arc<HashSet<String>>,
+    glyph_names: Arc<HashSet<GlyphName>>,
     designspace_file: PathBuf,
     designspace: Arc<DesignSpaceDocument>,
     fea_files: Arc<Vec<PathBuf>>,
@@ -52,7 +52,7 @@ struct Cache {
 impl Cache {
     fn new(
         static_metadata: StateSet,
-        glyph_names: HashSet<String>,
+        glyph_names: HashSet<GlyphName>,
         locations: HashMap<PathBuf, Vec<DesignLocation>>,
         designspace_file: PathBuf,
         designspace: DesignSpaceDocument,
@@ -79,9 +79,9 @@ impl Cache {
 
 fn glif_files<'a>(
     ufo_dir: &Path,
-    layer_cache: &'a mut HashMap<String, HashMap<String, PathBuf>>,
+    layer_cache: &'a mut HashMap<String, HashMap<GlyphName, PathBuf>>,
     source: &designspace::Source,
-) -> Result<BTreeMap<String, PathBuf>, Error> {
+) -> Result<BTreeMap<GlyphName, PathBuf>, Error> {
     let layer_name = layer_dir(ufo_dir, layer_cache, source)?;
     let glyph_dir = ufo_dir.join(layer_name);
     if !glyph_dir.is_dir() {
@@ -101,23 +101,23 @@ fn glif_files<'a>(
 
     Ok(result
         .into_iter()
-        .map(|(glyph_name, path)| (glyph_name, glyph_dir.join(path)))
+        .map(|(glyph_name, path)| (glyph_name.into(), glyph_dir.join(path)))
         .collect())
 }
 
-fn layer_contents(ufo_dir: &Path) -> Result<HashMap<String, PathBuf>, Error> {
+fn layer_contents(ufo_dir: &Path) -> Result<HashMap<GlyphName, PathBuf>, Error> {
     let file = ufo_dir.join("layercontents.plist");
     if !file.is_file() {
         return Ok(HashMap::new());
     }
     let contents: Vec<(String, PathBuf)> =
         plist::from_file(&file).map_err(|e| Error::ParseError(file, e.to_string()))?;
-    Ok(contents.into_iter().collect())
+    Ok(contents.into_iter().map(|(k, v)| (k.into(), v)).collect())
 }
 
 pub(crate) fn layer_dir<'a>(
     ufo_dir: &Path,
-    layer_cache: &'a mut HashMap<String, HashMap<String, PathBuf>>,
+    layer_cache: &'a mut HashMap<String, HashMap<GlyphName, PathBuf>>,
     source: &designspace::Source,
 ) -> Result<&'a PathBuf, Error> {
     if !layer_cache.contains_key(&source.filename) {
@@ -127,12 +127,16 @@ pub(crate) fn layer_dir<'a>(
     let name_to_path = layer_cache.get_mut(&source.filename).unwrap();
 
     // No answer means dir is glyphs, which we'll stuff in under an empty string so the lifetime checks out
-    let default_name = String::new();
+    let glyph_name = source
+        .layer
+        .as_ref()
+        .map_or_else(GlyphName::empty, |l| l.into());
     if source.layer.is_none() {
-        name_to_path.insert(default_name.clone(), PathBuf::from("glyphs"));
+        name_to_path.insert(glyph_name.clone(), PathBuf::from("glyphs"));
     }
+
     name_to_path
-        .get(source.layer.as_ref().unwrap_or(&default_name))
+        .get(&glyph_name)
         .ok_or_else(|| Error::NoSuchLayer(source.filename.clone()))
 }
 
@@ -191,12 +195,12 @@ impl Source for DesignSpaceIrSource {
 
         // glif filenames are not reversible so we need to read contents.plist to figure out groups
         // See https://github.com/unified-font-object/ufo-spec/issues/164.
-        let mut glyphs: HashMap<String, StateSet> = HashMap::new();
+        let mut glyphs: HashMap<GlyphName, StateSet> = HashMap::new();
 
         // UFO filename => map of layer
         let mut layer_cache = HashMap::new();
         let mut glif_locations: HashMap<PathBuf, Vec<DesignLocation>> = HashMap::new();
-        let mut glyph_names = HashSet::new();
+        let mut glyph_names: HashSet<GlyphName> = HashSet::new();
 
         let Some((default_master_idx, default_master)) = default_master(&designspace) else {
             return Err(Error::NoDefaultMaster(self.designspace_file.clone()));
@@ -223,7 +227,7 @@ impl Source for DesignSpaceIrSource {
                     return Err(Error::FileExpected(glif_file));
                 }
                 if idx > 0 && !glyph_names.contains(&glyph_name) {
-                    warn!("The glyph name '{}' exists in {} but not in the default master and will be ignored", glyph_name, source.filename);
+                    warn!("The glyph name '{:?}' exists in {} but not in the default master and will be ignored", glyph_name, source.filename);
                     continue;
                 }
                 glyph_names.insert(glyph_name.clone());
@@ -296,7 +300,7 @@ impl Source for DesignSpaceIrSource {
 
     fn create_glyph_ir_work(
         &self,
-        glyph_names: &IndexSet<&str>,
+        glyph_names: &IndexSet<GlyphName>,
         input: &Input,
     ) -> Result<Vec<Box<IrWork>>, Error> {
         self.check_static_metadata(&input.static_metadata)?;
@@ -319,17 +323,16 @@ impl Source for DesignSpaceIrSource {
 impl DesignSpaceIrSource {
     fn create_work_for_one_glyph(
         &self,
-        glyph_name: &str,
+        glyph_name: &GlyphName,
         input: &Input,
     ) -> Result<GlyphIrWork, Error> {
         // A single glif could be used by many source blocks that use the same layer
         // *gasp*
         // So resolve each file to 1..N locations in designspace
 
-        let glyph_name = glyph_name.to_string();
         let stateset = input
             .glyphs
-            .get(&glyph_name)
+            .get(glyph_name)
             .ok_or_else(|| Error::NoStateForGlyph(glyph_name.clone()))?;
         let mut glif_files = HashMap::new();
         let cache = self.cache.as_ref().unwrap();
@@ -352,7 +355,7 @@ impl DesignSpaceIrSource {
 struct StaticMetadataWork {
     designspace_file: PathBuf,
     designspace: Arc<DesignSpaceDocument>,
-    glyph_names: Arc<HashSet<String>>,
+    glyph_names: Arc<HashSet<GlyphName>>,
 }
 
 struct FeatureWork {
@@ -397,33 +400,34 @@ fn load_lib_plist(ufo_dir: &Path) -> Result<plist::Dictionary, WorkError> {
 fn glyph_order(
     designspace: &DesignSpaceDocument,
     designspace_dir: &Path,
-    glyph_names: &HashSet<String>,
-) -> Result<IndexSet<String>, WorkError> {
+    glyph_names: &HashSet<GlyphName>,
+) -> Result<IndexSet<GlyphName>, WorkError> {
     // The UFO at the default master *may* elect to specify a glyph order
     // That glyph order *may* deign to overlap with the actual glyph set
     let mut glyph_order = IndexSet::new();
     if let Some((_, source)) = default_master(designspace) {
         let lib_plist = load_lib_plist(&designspace_dir.join(&source.filename))?;
         if let Some(plist::Value::Array(ufo_order)) = lib_plist.get("public.glyphOrder") {
-            let mut pending_add: HashSet<_> = glyph_names.iter().map(|s| s.as_str()).collect();
+            let mut pending_add: HashSet<_> = glyph_names.clone();
             // Add names from ufo glyph order union glyph_names in ufo glyph order
             ufo_order
                 .iter()
-                .filter_map(|v| v.as_string().map(|s| s.to_string()))
+                .filter_map(|v| v.as_string().map(|s| s.into()))
                 .filter(|name| glyph_names.contains(name))
                 .for_each(|name| {
-                    glyph_order.insert(name.to_string());
-                    pending_add.remove(name.as_str());
+                    glyph_order.insert(name.clone());
+                    pending_add.remove(&name);
                 });
             // Add anything leftover in sorted order
-            let mut pending_add: Vec<_> = pending_add.into_iter().map(|s| s.to_string()).collect();
+            let mut pending_add: Vec<_> = pending_add.into_iter().collect();
             pending_add.sort();
             glyph_order.extend(pending_add);
         }
     }
     if glyph_order.is_empty() {
-        if glyph_names.contains(".notdef") {
-            glyph_order.insert(".notdef".to_string());
+        let notdef = ".notdef".into();
+        if glyph_names.contains(&notdef) {
+            glyph_order.insert(notdef);
         }
         glyph_names
             .iter()
@@ -497,14 +501,14 @@ impl Work<Context, WorkError> for FeatureWork {
 }
 
 struct GlyphIrWork {
-    glyph_name: String,
+    glyph_name: GlyphName,
     glif_files: HashMap<PathBuf, Vec<DesignLocation>>,
 }
 
 impl Work<Context, WorkError> for GlyphIrWork {
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         trace!(
-            "Generate glyph IR for {} from {:#?}",
+            "Generate glyph IR for {:?} from {:#?}",
             self.glyph_name,
             self.glif_files
         );
@@ -521,9 +525,9 @@ impl Work<Context, WorkError> for GlyphIrWork {
             glif_files.insert(path, normalized_locations);
         }
 
-        let glyph_ir = to_ir_glyph(&self.glyph_name, &glif_files)
+        let glyph_ir = to_ir_glyph(self.glyph_name.clone(), &glif_files)
             .map_err(|e| WorkError::GlyphIrWorkError(self.glyph_name.clone(), e.to_string()))?;
-        context.set_glyph_ir(&self.glyph_name, glyph_ir);
+        context.set_glyph_ir(self.glyph_name.clone(), glyph_ir);
         Ok(())
     }
 }
@@ -535,6 +539,7 @@ mod tests {
         path::{Path, PathBuf},
     };
 
+    use fontdrasil::types::GlyphName;
     use fontir::{
         coords::{DesignCoord, DesignLocation},
         source::{Input, Source},
@@ -612,7 +617,9 @@ mod tests {
     pub fn create_work() {
         let (ir_source, input) = test_source();
 
-        let work = ir_source.create_work_for_one_glyph("bar", &input).unwrap();
+        let work = ir_source
+            .create_work_for_one_glyph(&"bar".into(), &input)
+            .unwrap();
 
         let mut expected_glif_files = HashMap::new();
         add_design_location(
@@ -640,7 +647,9 @@ mod tests {
     pub fn create_sparse_work() {
         let (ir_source, input) = test_source();
 
-        let work = ir_source.create_work_for_one_glyph("plus", &input).unwrap();
+        let work = ir_source
+            .create_work_for_one_glyph(&"plus".into(), &input)
+            .unwrap();
 
         // Note there is NOT a glyphs.{600} version of plus
         let mut expected_glif_files = HashMap::new();
@@ -663,7 +672,7 @@ mod tests {
     pub fn only_glyphs_present_in_default() {
         let (_, inputs) = test_source();
         // bonus_bar is not present in the default master; should discard
-        assert!(!inputs.glyphs.contains_key("bonus_bar"));
+        assert!(!inputs.glyphs.contains_key(&"bonus_bar".into()));
     }
 
     #[test]
@@ -685,17 +694,13 @@ mod tests {
         let go = glyph_order(
             &ds,
             &source.designspace_dir,
-            &HashSet::from([
-                "bar".to_string(),
-                "plus".to_string(),
-                "an-imaginary-one".to_string(),
-            ]),
+            &HashSet::from(["bar".into(), "plus".into(), "an-imaginary-one".into()]),
         )
         .unwrap();
         // lib.plist specifies plus, so plus goes first and then the rest in alphabetical order
-        let expected: IndexSet<String> = vec!["plus", "an-imaginary-one", "bar"]
+        let expected: IndexSet<GlyphName> = vec!["plus", "an-imaginary-one", "bar"]
             .iter()
-            .map(|s| s.to_string())
+            .map(|s| (*s).into())
             .collect();
         assert_eq!(expected, go);
     }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -143,7 +143,7 @@ pub(crate) fn layer_dir<'a>(
 impl DesignSpaceIrSource {
     fn load_designspace(&self) -> Result<DesignSpaceDocument, Error> {
         DesignSpaceDocument::load(&self.designspace_file)
-            .map_err(|e| Error::UnableToLoadSource(Box::from(e)))
+            .map_err(|e| Error::UnableToLoadSource(Box::new(e)))
     }
 
     // When things like upem may have changed forget incremental and rebuild the whole thing
@@ -281,7 +281,7 @@ impl Source for DesignSpaceIrSource {
         self.check_static_metadata(&input.static_metadata)?;
         let cache = self.cache.as_ref().unwrap();
 
-        Ok(Box::from(StaticMetadataWork {
+        Ok(Box::new(StaticMetadataWork {
             designspace_file: cache.designspace_file.clone(),
             designspace: cache.designspace.clone(),
             glyph_names: cache.glyph_names.clone(),
@@ -292,7 +292,7 @@ impl Source for DesignSpaceIrSource {
         self.check_static_metadata(&input.static_metadata)?;
         let cache = self.cache.as_ref().unwrap();
 
-        Ok(Box::from(FeatureWork {
+        Ok(Box::new(FeatureWork {
             designspace_file: cache.designspace_file.clone(),
             fea_files: cache.fea_files.clone(),
         }))
@@ -311,9 +311,7 @@ impl Source for DesignSpaceIrSource {
         let mut work: Vec<Box<IrWork>> = Vec::new();
 
         for glyph_name in glyph_names {
-            work.push(Box::from(
-                self.create_work_for_one_glyph(glyph_name, input)?,
-            ));
+            work.push(Box::new(self.create_work_for_one_glyph(glyph_name, input)?));
         }
 
         Ok(work)

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use fontdrasil::types::GlyphName;
 use fontir::{
     coords::{CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
     ir,
@@ -98,14 +99,11 @@ pub fn to_ir_axis(axis: &designspace::Axis) -> ir::Axis {
     }
 }
 
-pub fn to_ir_glyph<S>(
-    glyph_name: S,
+pub fn to_ir_glyph(
+    glyph_name: GlyphName,
     glif_files: &HashMap<&PathBuf, Vec<NormalizedLocation>>,
-) -> Result<ir::Glyph, Error>
-where
-    S: Into<String>,
-{
-    let mut glyph = ir::Glyph::new(glyph_name.into());
+) -> Result<ir::Glyph, Error> {
+    let mut glyph = ir::Glyph::new(glyph_name);
     for (glif_file, locations) in glif_files {
         let norad_glyph = norad::Glyph::load(glif_file).map_err(Error::GlifLoadError)?;
         for location in locations {


### PR DESCRIPTION
Replaces #87 which made fontc unsuitable for library use.

Fixes #86 