### PR TITLE
Use upcoming compile api for fea-rs

### DIFF
--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -28,9 +28,9 @@ parking_lot = "0.12.1"
 
 read-fonts = "0.0.5"
 write-fonts = "0.0.5"
-# TODO: go back to released fea-rs once 
+# TODO: go back to released fea-rs once api released
 #fea-rs = "0.1.0"
-fea-rs = { git = "https://github.com/rsheeter/fea-rs.git", branch = "mvp" }
+fea-rs = { git = "https://github.com/cmyr/fea-rs.git", branch = "compile-api" }
 #fea-rs = { path= "../../fea-rs/fea-rs" }
 smol_str = "0.1.18"
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -28,10 +28,7 @@ parking_lot = "0.12.1"
 
 read-fonts = "0.0.5"
 write-fonts = "0.0.5"
-# TODO: go back to released fea-rs once api released
-#fea-rs = "0.1.0"
-fea-rs = { git = "https://github.com/cmyr/fea-rs.git", branch = "compile-api" }
-#fea-rs = { path= "../../fea-rs/fea-rs" }
+fea-rs = "0.2.0"
 smol_str = "0.1.18"
 
 [dev-dependencies]

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -1,11 +1,15 @@
 use std::io;
 
+use fea_rs::compile::error::BinaryCompilationError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("IO failure")]
     IoError(#[from] io::Error),
-    #[error("Bad fea: {0}")]
-    FeaError(String),
+    #[error("Fea binary assembly failure")]
+    FeaAssembleError(#[from] BinaryCompilationError),
+    // String because https://github.com/cmyr/fea-rs/pull/119/files#r1084797298
+    #[error("Fea compilation failure {0}")]
+    FeaCompileError(String),
 }

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use fea_rs::compile::error::BinaryCompilationError;
+use fea_rs::compile::error::{BinaryCompilationError, CompilerError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -9,7 +9,6 @@ pub enum Error {
     IoError(#[from] io::Error),
     #[error("Fea binary assembly failure")]
     FeaAssembleError(#[from] BinaryCompilationError),
-    // String because https://github.com/cmyr/fea-rs/pull/119/files#r1084797298
-    #[error("Fea compilation failure {0}")]
-    FeaCompileError(String),
+    #[error("Fea compilation failure")]
+    FeaCompileError(#[from] CompilerError),
 }

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -34,12 +34,12 @@ impl FeatureWork {
 // I did not want to clone the content
 // I do not like this construct
 // I do find the need to lament
-struct CursedClosures {
+struct InMemoryResolver {
     content_path: OsString,
     content: Rc<str>,
 }
 
-impl SourceResolver for CursedClosures {
+impl SourceResolver for InMemoryResolver {
     fn get_contents(&self, path: &OsStr) -> Result<Rc<str>, SourceLoadError> {
         if path == &*self.content_path {
             return Ok(self.content.clone());
@@ -76,15 +76,13 @@ impl Display for NotSupportedError {
 impl FeatureWork {
     fn compile(&self, features: &Features, glyph_order: GlyphMap) -> Result<FontBuilder, Error> {
         let root_path = if let Features::File(file) = features {
-            eprintln!("ROOT: {:?}", file);
             OsString::from(file)
         } else {
             OsString::new()
         };
-        eprintln!("ROOT: {:?}", root_path);
         let mut compiler = Compiler::new(root_path.clone(), &glyph_order);
         if let Features::Memory(fea_content) = features {
-            let resolver = CursedClosures {
+            let resolver = InMemoryResolver {
                 content_path: root_path.clone(),
                 content: Rc::from(fea_content.as_str()),
             };

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -83,20 +83,16 @@ impl FeatureWork {
         let mut compiler = Compiler::new(root_path.clone(), &glyph_order);
         if let Features::Memory(fea_content) = features {
             let resolver = InMemoryResolver {
-                content_path: root_path.clone(),
+                content_path: root_path,
                 content: Rc::from(fea_content.as_str()),
             };
             compiler = compiler.with_resolver(resolver);
         }
-        match compiler.compile() {
-            Ok(compilation) => compilation
-                .assemble(&glyph_order, Default::default())
-                .map_err(|e| Error::FeaError(format!("{:?} assembling {:?}", e, root_path))),
-            Err(e) => Err(Error::FeaError(format!(
-                "{:?} compiling {:?}",
-                e, root_path
-            ))),
-        }
+        compiler
+            .compile()
+            .map_err(|e| Error::FeaCompileError(format!("{}", e)))?
+            .assemble(&glyph_order, Default::default())
+            .map_err(Error::FeaAssembleError)
     }
 }
 

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -1,12 +1,14 @@
 //! Feature binary compilation.
 
 use std::{
-    fmt::Debug,
+    ffi::{OsStr, OsString},
     fs,
-    path::{Path, PathBuf},
 };
 
-use fea_rs::{Diagnostic, GlyphMap, GlyphName as FeaRsGlyphName, ParseContext};
+use fea_rs::{
+    parse::{SourceLoadError, SourceResolver},
+    Compiler, GlyphMap, GlyphName as FeaRsGlyphName,
+};
 use fontir::ir::Features;
 use log::{debug, error, trace, warn};
 use write_fonts::FontBuilder;
@@ -18,114 +20,59 @@ use crate::{
     orchestration::{BeWork, Context},
 };
 
-pub struct FeatureWork {
-    build_dir: PathBuf,
-}
+pub struct FeatureWork {}
 
 impl FeatureWork {
-    pub fn create(build_dir: &Path) -> Box<BeWork> {
-        let build_dir = build_dir.to_path_buf();
-        Box::new(FeatureWork { build_dir })
+    pub fn create() -> Box<BeWork> {
+        Box::new(FeatureWork {})
     }
 }
 
-fn check_diagnostics(
-    feature_source: impl Debug,
-    op: &str,
-    diagnostics: &Vec<Diagnostic>,
-    formatter: impl Fn(&Diagnostic) -> String,
-) -> Result<(), Error> {
-    let mut err = false;
-    for diagnostic in diagnostics {
-        if diagnostic.is_error() {
-            warn!(
-                "{:?} {} error {}",
-                feature_source,
-                op,
-                formatter(diagnostic)
-            );
-            err = true;
+// I did not want to make a struct
+// I did not want to clone the content
+// I do not like this construct
+// I do find the need to lament
+struct CursedClosures {
+    content_path: OsString,
+    content: String,
+}
+
+impl SourceResolver for CursedClosures {
+    fn get_contents(&self, path: &OsStr) -> Result<String, SourceLoadError> {
+        if path == &*self.content_path {
+            return Ok(self.content.clone());
+        }
+        // I don't think I can actually construct this given private fields and pub(crate) new
+        todo!("Construct a SourceLoadError")
+    }
+}
+
+impl FeatureWork {
+    fn compile(&self, features: &Features, glyph_order: GlyphMap) -> Result<FontBuilder, Error> {
+        let root_path = if let Features::File(file) = features {
+            eprintln!("ROOT: {:?}", file);
+            OsString::from(file)
         } else {
-            debug!("{:?} {} {}", feature_source, op, formatter(diagnostic));
-        }
-    }
-    if err {
-        return Err(Error::FeaError(format!(
-            "{:?} {} failed",
-            feature_source, op
-        )));
-    }
-    Ok(())
-}
-
-impl FeatureWork {
-    fn compile_parse(
-        &self,
-        feature_source: &str,
-        parse: ParseContext,
-        glyph_order: GlyphMap,
-    ) -> Result<FontBuilder, Error> {
-        let (tree, diagnostics) = parse.generate_parse_tree();
-        check_diagnostics(feature_source, "generate parse tree", &diagnostics, |d| {
-            format!("{:?}", d)
-        })?;
-
-        // Maybe even compile?
-        let compilation = match fea_rs::compile::compile(&tree, &glyph_order) {
-            Ok(compilation) => {
-                check_diagnostics(feature_source, "compile", &compilation.warnings, |d| {
-                    tree.format_diagnostic(d)
-                })?;
-                trace!("Compiled {} successfully", feature_source);
-                compilation
-            }
-            Err(errors) => {
-                check_diagnostics(feature_source, "compile", &errors, |d| {
-                    tree.format_diagnostic(d)
-                })?;
-                unreachable!("errors aren't ... errors?!");
-            }
+            OsString::new()
         };
-
-        // Capture the binary tables we got from the features for future merge into final font
-        // TODO do we want to do the whole blob or to emit table-by-table?
-        let font = compilation
-            .build_raw(&glyph_order, Default::default())
-            .map_err(|_| {
-                Error::FeaError(format!(
-                    "{} build_raw failed; no useful diagnostic available",
-                    feature_source
-                ))
-            })?;
-        Ok(font)
-    }
-
-    fn compile_memory(
-        &self,
-        context: &Context,
-        fea_content: &String,
-        glyph_order: GlyphMap,
-    ) -> Result<FontBuilder, Error> {
-        // Will you not parse?!
-
-        // TODO write out the feature content on failure
-        let parse = fea_rs::parse_from_memory(fea_content, Some(&glyph_order))
-            .map_err(|e| Error::FeaError(format!("{:?} parsing in-memory feature content", e)));
-        if parse.is_err() {
-            write_debug_fea(context, parse.is_err(), "fea parse failed", fea_content);
+        eprintln!("ROOT: {:?}", root_path);
+        let mut compiler = Compiler::new(root_path.clone(), &glyph_order);
+        if let Features::Memory(fea_content) = features {
+            let resolver = CursedClosures {
+                content_path: root_path.clone(),
+                content: fea_content.clone(),
+            };
+            compiler = compiler.with_resolver(resolver);
         }
-        let parse = parse?;
-        self.compile_parse("Memory", parse, glyph_order)
-    }
-
-    /// Inspired by (as in shameless copy of) how the fea-rs binary flows.
-    fn compile_file(&self, fea_file: &Path, glyph_order: GlyphMap) -> Result<FontBuilder, Error> {
-        // Will you not parse?!
-        let parse =
-            fea_rs::parse_root_file(fea_file, Some(&glyph_order), Some(self.build_dir.clone()))
-                .map_err(|e| Error::FeaError(format!("{:?} parsing {:?}", e, fea_file)))?;
-
-        self.compile_parse(fea_file.to_str().unwrap_or_default(), parse, glyph_order)
+        match compiler.compile() {
+            Ok(compilation) => compilation
+                .assemble(&glyph_order, Default::default())
+                .map_err(|e| Error::FeaError(format!("{:?} assembling {:?}", e, root_path))),
+            Err(e) => Err(Error::FeaError(format!(
+                "{:?} compiling {:?}",
+                e, root_path
+            ))),
+        }
     }
 }
 
@@ -161,18 +108,13 @@ impl Work<Context, Error> for FeatureWork {
             .map(|n| Into::<FeaRsGlyphName>::into(n.as_str()))
             .collect();
 
-        let font = match &*features {
-            Features::File(fea_file) => self.compile_file(fea_file, glyph_map)?,
-            Features::Memory(fea_content) => {
-                let result = self.compile_memory(context, fea_content, glyph_map);
-                if result.is_err() || context.emit_debug {
-                    write_debug_fea(context, result.is_err(), "fea compile failed", fea_content);
-                }
-                result?
+        let result = self.compile(&*features, glyph_map);
+        if result.is_err() || context.emit_debug {
+            if let Features::Memory(fea_content) = &*features {
+                write_debug_fea(context, result.is_err(), "compile failed", fea_content);
             }
-            Features::Empty => unreachable!("Empty exits early"),
-        };
-
+        }
+        let font = result?;
         context.set_features(font);
         Ok(())
     }

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -4,7 +4,7 @@ use std::{
     ffi::{OsStr, OsString},
     fmt::Display,
     fs,
-    rc::Rc,
+    sync::Arc,
 };
 
 use fea_rs::{
@@ -36,11 +36,11 @@ impl FeatureWork {
 // I do find the need to lament
 struct InMemoryResolver {
     content_path: OsString,
-    content: Rc<str>,
+    content: Arc<str>,
 }
 
 impl SourceResolver for InMemoryResolver {
-    fn get_contents(&self, path: &OsStr) -> Result<Rc<str>, SourceLoadError> {
+    fn get_contents(&self, path: &OsStr) -> Result<Arc<str>, SourceLoadError> {
         if path == &*self.content_path {
             return Ok(self.content.clone());
         }
@@ -84,13 +84,13 @@ impl FeatureWork {
         if let Features::Memory(fea_content) = features {
             let resolver = InMemoryResolver {
                 content_path: root_path,
-                content: Rc::from(fea_content.as_str()),
+                content: Arc::from(fea_content.as_str()),
             };
             compiler = compiler.with_resolver(resolver);
         }
         compiler
             .compile()
-            .map_err(|e| Error::FeaCompileError(format!("{}", e)))?
+            .map_err(Error::FeaCompileError)?
             .assemble(&glyph_order, Default::default())
             .map_err(Error::FeaAssembleError)
     }

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -259,7 +259,7 @@ fn add_feature_be_job(
         workload.insert(
             BeWorkIdentifier::Features.into(),
             Job {
-                work: FeatureWork::create(change_detector.ir_paths.build_dir()).into(),
+                work: FeatureWork::create().into(),
                 dependencies: HashSet::from([
                     FeWorkIdentifier::StaticMetadata.into(),
                     FeWorkIdentifier::Features.into(),


### PR DESCRIPTION
Build against https://github.com/cmyr/fea-rs/pull/119.

Ran into some issues:

1. Had to copy the feature content for in memory use
1. Using a closure for the resolve sounded lovely until I tried to actually do it, then I angered the compiler and ultimately made a struct
1. `cargo test -p fontc fea` now fails, apparently absolute paths aren't welcome?
   * `/blah-blah-blah/fontmake-rs/resources/testdata/Static-Regular.ufo/features.fea` triggers `thread 'tests::compile_fea' panicked at 'assertion failed: path.is_relative()', ...blah blah.../fea-rs/src/util/paths.rs:15:9

Update: ^ fixed by latest updates to the fea-rs branch.