### PR TITLE
glyphs contour and component conversion

### DIFF
--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -19,7 +19,10 @@ serde_yaml = "0.9.14"
 bincode = "1.3.3"
 filetime = "0.2.18"
 thiserror = "1.0.37"
+
+kurbo = { version = "0.9.0", features = ["serde"] }
 ordered-float = { version = "3.4.0", features = ["serde"] }
+
 indexmap = "1.9.2"
 
 blake3 = "1.3.3"

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -91,4 +91,9 @@ pub enum WorkError {
         axis: String,
         pos: NormalizedCoord,
     },
+    #[error("{glyph_name} invalid {message}")]
+    InvalidSourceGlyph {
+        glyph_name: GlyphName,
+        message: String,
+    },
 }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use fontdrasil::types::GlyphName;
 use indexmap::IndexSet;
+use kurbo::Affine;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -146,24 +147,7 @@ pub struct Component {
     /// The name of the referenced glyph.
     pub base: String,
     /// Affine transformation to apply to the referenced glyph.
-    pub transform: Affine2x3,
-}
-
-/// A 2×3 affine transformation matrix.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct Affine2x3 {
-    /// x-component of transformed x-basis vector.
-    pub xx: f64,
-    /// y-component of transformed x-basis vector.
-    pub yx: f64,
-    /// x-component of transformed y-basis vector.
-    pub xy: f64,
-    /// y-component of transformed y-basis vector.
-    pub yy: f64,
-    /// x-component of translation vector.
-    pub dx: f64,
-    /// y-component of translation vector.
-    pub dy: f64,
+    pub transform: Affine,
 }
 
 #[cfg(test)]

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kurbo = "0.5.1"
 plist_derive = { path = "plist_derive" }
 ordered-float = "3.4.0"
+kurbo = { version="0.9.0", features=["serde"] }
 
 thiserror = "1.0.37"
 

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -5,10 +5,10 @@
 //! where it gets serialized to more Rust-native structures, proc macros, etc.
 
 use std::collections::{BTreeMap, HashSet};
-use std::fmt::{Display, Write};
 use std::hash::Hash;
 use std::{fs, path};
 
+use kurbo::{Affine, Point};
 use log::warn;
 use ordered_float::OrderedFloat;
 use regex::Regex;
@@ -31,7 +31,7 @@ type RawUserToDesignMapping = Vec<(OrderedFloat<f32>, OrderedFloat<f32>)>;
 /// A tidied up font from a plist.
 ///
 /// Normalized representation of Glyphs 2/3 content
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Hash)]
 pub struct Font {
     pub family_name: String,
     pub axes: Vec<Axis>,
@@ -54,20 +54,20 @@ impl FeatureSnippet {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Hash)]
 pub struct Glyph {
     pub glyphname: String,
     pub layers: Vec<Layer>,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Hash)]
 pub struct Layer {
     pub layer_id: String,
     pub width: OrderedFloat<f64>,
     pub shapes: Vec<Shape>,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Hash)]
 pub enum Shape {
     Path(Path),
     Component(Component),
@@ -106,7 +106,7 @@ pub struct Axis {
     pub hidden: Option<bool>,
 }
 
-#[derive(Clone, Debug, FromPlist, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, FromPlist, PartialEq, Eq)]
 pub struct RawGlyph {
     pub layers: Vec<RawLayer>,
     pub glyphname: String,
@@ -114,7 +114,7 @@ pub struct RawGlyph {
     pub other_stuff: BTreeMap<String, Plist>,
 }
 
-#[derive(Clone, Debug, FromPlist, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, FromPlist, PartialEq, Eq)]
 pub struct RawLayer {
     pub layer_id: String,
     pub associated_master_id: Option<String>,
@@ -130,7 +130,7 @@ pub struct RawLayer {
 /// Represents a path OR a component
 ///
 /// <https://github.com/schriftgestalt/GlyphsSDK/blob/Glyphs3/GlyphsFileFormat/GlyphsFileFormatv3.md#differences-between-version-2>
-#[derive(Clone, Debug, FromPlist, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, FromPlist, PartialEq, Eq)]
 pub struct RawShape {
     // TODO: add numerous unsupported attributes
 
@@ -152,7 +152,7 @@ pub struct Path {
     pub nodes: Vec<Node>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Component {
     /// The glyph this component references
     pub glyph_name: String,
@@ -160,150 +160,44 @@ pub struct Component {
     pub other_stuff: BTreeMap<String, Plist>,
 }
 
-// We do not use kurbo's point because it does not hash
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Point {
-    pub x: OrderedFloat<f64>,
-    pub y: OrderedFloat<f64>,
-}
-
-impl Point {
-    pub fn new(x: f64, y: f64) -> Point {
-        Point {
-            x: x.into(),
-            y: y.into(),
-        }
+impl PartialEq for Component {
+    fn eq(&self, other: &Self) -> bool {
+        self.glyph_name == other.glyph_name
+            && Into::<AffineForEqAndHash>::into(self.transform) == other.transform.into()
+            && self.other_stuff == other.other_stuff
     }
 }
 
-// We do not use kurbo's affine because it does not hash
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Affine([OrderedFloat<f64>; 6]);
+impl Eq for Component {}
 
-fn round(value: OrderedFloat<f64>, digits: u8) -> OrderedFloat<f64> {
-    let m = 10f64.powi(digits as i32);
-    ((value.into_inner() * m).round() / m).into()
-}
-
-impl Affine {
-    pub fn new(matrix: [f64; 6]) -> Affine {
-        Affine([
-            matrix[0].into(),
-            matrix[1].into(),
-            matrix[2].into(),
-            matrix[3].into(),
-            matrix[4].into(),
-            matrix[5].into(),
-        ])
-    }
-
-    pub fn identity() -> Affine {
-        Affine([
-            1f64.into(),
-            0f64.into(),
-            0f64.into(),
-            1f64.into(),
-            0f64.into(),
-            0f64.into(),
-        ])
-    }
-
-    /// Round each field of the transform to specified # of digits.
-    ///
-    /// <https://github.com/googlefonts/picosvg/blob/69cbfec486eca35a46187405abc39f608d3b2963/src/picosvg/svg_transform.py#L195>
-    pub fn round(&self, digits: u8) -> Affine {
-        let mut matrix = self.0;
-        for item in &mut matrix {
-            *item = round(*item, digits);
-        }
-        Affine(matrix)
-    }
-
-    /// Returns the product of self x other. Order matters.
-    ///
-    /// The combined affine matrix can be thought of mapping by other before applying self.
-    /// Beware, this can have counter-intuitive results.
-    ///
-    /// <https://github.com/googlefonts/picosvg/blob/69cbfec486eca35a46187405abc39f608d3b2963/src/picosvg/svg_transform.py#L82>
-    /// <https://en.wikipedia.org/wiki/Matrix_multiplication>
-    pub fn mul(&self, other: Affine) -> Affine {
-        let [sa, sb, sc, sd, se, sf] = self.0;
-        let [oa, ob, oc, od, oe, of] = other.0;
-        Affine([
-            sa * oa + sc * ob,
-            sb * oa + sd * ob,
-            sa * oc + sc * od,
-            sb * oc + sd * od,
-            sa * oe + sc * of + se,
-            sb * oe + sd * of + sf,
-        ])
-    }
-
-    /// Rotate around 0,0
-    pub fn rotate(&self, angle_rads: f64) -> Affine {
-        // https://en.wikipedia.org/wiki/Transformation_matrix#/media/File:2D_affine_transformation_matrix.svg
-        let cos = angle_rads.cos().into();
-        let sin = angle_rads.sin().into();
-        self.mul(Affine([cos, sin, -sin, cos, 0.0.into(), 0.0.into()]))
-    }
-
-    /// Move it!
-    pub fn translate(&self, dx: f64, dy: f64) -> Affine {
-        // https://en.wikipedia.org/wiki/Transformation_matrix#/media/File:2D_affine_transformation_matrix.svg
-        self.mul(Affine([
-            1.0.into(),
-            0.0.into(),
-            0.0.into(),
-            1.0.into(),
-            dx.into(),
-            dy.into(),
-        ]))
-    }
-
-    /// Scale around 0,0.
-    pub fn scale(&self, sx: f64, sy: f64) -> Affine {
-        // https://en.wikipedia.org/wiki/Transformation_matrix#/media/File:2D_affine_transformation_matrix.svg
-        self.mul(Affine([
-            sx.into(),
-            0.0.into(),
-            0.0.into(),
-            sy.into(),
-            0.0.into(),
-            0.0.into(),
-        ]))
-    }
-
-    pub fn x_basis(&self) -> (f64, f64) {
-        (self.0[0].into_inner(), self.0[1].into_inner())
-    }
-
-    pub fn y_basis(&self) -> (f64, f64) {
-        (self.0[2].into_inner(), self.0[3].into_inner())
-    }
-
-    pub fn translation(&self) -> (f64, f64) {
-        (self.0[4].into_inner(), self.0[5].into_inner())
+impl Hash for Component {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.glyph_name.hash(state);
+        Into::<AffineForEqAndHash>::into(self.transform).hash(state);
+        self.other_stuff.hash(state);
     }
 }
 
-impl Display for Affine {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_char('{')?;
-        for (i, v) in self.0.iter().enumerate() {
-            if i > 0 {
-                f.write_str(", ")?;
-            }
-            f.write_fmt(format_args!("{:.4}", v.into_inner()))?;
-        }
-        f.write_char('}')?;
-        Ok(())
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Node {
     pub pt: Point,
     pub node_type: NodeType,
+}
+
+impl PartialEq for Node {
+    fn eq(&self, other: &Self) -> bool {
+        Into::<PointForEqAndHash>::into(self.pt) == other.pt.into()
+            && self.node_type == other.node_type
+    }
+}
+
+impl Eq for Node {}
+
+impl Hash for Node {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        PointForEqAndHash::new(self.pt).hash(state);
+        self.node_type.hash(state);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -315,7 +209,7 @@ pub enum NodeType {
     CurveSmooth,
 }
 
-#[derive(Clone, Debug, FromPlist, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, FromPlist, PartialEq)]
 pub struct Anchor {
     pub name: String,
     pub position: Point,
@@ -410,7 +304,7 @@ impl TryFrom<BTreeMap<String, Plist>> for Component {
         let mut transform = if let Some(plist) = dict.remove("transform") {
             Affine::from_plist(plist)
         } else {
-            Affine::identity()
+            Affine::IDENTITY
         };
 
         // Glyphs 3 gives us {angle, pos, scale}. Glyphs 2 gives us the standard 2x3 matrix.
@@ -423,7 +317,7 @@ impl TryFrom<BTreeMap<String, Plist>> for Component {
             if pos.len() != 2 {
                 return Err(Error::StructuralError(format!("Bad pos: {:?}", pos)));
             }
-            transform = transform.translate(try_f64(&pos[0])?, try_f64(&pos[1])?);
+            transform *= Affine::translate((try_f64(&pos[0])?, try_f64(&pos[1])?));
         }
 
         // Scale
@@ -431,12 +325,12 @@ impl TryFrom<BTreeMap<String, Plist>> for Component {
             if scale.len() != 2 {
                 return Err(Error::StructuralError(format!("Bad scale: {:?}", scale)));
             }
-            transform = transform.scale(try_f64(&scale[0])?, try_f64(&scale[1])?);
+            transform *= Affine::scale_non_uniform(try_f64(&scale[0])?, try_f64(&scale[1])?);
         }
 
         // Rotate
         if let Some(angle) = dict.remove("angle") {
-            transform = transform.rotate(try_f64(&angle)?.to_radians());
+            transform *= Affine::rotate(try_f64(&angle)?.to_radians());
         }
 
         Ok(Component {
@@ -1206,6 +1100,38 @@ impl Font {
     }
 }
 
+/// Convert [kurbo::Point] to this for eq and hash/
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct PointForEqAndHash {
+    x: OrderedFloat<f64>,
+    y: OrderedFloat<f64>,
+}
+
+impl PointForEqAndHash {
+    fn new(point: Point) -> PointForEqAndHash {
+        point.into()
+    }
+}
+
+impl From<Point> for PointForEqAndHash {
+    fn from(value: Point) -> Self {
+        PointForEqAndHash {
+            x: value.x.into(),
+            y: value.y.into(),
+        }
+    }
+}
+
+/// Convert [kurbo::Affine] to this for eq and hash/
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct AffineForEqAndHash([OrderedFloat<f64>; 6]);
+
+impl From<Affine> for AffineForEqAndHash {
+    fn from(value: Affine) -> Self {
+        Self(value.as_coeffs().map(|coeff| coeff.into()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -1219,7 +1145,7 @@ mod tests {
 
     use pretty_assertions::assert_eq;
 
-    use super::Affine;
+    use kurbo::Affine;
 
     fn testdata_dir() -> PathBuf {
         let dir = Path::new("../resources/testdata");
@@ -1235,15 +1161,21 @@ mod tests {
         testdata_dir().join("glyphs3")
     }
 
+    fn round(transform: Affine, digits: u8) -> Affine {
+        let m = 10f64.powi(digits as i32);
+        let mut coeffs = transform.as_coeffs();
+        for c in coeffs.iter_mut() {
+            *c = (*c * m).round() / m;
+        }
+        Affine::new(coeffs)
+    }
+
     #[test]
     fn test_glyphs3_node() {
         assert_eq!(
             Node {
                 node_type: crate::NodeType::Line,
-                pt: super::Point {
-                    x: 354.0.into(),
-                    y: 183.0.into()
-                }
+                pt: super::Point { x: 354.0, y: 183.0 }
             },
             Node::from_plist(Plist::Array(vec![
                 Plist::Integer(354),
@@ -1258,10 +1190,7 @@ mod tests {
         assert_eq!(
             Node {
                 node_type: crate::NodeType::Line,
-                pt: super::Point {
-                    x: 354.0.into(),
-                    y: 183.0.into()
-                }
+                pt: super::Point { x: 354.0, y: 183.0 }
             },
             Node::from_plist(Plist::String("354 183 LINE".into()))
         );
@@ -1311,17 +1240,10 @@ mod tests {
             panic!("{:?} should be a component", g3_shape);
         };
 
-        let expected = Affine([
-            1.6655.into(),
-            1.1611.into(),
-            (-1.1611).into(),
-            1.6655.into(),
-            (-233.0).into(),
-            (-129.0).into(),
-        ]);
+        let expected = Affine::new([1.6655, 1.1611, -1.1611, 1.6655, -233.0, -129.0]);
 
-        assert_eq!(expected, g2_shape.transform.round(4));
-        assert_eq!(expected, g3_shape.transform.round(4));
+        assert_eq!(expected, round(g2_shape.transform, 4));
+        assert_eq!(expected, round(g3_shape.transform, 4));
     }
 
     #[test]

--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -7,7 +7,7 @@ mod plist;
 mod to_plist;
 
 pub use font::{
-    Axis, Component, FeatureSnippet, Font, FontMaster, Glyph, Layer, Node, NodeType, Path,
+    Axis, Component, FeatureSnippet, Font, FontMaster, Glyph, Layer, Node, NodeType, Path, Shape,
 };
 pub use from_plist::FromPlist;
 pub use plist::Plist;

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 
-use crate::toir::{to_ir_features, FontInfo};
+use crate::toir::{to_ir_contours_and_components, to_ir_features, FontInfo};
 
 pub struct GlyphsIrSource {
     glyphs_file: PathBuf,
@@ -261,12 +261,14 @@ impl Work<Context, WorkError> for GlyphIrWork {
                     .insert(*coord);
             }
 
-            // TODO actually populate fields
+            // TODO populate width and height properly
+            let (contours, components) =
+                to_ir_contours_and_components(&self.glyph_name, &instance.shapes)?;
             let glyph_instance = GlyphInstance {
                 width: instance.width.into_inner(),
                 height: None,
-                contours: Vec::new(),
-                components: Vec::new(),
+                contours,
+                components,
             };
 
             ir_glyph

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -1,12 +1,107 @@
 use std::collections::HashMap;
 
+use fontdrasil::types::GlyphName;
 use fontir::{
     coords::{CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
     error::{Error, WorkError},
     ir,
 };
-use glyphs_reader::{FeatureSnippet, Font, FontMaster};
+use glyphs_reader::{Component, FeatureSnippet, Font, FontMaster, Node, NodeType, Path, Shape};
+use log::trace;
 use ordered_float::OrderedFloat;
+
+pub(crate) fn to_ir_contours_and_components(
+    glyph_name: &GlyphName,
+    shapes: &[Shape],
+) -> Result<(Vec<ir::Contour>, Vec<ir::Component>), WorkError> {
+    let mut contours = Vec::new();
+    let mut components = Vec::new();
+
+    for shape in shapes.iter() {
+        match shape {
+            Shape::Component(component) => components.push(to_ir_component(glyph_name, component)),
+            Shape::Path(path) => contours.push(to_ir_contour(glyph_name, path)?),
+        }
+    }
+
+    Ok((contours, components))
+}
+
+fn to_ir_component(glyph_name: &GlyphName, component: &Component) -> ir::Component {
+    let (xx, yx) = component.transform.x_basis();
+    let (xy, yy) = component.transform.y_basis();
+    let (dx, dy) = component.transform.translation();
+
+    trace!("Built a component for {}", glyph_name);
+    ir::Component {
+        base: component.glyph_name.clone(),
+        transform: ir::Affine2x3 {
+            xx,
+            yx,
+            xy,
+            yy,
+            dx,
+            dy,
+        },
+    }
+}
+
+fn to_ir_contour(glyph_name: &GlyphName, path: &Path) -> Result<ir::Contour, WorkError> {
+    // Based on https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/paths.py#L20
+    // See also https://github.com/fonttools/ufoLib2/blob/4d8a9600148b670b0840120658d9aab0b38a9465/src/ufoLib2/pointPens/glyphPointPen.py#L16
+    let mut contour = ir::Contour::new();
+    if path.nodes.is_empty() {
+        return Ok(contour);
+    }
+
+    let mut nodes = &path.nodes[..];
+    if !path.closed {
+        let first = &nodes[0];
+        nodes = &nodes[1..];
+        if first.node_type != NodeType::Line {
+            return Err(WorkError::InvalidSourceGlyph {
+                glyph_name: glyph_name.clone(),
+                message: String::from("Open path starts with off-curve points"),
+            });
+        }
+        let mut pt = to_ir_point(first);
+        pt.typ = ir::PointType::Move;
+        contour.push(pt);
+    } else {
+        // In Glyphs.app, the starting node of a closed contour is always
+        // stored at the end of the nodes list.
+        let Some((last, elements)) = nodes.split_last() else {
+            unreachable!("Not empty and no last is a good trick");
+        };
+        nodes = elements;
+        contour.push(to_ir_point(last));
+    }
+
+    nodes.iter().map(to_ir_point).for_each(|p| contour.push(p));
+
+    trace!("Built a {} entry contour for {}", contour.len(), glyph_name);
+    Ok(contour)
+}
+
+fn to_ir_point(node: &Node) -> ir::ContourPoint {
+    ir::ContourPoint {
+        x: node.pt.x.into_inner(),
+        y: node.pt.y.into_inner(),
+        typ: to_ir_point_type(node.node_type),
+    }
+}
+
+fn to_ir_point_type(node_type: NodeType) -> ir::PointType {
+    // https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/pens.py#L92
+    // Convert XSmooth to X because Smooth is only relevant to editor behavior
+    match node_type {
+        NodeType::Line => ir::PointType::Line,
+        NodeType::Curve => ir::PointType::Curve,
+        NodeType::LineSmooth => ir::PointType::Line,
+        NodeType::CurveSmooth => ir::PointType::Curve,
+        NodeType::OffCurve => ir::PointType::OffCurve,
+    }
+}
 
 pub(crate) fn to_ir_features(features: &[FeatureSnippet]) -> Result<ir::Features, WorkError> {
     // Based on https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/features.py#L74

--- a/resources/testdata/glyphs2/Component.glyphs
+++ b/resources/testdata/glyphs2/Component.glyphs
@@ -1,0 +1,70 @@
+{
+.appVersion = "3151";
+DisplayStrings = (
+".",
+","
+);
+date = "2023-01-20 20:20:30 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+alignmentZones = (
+"{800, 16}",
+"{700, 16}",
+"{500, 16}",
+"{0, -16}",
+"{0, -16}",
+"{-200, -16}"
+);
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = m01;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = period;
+lastChange = "2023-01-20 20:20:51 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"238 0 LINE",
+"362 0 LINE",
+"362 112 LINE",
+"238 112 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 002E;
+},
+{
+glyphname = comma;
+lastChange = "2023-01-20 20:22:39 +0000";
+layers = (
+{
+components = (
+{
+name = period;
+transform = "{1.66552, 1.16109, -1.16109, 1.66552, -233, -129}";
+}
+);
+layerId = m01;
+width = 600;
+}
+);
+unicode = 002C;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs2/WghtVar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar.glyphs
@@ -170,7 +170,7 @@ width = 600;
 components = (
 {
 name = hyphen;
-transform = "{1, 0, 0, 1, 0, 100}";
+transform = "{1.15, 0, 0, 1.25, 10, 100}";
 },
 {
 name = hyphen;

--- a/resources/testdata/glyphs3/Component.glyphs
+++ b/resources/testdata/glyphs3/Component.glyphs
@@ -1,0 +1,106 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+DisplayStrings = (
+".",
+","
+);
+date = "2023-01-20 20:20:30 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+over = -16;
+}
+);
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = period;
+lastChange = "2023-01-20 20:20:51 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(238,0,l),
+(362,0,l),
+(362,112,l),
+(238,112,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 46;
+},
+{
+glyphname = comma;
+lastChange = "2023-01-20 20:22:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+angle = 34.88155;
+pos = (-233,-129);
+ref = period;
+scale = (2.0303,2.0303);
+}
+);
+width = 600;
+}
+);
+unicode = 44;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs3/WghtVar.glyphs
+++ b/resources/testdata/glyphs3/WghtVar.glyphs
@@ -192,7 +192,8 @@ width = 600;
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 shapes = (
 {
-pos = (0, 100);
+pos = (10, 100);
+scale = (1.15, 1.25);
 ref = hyphen;
 },
 {

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -15,6 +15,7 @@ fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontir = { version = "0.0.1", path = "../fontir" }
 
 norad = "0.8.0"
+kurbo = { version="0.9.0", features=["serde"] }
 serde = {version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.14"
 

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -6,6 +6,7 @@ use fontir::{
     coords::{CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
     ir,
 };
+use kurbo::Affine;
 use norad::designspace::{self, Dimension};
 
 use crate::error::Error;
@@ -42,14 +43,14 @@ fn to_ir_contour(contour: &norad::Contour) -> ir::Contour {
 fn to_ir_component(component: &norad::Component) -> ir::Component {
     ir::Component {
         base: component.base.to_string(),
-        transform: ir::Affine2x3 {
-            xx: component.transform.x_scale,
-            yx: component.transform.yx_scale,
-            xy: component.transform.xy_scale,
-            yy: component.transform.y_scale,
-            dx: component.transform.x_offset,
-            dy: component.transform.y_offset,
-        },
+        transform: Affine::new([
+            component.transform.x_scale,
+            component.transform.yx_scale,
+            component.transform.xy_scale,
+            component.transform.y_scale,
+            component.transform.x_offset,
+            component.transform.y_offset,
+        ]),
     }
 }
 


### PR DESCRIPTION
Fixes #93. Note that I chose to keep a 2x3 - as Glyphs 2 did - rather than Glyphs 3 style individual fields because it's not obvious what order those fields apply in.
