### PR TITLE
WIP: remove GlyphSerdeRepr

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -3,7 +3,7 @@
 use crate::{
     coords::{CoordConverter, NormalizedLocation, UserCoord},
     error::Error,
-    serde::{GlyphSerdeRepr, StaticMetadataSerdeRepr},
+    serde::StaticMetadataSerdeRepr,
 };
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
@@ -72,7 +72,6 @@ impl Features {
 /// many, presumed to vary continuously between positions and required
 /// to have variation compatible structure.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(from = "GlyphSerdeRepr", into = "GlyphSerdeRepr")]
 pub struct Glyph {
     pub name: String,
     pub sources: HashMap<NormalizedLocation, GlyphInstance>,
@@ -164,10 +163,9 @@ pub struct Affine2x3 {
 
 #[cfg(test)]
 mod tests {
-
     use crate::{
-        coords::{CoordConverter, UserCoord},
-        ir::Axis,
+        coords::{CoordConverter, NormalizedCoord, NormalizedLocation, UserCoord},
+        ir::{Axis, Glyph, GlyphInstance},
     };
 
     fn test_axis() -> Axis {
@@ -198,5 +196,26 @@ mod tests {
         let test_axis = test_axis();
         let bin = bincode::serialize(&test_axis).unwrap();
         assert_eq!(test_axis, bincode::deserialize(&bin).unwrap());
+    }
+
+    #[test]
+    fn glyph_yml() {
+        let mut glyph = Glyph::new(String::from("A"));
+
+        let loc1 = NormalizedLocation::on_axis("Weight", NormalizedCoord::new(0.0));
+        glyph
+            .try_add_source(&loc1, GlyphInstance::default())
+            .unwrap();
+
+        // // Uncomment lines below to see libyaml error disappear...
+        // let loc2 = NormalizedLocation::on_axis("Weight", NormalizedCoord::new(1.0));
+        // glyph.try_add_source(&loc2, GlyphInstance::default()).unwrap();
+
+        println!("{:#?}", glyph);
+
+        let yml = serde_yaml::to_string(&glyph).unwrap();
+        println!("{}", yml);
+
+        assert_eq!(yml, "TODO");
     }
 }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -4,8 +4,8 @@ use filetime::FileTime;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    coords::{CoordConverter, DesignCoord, NormalizedLocation, UserCoord},
-    ir::{Axis, Glyph, GlyphInstance, StaticMetadata},
+    coords::{CoordConverter, DesignCoord, UserCoord},
+    ir::{Axis, StaticMetadata},
     stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
 };
 
@@ -59,48 +59,6 @@ impl From<StaticMetadata> for StaticMetadataSerdeRepr {
         StaticMetadataSerdeRepr {
             axes: from.axes,
             glyph_order: from.glyph_order.into_iter().collect(),
-        }
-    }
-}
-
-// The HashMap<NormalizedLocation, GlyphInstance> seems to throw serde for a loop sometimes
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GlyphInstanceSerdeRepr {
-    location: NormalizedLocation,
-    instance: GlyphInstance,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GlyphSerdeRepr {
-    pub name: String,
-    pub instances: Vec<GlyphInstanceSerdeRepr>,
-}
-
-impl From<GlyphSerdeRepr> for Glyph {
-    fn from(from: GlyphSerdeRepr) -> Self {
-        Glyph {
-            name: from.name,
-            sources: from
-                .instances
-                .into_iter()
-                .map(|g| (g.location, g.instance))
-                .collect(),
-        }
-    }
-}
-
-impl From<Glyph> for GlyphSerdeRepr {
-    fn from(from: Glyph) -> Self {
-        GlyphSerdeRepr {
-            name: from.name,
-            instances: from
-                .sources
-                .into_iter()
-                .map(|(loc, inst)| GlyphInstanceSerdeRepr {
-                    location: loc,
-                    instance: inst,
-                })
-                .collect(),
         }
     }
 }


### PR DESCRIPTION
The test in `fontir::ir::tests::glyph_yml` reproduces the error (probably coming from underlying libyaml) found in https://github.com/googlefonts/fontmake-rs/pull/81/files#r1067967739:

`expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS`

Surprisingly, if the ir::Glyph contains more than one sources, then the error disappears... :/

Try uncommenting the lines that add the additional GlyphInstance to the Glyph::sources and see how serde_yaml completes without error. I have no idea what's going on.