### PR TITLE
Compile simple - no token expansion - fea for .glyphs

### DIFF
--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -28,7 +28,10 @@ parking_lot = "0.12.1"
 
 read-fonts = "0.0.5"
 write-fonts = "0.0.5"
-fea-rs = "0.1.0"
+# TODO: go back to released fea-rs once 
+#fea-rs = "0.1.0"
+fea-rs = { git = "https://github.com/rsheeter/fea-rs.git", branch = "mvp" }
+#fea-rs = { path= "../../fea-rs/fea-rs" }
 smol_str = "0.1.18"
 
 [dev-dependencies]

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -1,9 +1,14 @@
 //! Feature binary compilation.
 
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::Debug,
+    fs,
+    path::{Path, PathBuf},
+};
 
-use fea_rs::{Diagnostic, GlyphMap, GlyphName as FeaRsGlyphName};
-use log::{debug, trace, warn};
+use fea_rs::{Diagnostic, GlyphMap, GlyphName as FeaRsGlyphName, ParseContext};
+use fontir::ir::Features;
+use log::{debug, error, trace, warn};
 use write_fonts::FontBuilder;
 
 use fontdrasil::orchestration::Work;
@@ -25,7 +30,7 @@ impl FeatureWork {
 }
 
 fn check_diagnostics(
-    fea_file: &Path,
+    feature_source: impl Debug,
     op: &str,
     diagnostics: &Vec<Diagnostic>,
     formatter: impl Fn(&Diagnostic) -> String,
@@ -33,41 +38,51 @@ fn check_diagnostics(
     let mut err = false;
     for diagnostic in diagnostics {
         if diagnostic.is_error() {
-            warn!("{:?} {} error {}", fea_file, op, formatter(diagnostic));
+            warn!(
+                "{:?} {} error {}",
+                feature_source,
+                op,
+                formatter(diagnostic)
+            );
             err = true;
         } else {
-            debug!("{:?} {} {}", fea_file, op, formatter(diagnostic));
+            debug!("{:?} {} {}", feature_source, op, formatter(diagnostic));
         }
     }
     if err {
-        return Err(Error::FeaError(format!("{:?} {} failed", fea_file, op)));
+        return Err(Error::FeaError(format!(
+            "{:?} {} failed",
+            feature_source, op
+        )));
     }
     Ok(())
 }
 
 impl FeatureWork {
-    /// Inspired by (as in shameless copy of) how the fea-rs binary flows.
-    fn compile(&self, fea_file: &Path, glyph_order: GlyphMap) -> Result<FontBuilder, Error> {
-        // Will you not parse?!
-        let parse =
-            fea_rs::parse_root_file(fea_file, Some(&glyph_order), Some(self.build_dir.clone()))
-                .map_err(|e| Error::FeaError(format!("{:?} parsing {:?}", e, fea_file)))?;
+    fn compile_parse(
+        &self,
+        feature_source: &str,
+        parse: ParseContext,
+        glyph_order: GlyphMap,
+    ) -> Result<FontBuilder, Error> {
         let (tree, diagnostics) = parse.generate_parse_tree();
-        check_diagnostics(fea_file, "generate parse tree", &diagnostics, |d| {
+        check_diagnostics(feature_source, "generate parse tree", &diagnostics, |d| {
             format!("{:?}", d)
         })?;
 
         // Maybe even compile?
         let compilation = match fea_rs::compile::compile(&tree, &glyph_order) {
             Ok(compilation) => {
-                check_diagnostics(fea_file, "compile", &compilation.warnings, |d| {
+                check_diagnostics(feature_source, "compile", &compilation.warnings, |d| {
                     tree.format_diagnostic(d)
                 })?;
-                trace!("Compiled {:?} successfully", fea_file);
+                trace!("Compiled {} successfully", feature_source);
                 compilation
             }
             Err(errors) => {
-                check_diagnostics(fea_file, "compile", &errors, |d| tree.format_diagnostic(d))?;
+                check_diagnostics(feature_source, "compile", &errors, |d| {
+                    tree.format_diagnostic(d)
+                })?;
                 unreachable!("errors aren't ... errors?!");
             }
         };
@@ -78,26 +93,46 @@ impl FeatureWork {
             .build_raw(&glyph_order, Default::default())
             .map_err(|_| {
                 Error::FeaError(format!(
-                    "{:?} build_raw failed; no useful diagnostic available",
-                    fea_file
+                    "{} build_raw failed; no useful diagnostic available",
+                    feature_source
                 ))
             })?;
         Ok(font)
+    }
+
+    fn compile_memory(
+        &self,
+        fea_content: &String,
+        glyph_order: GlyphMap,
+    ) -> Result<FontBuilder, Error> {
+        // Will you not parse?!
+
+        // TODO write out the feature content on failure
+        let parse = fea_rs::parse_from_memory(fea_content, Some(&glyph_order))
+            .map_err(|e| Error::FeaError(format!("{:?} parsing in-memory feature content", e)))?;
+        self.compile_parse("Memory", parse, glyph_order)
+    }
+
+    /// Inspired by (as in shameless copy of) how the fea-rs binary flows.
+    fn compile_file(&self, fea_file: &Path, glyph_order: GlyphMap) -> Result<FontBuilder, Error> {
+        // Will you not parse?!
+        let parse =
+            fea_rs::parse_root_file(fea_file, Some(&glyph_order), Some(self.build_dir.clone()))
+                .map_err(|e| Error::FeaError(format!("{:?} parsing {:?}", e, fea_file)))?;
+
+        self.compile_parse(fea_file.to_str().unwrap_or_default(), parse, glyph_order)
     }
 }
 
 impl Work<Context, Error> for FeatureWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let features = context.ir.get_features();
-        let fea_file = match &features.fea_file {
-            Some(file) => file,
-            None => {
-                // set a default in place so subsequent compiles skip this step
-                trace!("No fea file, dull compile");
-                context.set_features(FontBuilder::default());
-                return Ok(());
-            }
-        };
+        if let Features::Empty = *features {
+            // set a default in place so subsequent compiles skip this step
+            trace!("No fea file, dull compile");
+            context.set_features(FontBuilder::default());
+            return Ok(());
+        }
         let glyph_order = &context.ir.get_static_metadata().glyph_order;
         if glyph_order.is_empty() {
             warn!("Glyph order is empty; feature compile improbable");
@@ -106,7 +141,32 @@ impl Work<Context, Error> for FeatureWork {
             .iter()
             .map(|n| Into::<FeaRsGlyphName>::into(n.as_str()))
             .collect();
-        let font = self.compile(fea_file, glyph_map)?;
+
+        let font = match &*features {
+            Features::File(fea_file) => self.compile_file(fea_file, glyph_map)?,
+            Features::Memory(fea_content) => {
+                let result = self.compile_memory(fea_content, glyph_map);
+                if result.is_err() || context.emit_ir {
+                    let debug_file = context.debug_dir().join("glyphs.fea");
+                    match fs::write(&debug_file, fea_content) {
+                        Ok(..) => {
+                            if result.is_err() {
+                                warn!("fea compile failed; fea written to {:?}", debug_file)
+                            } else {
+                                debug!("fea written to {:?}", debug_file);
+                            }
+                        }
+                        Err(e) => error!(
+                            "fea compile failed; failed to write fea to {:?}: {}",
+                            debug_file, e
+                        ),
+                    };
+                }
+                result?
+            }
+            Features::Empty => unreachable!("Empty exits early"),
+        };
+
         context.set_features(font);
         Ok(())
     }

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -165,7 +165,7 @@ impl Work<Context, Error> for FeatureWork {
             Features::File(fea_file) => self.compile_file(fea_file, glyph_map)?,
             Features::Memory(fea_content) => {
                 let result = self.compile_memory(context, fea_content, glyph_map);
-                if result.is_err() || context.emit_ir {
+                if result.is_err() || context.emit_debug {
                     write_debug_fea(context, result.is_err(), "fea compile failed", fea_content);
                 }
                 result?

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -71,6 +71,9 @@ pub struct Context {
     // If set artifacts prior to final binary will be emitted to disk when written into Context
     pub emit_ir: bool,
 
+    // If set additional debug files will be emitted to disk
+    pub emit_debug: bool,
+
     paths: Arc<Paths>,
 
     // The final, fully populated, read-only FE context
@@ -84,9 +87,15 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new_root(emit_ir: bool, paths: Paths, ir: &fontir::orchestration::Context) -> Context {
+    pub fn new_root(
+        emit_ir: bool,
+        emit_debug: bool,
+        paths: Paths,
+        ir: &fontir::orchestration::Context,
+    ) -> Context {
         Context {
             emit_ir,
+            emit_debug,
             paths: Arc::from(paths),
             ir: Arc::from(ir.read_only()),
             acl: AccessControlList::read_only(),
@@ -101,6 +110,7 @@ impl Context {
     ) -> Context {
         Context {
             emit_ir: self.emit_ir,
+            emit_debug: self.emit_debug,
             paths: self.paths.clone(),
             ir: self.ir.clone(),
             acl: AccessControlList::read_write(dependencies.unwrap_or_default(), work_id.into()),

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -69,7 +69,7 @@ pub type BeWork = dyn Work<Context, Error> + Send;
 /// execution order / mistakes, not to block actual bad actors.
 pub struct Context {
     // If set artifacts prior to final binary will be emitted to disk when written into Context
-    emit_ir: bool,
+    pub emit_ir: bool,
 
     paths: Arc<Paths>,
 
@@ -110,6 +110,11 @@ impl Context {
 }
 
 impl Context {
+    /// A reasonable place to write extra files to help someone debugging
+    pub fn debug_dir(&self) -> &Path {
+        self.paths.debug_dir()
+    }
+
     fn maybe_persist(&self, file: &Path, content: &[u8]) {
         if !self.emit_ir {
             return;

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -16,7 +16,7 @@ pub struct Paths {
 impl Paths {
     pub fn new(build_dir: &Path) -> Paths {
         let glyph_dir = build_dir.join("glyphs");
-        let debug_dir = build_dir.join("_debug");
+        let debug_dir = build_dir.join("debug");
         let build_dir = build_dir.to_path_buf();
         Paths {
             build_dir,

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -10,20 +10,27 @@ use crate::orchestration::WorkId;
 pub struct Paths {
     build_dir: PathBuf,
     glyph_dir: PathBuf,
+    debug_dir: PathBuf,
 }
 
 impl Paths {
     pub fn new(build_dir: &Path) -> Paths {
         let glyph_dir = build_dir.join("glyphs");
+        let debug_dir = build_dir.join("_debug");
         let build_dir = build_dir.to_path_buf();
         Paths {
             build_dir,
             glyph_dir,
+            debug_dir,
         }
     }
 
     pub fn build_dir(&self) -> &Path {
         &self.build_dir
+    }
+
+    pub fn debug_dir(&self) -> &Path {
+        &self.debug_dir
     }
 
     fn glyph_file(&self, name: &str) -> PathBuf {

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -52,18 +52,21 @@ pub struct Axis {
 /// In time will split gpos/gsub, have different features for different
 /// locations, etc.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-pub struct Features {
-    pub fea_file: Option<PathBuf>,
+pub enum Features {
+    Empty,
+    File(PathBuf),
+    Memory(String),
 }
 
 impl Features {
     pub fn empty() -> Features {
-        Features { fea_file: None }
+        Features::Empty
     }
     pub fn from_file(file: &Path) -> Features {
-        Features {
-            fea_file: Some(file.to_path_buf()),
-        }
+        Features::File(file.to_path_buf())
+    }
+    pub fn from_string(fea_content: String) -> Features {
+        Features::Memory(fea_content)
     }
 }
 

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -39,6 +39,9 @@ pub struct Context {
     // If set IR will be emitted to disk when written into Context
     emit_ir: bool,
 
+    // If set additional debug files will be emitted to disk
+    emit_debug: bool,
+
     paths: Arc<Paths>,
 
     // The input we're working on. Note that change detection may mean we only process
@@ -58,6 +61,7 @@ impl Context {
     fn copy(&self, acl: AccessControlList<WorkId>) -> Context {
         Context {
             emit_ir: self.emit_ir,
+            emit_debug: self.emit_debug,
             paths: self.paths.clone(),
             input: self.input.clone(),
             acl,
@@ -67,9 +71,10 @@ impl Context {
         }
     }
 
-    pub fn new_root(emit_ir: bool, paths: Paths, input: Input) -> Context {
+    pub fn new_root(emit_ir: bool, emit_debug: bool, paths: Paths, input: Input) -> Context {
         Context {
             emit_ir,
+            emit_debug,
             paths: Arc::from(paths),
             input: Arc::from(input),
             acl: AccessControlList::read_only(),

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -5,6 +5,7 @@
 //! where it gets serialized to more Rust-native structures, proc macros, etc.
 
 use std::collections::{BTreeMap, HashSet};
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::{fs, path};
 
@@ -41,6 +42,16 @@ pub struct Font {
     pub codepoints: BTreeMap<Vec<u32>, String>,
     // tag => (user:design) tuples
     pub axis_mappings: BTreeMap<String, RawUserToDesignMapping>,
+    pub features: Vec<FeatureSnippet>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct FeatureSnippet(String);
+
+impl FeatureSnippet {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -70,6 +81,20 @@ struct RawFont {
     pub axes: Option<Vec<Axis>>,
     pub glyphs: Vec<RawGlyph>,
     pub font_master: Vec<FontMaster>,
+    pub feature_prefixes: Option<Vec<RawFeature>>,
+    pub features: Option<Vec<RawFeature>>,
+    pub classes: Option<Vec<RawFeature>>,
+
+    #[rest]
+    pub other_stuff: BTreeMap<String, Plist>,
+}
+
+#[derive(Clone, Debug, FromPlist, PartialEq, Eq, Hash)]
+pub struct RawFeature {
+    pub automatic: Option<i64>,
+    pub name: Option<String>,
+    pub code: String,
+
     #[rest]
     pub other_stuff: BTreeMap<String, Plist>,
 }
@@ -953,6 +978,59 @@ impl TryFrom<RawGlyph> for Glyph {
     }
 }
 
+// https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/features.py#L43
+fn autostr(feature: &RawFeature) -> String {
+    match feature.automatic {
+        Some(1) => "# automatic\n".to_string(),
+        _ => "".to_string(),
+    }
+}
+
+fn name(feature: &RawFeature) -> Result<String, Error> {
+    match &feature.name {
+        Some(name) => Ok(name.clone()),
+        None => Err(Error::StructuralError(format!(
+            "{:?} missing name",
+            feature
+        ))),
+    }
+}
+
+// https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/features.py#L90
+fn prefix_to_feature(prefix: RawFeature) -> Result<FeatureSnippet, Error> {
+    let name = match &prefix.name {
+        Some(name) => name.as_str(),
+        None => "",
+    };
+    let code = format!("# Prefix: {}\n{}{}", name, autostr(&prefix), prefix.code);
+    Ok(FeatureSnippet(code))
+}
+
+// https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/features.py#L101
+fn class_to_feature(feature: RawFeature) -> Result<FeatureSnippet, Error> {
+    let name = name(&feature)?;
+    let code = format!(
+        "{}{}{} = [ {}\n];",
+        autostr(&feature),
+        if name.starts_with('@') { "" } else { "@" },
+        name,
+        feature.code
+    );
+    Ok(FeatureSnippet(code))
+}
+
+// https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/features.py#L113
+fn raw_feature_to_feature(feature: RawFeature) -> Result<FeatureSnippet, Error> {
+    let name = name(&feature)?;
+    let code = format!(
+        "feature {0} {{\n{1}{2}\n}} {0};",
+        name,
+        autostr(&feature),
+        feature.code
+    );
+    Ok(FeatureSnippet(code))
+}
+
 impl TryFrom<RawFont> for Font {
     type Error = Error;
 
@@ -976,6 +1054,17 @@ impl TryFrom<RawFont> for Font {
             glyphs.insert(raw_glyph.glyphname.clone(), raw_glyph.try_into()?);
         }
 
+        let mut features = Vec::new();
+        for class in from.classes.unwrap_or_default().into_iter() {
+            features.push(class_to_feature(class)?);
+        }
+        for prefix in from.feature_prefixes.unwrap_or_default().into_iter() {
+            features.push(prefix_to_feature(prefix)?);
+        }
+        for feature in from.features.unwrap_or_default().into_iter() {
+            features.push(raw_feature_to_feature(feature)?);
+        }
+
         Ok(Font {
             family_name: from.family_name,
             axes: from.axes.unwrap_or_default(),
@@ -985,6 +1074,7 @@ impl TryFrom<RawFont> for Font {
             glyph_order,
             codepoints,
             axis_mappings,
+            features,
         })
     }
 }
@@ -1237,5 +1327,74 @@ mod tests {
             ),]),
             font.axis_mappings
         );
+    }
+
+    #[test]
+    fn fea_for_class() {
+        let font = Font::load(&glyphs2_dir().join("Fea_Class.glyphs")).unwrap();
+        assert_eq!(
+            vec![
+                concat!("# automatic\n", "@Uppercase = [ A B C\n", "];",),
+                concat!("@Lowercase = [ a b c\n", "];",),
+            ],
+            font.features.iter().map(|f| f.as_str()).collect::<Vec<_>>()
+        )
+    }
+
+    #[test]
+    fn fea_for_prefix() {
+        let font = Font::load(&glyphs2_dir().join("Fea_Prefix.glyphs")).unwrap();
+        assert_eq!(
+            vec![
+                concat!(
+                    "# Prefix: Languagesystems\n",
+                    "# automatic\n",
+                    "languagesystem DFLT dflt;\n\n",
+                    "languagesystem latn dflt;\n",
+                    "and more;\n",
+                ),
+                concat!("# Prefix: \n# automatic\nthanks for all the fish;",),
+            ],
+            font.features.iter().map(|f| f.as_str()).collect::<Vec<_>>()
+        )
+    }
+
+    #[test]
+    fn fea_for_feature() {
+        let font = Font::load(&glyphs2_dir().join("Fea_Feature.glyphs")).unwrap();
+        assert_eq!(
+            vec![
+                concat!(
+                    "feature aalt {\n",
+                    "feature locl;\n",
+                    "feature tnum;\n",
+                    "} aalt;",
+                ),
+                concat!(
+                    "feature ccmp {\n",
+                    "# automatic\n",
+                    "lookup ccmp_Other_2 {\n",
+                    "  sub @Markscomb' @MarkscombCase by @MarkscombCase;\n",
+                    "  sub @MarkscombCase @Markscomb' by @MarkscombCase;\n",
+                    "} ccmp_Other_2;\n\n",
+                    "etc;\n",
+                    "} ccmp;",
+                ),
+            ],
+            font.features.iter().map(|f| f.as_str()).collect::<Vec<_>>()
+        )
+    }
+
+    #[test]
+    fn fea_order() {
+        let font = Font::load(&glyphs2_dir().join("Fea_Order.glyphs")).unwrap();
+        assert_eq!(
+            vec![
+                "@class_first = [ meh\n];",
+                "# Prefix: second\nmeh",
+                "feature third {\nmeh\n} third;",
+            ],
+            font.features.iter().map(|f| f.as_str()).collect::<Vec<_>>()
+        )
     }
 }

--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -6,7 +6,9 @@ mod from_plist;
 mod plist;
 mod to_plist;
 
-pub use font::{Axis, Component, Font, FontMaster, Glyph, Layer, Node, NodeType, Path};
+pub use font::{
+    Axis, Component, FeatureSnippet, Font, FontMaster, Glyph, Layer, Node, NodeType, Path,
+};
 pub use from_plist::FromPlist;
 pub use plist::Plist;
 pub use to_plist::ToPlist;

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -382,6 +382,7 @@ mod tests {
             source,
             Context::new_root(
                 false,
+                false,
                 Paths::new(Path::new("/nothing/should/write/here")),
                 input,
             ),

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -2,11 +2,19 @@ use std::collections::HashMap;
 
 use fontir::{
     coords::{CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
-    error::Error,
+    error::{Error, WorkError},
     ir,
 };
-use glyphs_reader::{Font, FontMaster};
+use glyphs_reader::{FeatureSnippet, Font, FontMaster};
 use ordered_float::OrderedFloat;
+
+pub(crate) fn to_ir_features(features: &[FeatureSnippet]) -> Result<ir::Features, WorkError> {
+    // Based on https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/features.py#L74
+    // TODO: token expansion
+    // TODO: implement notes and labels
+    let fea_snippets: Vec<String> = features.iter().map(|f| f.as_str().to_string()).collect();
+    Ok(ir::Features::Memory(fea_snippets.join("\n\n")))
+}
 
 fn design_location(axes: &[ir::Axis], master: &FontMaster) -> DesignLocation {
     axes.iter()

--- a/resources/testdata/glyphs2/Fea_Class.glyphs
+++ b/resources/testdata/glyphs2/Fea_Class.glyphs
@@ -1,0 +1,51 @@
+{
+.appVersion = "3148";
+classes = (
+{
+automatic = 1;
+code = "A B C";
+name = Uppercase;
+},
+{
+code = "a b c";
+name = Lowercase;
+}
+);
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+},
+{
+name = "Variable Font Origin";
+value = "regular";
+}
+);
+familyName = Fea;
+fontMaster = (
+{
+id = thin;
+weightValue = 200;
+},
+{
+id = "regular";
+weightValue = 400;
+}
+);
+glyphs = (
+{
+glyphname = "g";
+layers = (
+  { layerId = thin; paths = (); width = 400; },
+  { layerId = "regular"; paths = (); width = 600; }
+);
+unicode = 0021;
+}
+);
+unitsPerEm = 1000;
+}

--- a/resources/testdata/glyphs2/Fea_Feature.glyphs
+++ b/resources/testdata/glyphs2/Fea_Feature.glyphs
@@ -1,0 +1,57 @@
+{
+.appVersion = "3148";
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+},
+{
+name = "Variable Font Origin";
+value = "regular";
+}
+);
+features = (
+{
+code = "feature locl;
+feature tnum;";
+name = aalt;
+},
+{
+automatic = 1;
+code = "lookup ccmp_Other_2 {
+  sub @Markscomb' @MarkscombCase by @MarkscombCase;
+  sub @MarkscombCase @Markscomb' by @MarkscombCase;
+} ccmp_Other_2;
+
+etc;";
+name = ccmp;
+}
+);
+familyName = Fea;
+fontMaster = (
+{
+id = thin;
+weightValue = 200;
+},
+{
+id = "regular";
+weightValue = 400;
+}
+);
+glyphs = (
+{
+glyphname = "g";
+layers = (
+  { layerId = thin; paths = (); width = 400; },
+  { layerId = "regular"; paths = (); width = 600; }
+);
+unicode = 0021;
+}
+);
+unitsPerEm = 1000;
+}

--- a/resources/testdata/glyphs2/Fea_Order.glyphs
+++ b/resources/testdata/glyphs2/Fea_Order.glyphs
@@ -1,0 +1,69 @@
+{
+.appVersion = "3148";
+classes = (
+{
+automatic = 1;
+code = "A B C";
+name = Uppercase;
+},
+{
+code = "a b c";
+name = Lowercase;
+}
+);
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+},
+{
+name = "Variable Font Origin";
+value = "regular";
+}
+);
+featurePrefixes = (
+{
+code = "meh";
+name = "second";
+}
+);
+features = (
+{
+code = "meh";
+name = "third";
+}
+);
+classes = (
+{
+code = "meh";
+name = "class_first";
+}
+);
+familyName = Fea;
+fontMaster = (
+{
+id = thin;
+weightValue = 200;
+},
+{
+id = "regular";
+weightValue = 400;
+}
+);
+glyphs = (
+{
+glyphname = "g";
+layers = (
+  { layerId = thin; paths = (); width = 400; },
+  { layerId = "regular"; paths = (); width = 600; }
+);
+unicode = 0021;
+}
+);
+unitsPerEm = 1000;
+}

--- a/resources/testdata/glyphs2/Fea_Order.glyphs
+++ b/resources/testdata/glyphs2/Fea_Order.glyphs
@@ -1,16 +1,5 @@
 {
 .appVersion = "3148";
-classes = (
-{
-automatic = 1;
-code = "A B C";
-name = Uppercase;
-},
-{
-code = "a b c";
-name = Lowercase;
-}
-);
 customParameters = (
 {
 name = Axes;

--- a/resources/testdata/glyphs2/Fea_Prefix.glyphs
+++ b/resources/testdata/glyphs2/Fea_Prefix.glyphs
@@ -1,0 +1,55 @@
+{
+.appVersion = "3148";
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+},
+{
+name = "Variable Font Origin";
+value = "regular";
+}
+);
+featurePrefixes = (
+{
+automatic = 1;
+code = "languagesystem DFLT dflt;
+
+languagesystem latn dflt;
+and more;
+";
+name = Languagesystems;
+},
+{
+automatic = 1;
+code = "thanks for all the fish;";
+}
+);
+familyName = Fea;
+fontMaster = (
+{
+id = thin;
+weightValue = 200;
+},
+{
+id = "regular";
+weightValue = 400;
+}
+);
+glyphs = (
+{
+glyphname = "g";
+layers = (
+  { layerId = thin; paths = (); width = 400; },
+  { layerId = "regular"; paths = (); width = 600; }
+);
+unicode = 0021;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
Using a workaround for https://github.com/cmyr/fea-rs/issues/115. Will need changes when an official way to compile from memory arrives.

Does not implement the only interesting part of feature compilation: [TokenExpander](https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/tokens.py#L12). Tracking token expansion in #92.

Confirmed generated file for Texturina was identical to what I got from Python and used Texturina to build the tests.