### PR TITLE
VariationModel in Rust, part 1

### DIFF
--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -130,13 +130,13 @@ impl Context {
             return;
         }
         fs::write(file, content)
-            .map_err(|e| panic!("Unable to write {:?} {}", file, e))
+            .map_err(|e| panic!("Unable to write {file:?} {e}"))
             .unwrap();
     }
 
     fn restore(&self, file: &Path) -> Vec<u8> {
         fs::read(file)
-            .map_err(|e| panic!("Unable to read {:?} {}", file, e))
+            .map_err(|e| panic!("Unable to read {file:?} {e}"))
             .unwrap()
     }
 

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -93,7 +93,7 @@ impl Config {
 
 fn require_dir(dir: &Path) -> Result<PathBuf, io::Error> {
     if dir.exists() && !dir.is_dir() {
-        panic!("{:#?} is taken by something that isn't a directory", dir);
+        panic!("{dir:#?} is taken by something that isn't a directory");
     }
     if !dir.exists() {
         fs::create_dir(dir)?
@@ -443,7 +443,7 @@ impl Workload {
         let mut opt_complete = match initial_read {
             RecvType::Blocking => match recv.recv() {
                 Ok(completed) => Some(completed),
-                Err(e) => panic!("Blocking read failed: {}", e),
+                Err(e) => panic!("Blocking read failed: {e}"),
             },
             RecvType::NonBlocking => match recv.try_recv() {
                 Ok(completed) => Some(completed),
@@ -458,11 +458,11 @@ impl Workload {
                 Ok(..) => self.success.insert(completed_id.clone()),
                 Err(e) => {
                     error!("{:?} failed {}", completed_id, e);
-                    self.error.push((completed_id.clone(), format!("{}", e)));
+                    self.error.push((completed_id.clone(), format!("{e}")));
                     true
                 }
             } {
-                panic!("Repeat signals for completion of {:#?}", completed_id);
+                panic!("Repeat signals for completion of {completed_id:#?}");
             }
             debug!(
                 "{}/{} complete, most recently {:?}",
@@ -588,7 +588,7 @@ mod tests {
         let path = PathBuf::from("../resources/testdata")
             .canonicalize()
             .unwrap();
-        assert!(path.is_dir(), "{:#?} isn't a dir", path);
+        assert!(path.is_dir(), "{path:#?} isn't a dir");
         path
     }
 
@@ -629,11 +629,10 @@ mod tests {
         let paths = IrPaths::new(build_dir);
         let ir_input_file = paths.ir_input_file();
 
-        assert!(config_file.exists(), "Should exist: {:#?}", config_file);
+        assert!(config_file.exists(), "Should exist: {config_file:#?}");
         assert!(
             !ir_input_file.exists(),
-            "Should not exist: {:#?}",
-            ir_input_file
+            "Should not exist: {ir_input_file:#?}"
         );
         assert!(!Config::new(args, build_dir.to_path_buf())
             .unwrap()
@@ -708,7 +707,7 @@ mod tests {
             if launchable.is_empty() {
                 eprintln!("Completed:");
                 for id in workload.success.iter() {
-                    eprintln!("  {:?}", id);
+                    eprintln!("  {id:?}");
                 }
                 eprintln!("Unable to proceed with:");
                 for (id, job) in workload.jobs_pending.iter() {
@@ -726,8 +725,7 @@ mod tests {
             job.work.exec(context).unwrap();
             assert!(
                 workload.success.insert(id.clone()),
-                "We just did {:?} a second time?",
-                id
+                "We just did {id:?} a second time?"
             );
         }
         finish_successfully(change_detector).unwrap();
@@ -802,7 +800,7 @@ mod tests {
         assert_eq!(IndexSet::new(), result.glyphs_deleted);
 
         let bar_ir = build_dir.join("glyph_ir/bar.yml");
-        assert!(bar_ir.is_file(), "no file {:#?}", bar_ir);
+        assert!(bar_ir.is_file(), "no file {bar_ir:#?}");
         fs::remove_file(bar_ir).unwrap();
 
         let result = compile(build_dir, "wght_var.designspace");
@@ -825,10 +823,6 @@ mod tests {
         );
 
         let feature_ttf = build_dir.join("features.ttf");
-        assert!(
-            feature_ttf.is_file(),
-            "Should have written {:?}",
-            feature_ttf
-        );
+        assert!(feature_ttf.is_file(), "Should have written {feature_ttf:?}");
     }
 }

--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -61,7 +61,7 @@ impl<I: Eq + Hash + Debug> AccessControlList<I> {
 
     pub fn check_write_access(&self, id: &I) {
         if self.write_mask.as_ref() != Some(id) {
-            panic!("Illegal access to {:?}", id);
+            panic!("Illegal access to {id:?}");
         }
     }
 }

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -40,7 +40,7 @@ pub struct NormalizedCoord(OrderedFloat<f32>);
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub struct Location<T>(BTreeMap<String, T>)
 where
-    T: Clone;
+    T: Copy;
 
 pub type DesignLocation = Location<DesignCoord>;
 pub type UserLocation = Location<UserCoord>;
@@ -184,13 +184,13 @@ impl Sub<NormalizedCoord> for NormalizedCoord {
     }
 }
 
-impl<T: Clone> FromIterator<(String, T)> for Location<T> {
+impl<T: Copy> FromIterator<(String, T)> for Location<T> {
     fn from_iter<I: IntoIterator<Item = (String, T)>>(iter: I) -> Self {
         Location(BTreeMap::from_iter(iter))
     }
 }
 
-impl<T: Clone> Location<T> {
+impl<T: Copy> Location<T> {
     pub fn new() -> Location<T> {
         Location(BTreeMap::new())
     }
@@ -213,11 +213,11 @@ impl<T: Clone> Location<T> {
     }
 
     pub fn get(&self, axis_name: &String) -> Option<T> {
-        self.0.get(axis_name).cloned()
+        self.0.get(axis_name).copied()
     }
 }
 
-impl<T: Clone> Default for Location<T> {
+impl<T: Copy> Default for Location<T> {
     fn default() -> Self {
         Self::new()
     }

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -3,6 +3,8 @@
 //! See <https://github.com/googlefonts/fontmake-rs/blob/main/resources/text/units.md>
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::{Debug, Write};
+use std::ops::Sub;
 
 use crate::serde::CoordConverterSerdeRepr;
 use crate::{ir::Axis, piecewise_linear_map::PiecewiseLinearMap};
@@ -26,15 +28,19 @@ pub struct UserCoord(OrderedFloat<f32>);
 /// Always in [-1, 1].
 ///
 /// Not typically used directly in sources.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Serialize, Deserialize, Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 pub struct NormalizedCoord(OrderedFloat<f32>);
 
 /// A set of per-axis coordinates that define a specific location in a coordinate system.
 ///
 /// E.g. a user location is a `Location<UserCoord>`. Hashable so it can do things like be
 /// the key for a map of sources by location.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Location<T>(BTreeMap<String, T>);
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub struct Location<T>(BTreeMap<String, T>)
+where
+    T: Clone;
 
 pub type DesignLocation = Location<DesignCoord>;
 pub type UserLocation = Location<UserCoord>;
@@ -170,13 +176,21 @@ impl NormalizedCoord {
     }
 }
 
-impl<T> FromIterator<(String, T)> for Location<T> {
+impl Sub<NormalizedCoord> for NormalizedCoord {
+    type Output = NormalizedCoord;
+
+    fn sub(self, rhs: NormalizedCoord) -> Self::Output {
+        NormalizedCoord::new(self.0 - rhs.0)
+    }
+}
+
+impl<T: Clone> FromIterator<(String, T)> for Location<T> {
     fn from_iter<I: IntoIterator<Item = (String, T)>>(iter: I) -> Self {
         Location(BTreeMap::from_iter(iter))
     }
 }
 
-impl<T> Location<T> {
+impl<T: Clone> Location<T> {
     pub fn new() -> Location<T> {
         Location(BTreeMap::new())
     }
@@ -189,9 +203,21 @@ impl<T> Location<T> {
     pub fn iter(&self) -> impl Iterator<Item = (&String, &T)> {
         self.0.iter()
     }
+
+    pub fn axis_names(&self) -> impl Iterator<Item = &String> {
+        self.0.keys()
+    }
+
+    pub fn has(&self, axis_name: &String) -> bool {
+        self.0.contains_key(axis_name)
+    }
+
+    pub fn get(&self, axis_name: &String) -> Option<T> {
+        self.0.get(axis_name).cloned()
+    }
 }
 
-impl<T> Default for Location<T> {
+impl<T: Clone> Default for Location<T> {
     fn default() -> Self {
         Self::new()
     }
@@ -226,6 +252,50 @@ impl NormalizedLocation {
                 })
                 .collect(),
         )
+    }
+}
+
+impl NormalizedLocation {
+    pub fn has_non_zero(&self, axis_name: &String) -> bool {
+        self.get(axis_name).unwrap_or_default().into_inner() != OrderedFloat(0.0)
+    }
+}
+
+fn format_location<'a, 'b>(
+    name: &str,
+    f: &mut std::fmt::Formatter<'a>,
+    items: impl Iterator<Item = (&'b String, OrderedFloat<f32>)>,
+) -> std::fmt::Result {
+    f.write_str(name)?;
+    f.write_str(" {")?;
+    for (i, (axis_name, value)) in items.enumerate() {
+        if i > 0 {
+            f.write_str(", ")?;
+        }
+        f.write_str(axis_name)?;
+        f.write_fmt(format_args!(": {value:.02}"))?;
+    }
+    f.write_char('}')
+}
+
+impl Debug for DesignLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let it = self.0.iter().map(|(n, v)| (n, v.into_inner()));
+        format_location("Design", f, it)
+    }
+}
+
+impl Debug for UserLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let it = self.0.iter().map(|(n, v)| (n, v.into_inner()));
+        format_location("User", f, it)
+    }
+}
+
+impl Debug for NormalizedLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let it = self.0.iter().map(|(n, v)| (n, v.into_inner()));
+        format_location("Normalized", f, it)
     }
 }
 

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -111,3 +111,12 @@ pub enum PathConversionError {
         points: Vec<Point>,
     },
 }
+
+#[derive(Debug, Error)]
+pub enum VariationModelError {
+    #[error("{axis_names:?} in {location:?} have no assigned order")]
+    AxesWithoutAssignedOrder {
+        axis_names: Vec<String>,
+        location: NormalizedLocation,
+    },
+}

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -4,6 +4,7 @@ use crate::{
     coords::{CoordConverter, NormalizedLocation, UserCoord},
     error::{PathConversionError, WorkError},
     serde::{GlyphSerdeRepr, StaticMetadataSerdeRepr},
+    variations::VariationModel,
 };
 use fontdrasil::types::GlyphName;
 use indexmap::IndexSet;
@@ -24,11 +25,16 @@ use std::{
 pub struct StaticMetadata {
     pub axes: Vec<Axis>,
     pub glyph_order: IndexSet<GlyphName>,
+    pub variation_model: VariationModel,
 }
 
 impl StaticMetadata {
     pub fn new(axes: Vec<Axis>, glyph_order: IndexSet<GlyphName>) -> StaticMetadata {
-        StaticMetadata { axes, glyph_order }
+        StaticMetadata {
+            axes,
+            glyph_order,
+            variation_model: VariationModel::empty(),
+        }
     }
 }
 

--- a/fontir/src/lib.rs
+++ b/fontir/src/lib.rs
@@ -7,3 +7,4 @@ pub mod piecewise_linear_map;
 pub(crate) mod serde;
 pub mod source;
 pub mod stateset;
+pub mod variations;

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -105,11 +105,11 @@ impl Context {
             return;
         }
         let raw_file = File::create(file)
-            .map_err(|e| panic!("Unable to write {:?} {}", file, e))
+            .map_err(|e| panic!("Unable to write {file:?} {e}"))
             .unwrap();
         let buf_io = BufWriter::new(raw_file);
         serde_yaml::to_writer(buf_io, &content)
-            .map_err(|e| panic!("Unable to serialize\n{:#?}\nto {:?}: {}", content, file, e))
+            .map_err(|e| panic!("Unable to serialize\n{content:#?}\nto {file:?}: {e}"))
             .unwrap();
     }
 
@@ -118,12 +118,12 @@ impl Context {
         V: ?Sized + DeserializeOwned,
     {
         let raw_file = File::open(file)
-            .map_err(|e| panic!("Unable to read {:?} {}", file, e))
+            .map_err(|e| panic!("Unable to read {file:?} {e}"))
             .unwrap();
         let buf_io = BufReader::new(raw_file);
         match serde_yaml::from_reader(buf_io) {
             Ok(v) => v,
-            Err(e) => panic!("Unable to deserialize {:?} {}", file, e),
+            Err(e) => panic!("Unable to deserialize {file:?} {e}"),
         }
     }
 

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -1,0 +1,795 @@
+//! Helps manipulate variation data.
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    fmt::{Debug, Display},
+};
+
+use log::{log_enabled, trace};
+use ordered_float::OrderedFloat;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    coords::{NormalizedCoord, NormalizedLocation},
+    error::VariationModelError,
+};
+
+const ZERO: OrderedFloat<f32> = OrderedFloat(0.0);
+const ONE: OrderedFloat<f32> = OrderedFloat(1.0);
+
+/// A model of how variation space is subdivided into regions to create deltas.
+///
+/// Given a set of master locations, figures out a set of regions and the weights each
+/// region assigns to each master. This enables us to compute deltas for variation stores.
+///
+/// See `class VariationModel` in <https://github.com/fonttools/fonttools/blob/main/Lib/fontTools/varLib/models.py>
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct VariationModel {
+    // TODO: why isn't this a Map<Loc, Region>
+    // All Vec's have same length and items at the same index refer to the same master
+    // Which sounds a *lot* like we should have a Vec or Map of Some Struct.
+    locations: Vec<NormalizedLocation>,
+    influence: Vec<VariationRegion>,
+
+    // [n] gives a vec of (master index, scale for deltas from that master)
+    delta_weights: Vec<Vec<(usize, OrderedFloat<f32>)>>,
+}
+
+impl VariationModel {
+    /// Create a model of variation space subdivision suitable for delta construction.
+    ///
+    /// Locations should be points in variation space where we wish to define something, such as a
+    /// glyph instance.
+    ///
+    /// Axis order should reflect the importance of the axis.
+    pub fn new(
+        locations: HashSet<NormalizedLocation>,
+        axis_order: Vec<String>,
+    ) -> Result<Self, VariationModelError> {
+        let axes = axis_order.iter().collect::<HashSet<&String>>();
+
+        let mut expanded_locations = HashSet::new();
+        for mut location in locations.into_iter() {
+            // Only axes that have an assigned order are valid
+            let bad_axes = location
+                .axis_names()
+                .filter(|n| !axes.contains(n))
+                .cloned()
+                .collect::<Vec<_>>();
+            if !bad_axes.is_empty() {
+                return Err(VariationModelError::AxesWithoutAssignedOrder {
+                    axis_names: bad_axes,
+                    location: location.clone(),
+                });
+            }
+
+            // Assign the normalized location 0 for every axis where no other value was assigned
+            for axis_name in axes.iter() {
+                if !location.has(axis_name) {
+                    let axis_name = *axis_name;
+                    location.set_pos(axis_name.clone(), NormalizedCoord::new(0.0));
+                }
+            }
+
+            expanded_locations.insert(location);
+        }
+
+        // sort locations for reasons as yet unclear
+        let mut locations: Vec<_> = expanded_locations.into_iter().collect();
+        let sorting_hat = LocationSortingHat::new(&locations, axis_order);
+        locations.sort_by_cached_key(|loc| sorting_hat.key_for(loc));
+
+        let regions = regions_for(&locations);
+        let influence = master_influence(regions);
+        let delta_weights = delta_weights(&locations, &influence);
+
+        Ok(VariationModel {
+            locations,
+            influence,
+            delta_weights,
+        })
+    }
+
+    pub fn empty() -> Self {
+        VariationModel {
+            locations: Vec::new(),
+            influence: Vec::new(),
+            delta_weights: Vec::new(),
+        }
+    }
+}
+
+/// Gryffindor!
+///
+/// Sorts locations, and thus the resulting regions, based on the intuition that from most
+/// to least influential are the default master, then corner masters, and finally
+/// any other masters (sometimes referred to as knockout or fixup masters). This is computed
+/// based on the master location being offset from default on fewer axes rather than more
+///
+/// * This is [LocationSortKey.rank] and [LocationSortKey.on_axis_points]
+/// * The default master will thus come first, followed by any masters directly on axes
+/// * For example, if default is weight 400, width 100 then the master at weight 700, width 100
+///   will sort before the master at weight 700, weight 75
+///
+/// Additional sorting is applied after this to ensure a deteriministic order in case of ties.
+///
+/// This algorithm started in MutatorMath and was subsequently modified in FontTools.
+///
+/// This is a Rust version of FontTools getMasterLocationsSortKeyFunc.
+/// <https://github.com/fonttools/fonttools/blob/2f1f5e5e7be331d960a0e30d537c2b4c70d89285/Lib/fontTools/varLib/models.py#L295>
+struct LocationSortingHat {
+    axis_order: Vec<String>,
+    on_axis_points: HashMap<String, HashSet<NormalizedCoord>>,
+}
+
+impl LocationSortingHat {
+    fn new(locations: &[NormalizedLocation], axis_order: Vec<String>) -> LocationSortingHat {
+        // Location is on-axis if it has exactly 1 non-zero coordinate
+        let mut on_axis_points: HashMap<String, HashSet<NormalizedCoord>> = HashMap::new();
+        'location: for location in locations {
+            let mut on_axis: Option<(&String, NormalizedCoord)> = None;
+            for (axis_name, pos) in location.iter() {
+                if pos.into_inner() == ZERO {
+                    continue;
+                }
+                if on_axis.is_some() {
+                    continue 'location; // multiple non-zero coords, bail out
+                }
+                on_axis = Some((axis_name, *pos));
+            }
+            if let Some((axis_name, pos)) = on_axis {
+                on_axis_points
+                    .entry(axis_name.clone())
+                    .or_default()
+                    .insert(pos);
+            }
+        }
+        LocationSortingHat {
+            axis_order,
+            on_axis_points,
+        }
+    }
+
+    fn key_for(&self, location: &NormalizedLocation) -> LocationSortKey {
+        let mut rank = 0;
+        let mut on_axis_points: i16 = 0;
+        let mut ordered_axes = Vec::new();
+        let mut non_zero_axes = Vec::new();
+
+        // Score the index of the axis for any axis with non-zero value in the user specified axis order
+        let mut known_axes = Vec::new();
+        for (idx, axis_name) in self.axis_order.iter().enumerate() {
+            if location.has_non_zero(axis_name) {
+                known_axes.push(idx);
+                ordered_axes.push(axis_name.clone());
+            }
+        }
+
+        for (axis_name, pos) in location.iter() {
+            if pos.into_inner() != ZERO {
+                // Rank is the # of axes with non-zero values
+                rank += 1;
+
+                // Score more than the max allowable axes for any axis with non-zero value that has no user-specified order
+                if !self.axis_order.contains(axis_name) {
+                    known_axes.push(0x10000);
+                }
+
+                non_zero_axes.push(axis_name);
+            }
+            // score -1 for every axis position that matches a location that was directly on an axis
+            on_axis_points += self
+                .on_axis_points
+                .get(axis_name)
+                .map(|on_axis| on_axis.get(pos).map_or(0, |_| -1))
+                .unwrap_or_default();
+        }
+
+        let mut unordered_axes: Vec<String> = non_zero_axes
+            .into_iter()
+            .filter(|axis_name| !ordered_axes.contains(axis_name))
+            .cloned()
+            .collect();
+        unordered_axes.sort();
+        ordered_axes.extend(unordered_axes);
+
+        let axis_value_signs = ordered_axes
+            .iter()
+            .map(|axis_name| {
+                location
+                    .get(axis_name)
+                    .map(|coord| match coord.into_inner().cmp(&ZERO) {
+                        Ordering::Greater => 1_i8,
+                        Ordering::Less => -1_i8,
+                        Ordering::Equal => 0_i8,
+                    })
+                    .unwrap_or_default()
+            })
+            .collect();
+
+        let axis_value_abs = ordered_axes
+            .iter()
+            .map(|axis_name| {
+                location
+                    .get(axis_name)
+                    .map(|coord| OrderedFloat(coord.into_inner().abs()))
+                    .unwrap_or_default()
+            })
+            .collect();
+
+        let result = LocationSortKey {
+            rank,
+            on_axis_points,
+            known_axes,
+            ordered_axes,
+            axis_value_signs,
+            axis_value_abs,
+        };
+        trace!("key for {:?} is {:?}", location, result);
+
+        result
+    }
+}
+
+/// Sort key for a location.
+///
+/// Only axes with a non-zero normalized value are of interest.
+///
+/// <https://github.com/fonttools/fonttools/blob/2f1f5e5e7be331d960a0e30d537c2b4c70d89285/Lib/fontTools/varLib/models.py#L326>
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct LocationSortKey {
+    // 1 for every non-zero entry in the map
+    rank: usize,
+    // -1 for every axis:value entry in location where a location exists whose only non-zero
+    // position is on axis at value. That is, a location exists that is directly on the axis there.
+    on_axis_points: i16,
+    // index in user-specified axis order, otherwise score 0x10000 (65536)
+    known_axes: Vec<usize>,
+    // ordered list of axis in location
+    ordered_axes: Vec<String>,
+    // signs of positions on axes in ordered_axes order
+    axis_value_signs: Vec<i8>,
+    // abs values of positions on axes in ordered_axes order
+    axis_value_abs: Vec<OrderedFloat<f32>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+struct VariationRegion(HashMap<String, Tent>);
+
+impl VariationRegion {
+    fn new() -> Self {
+        VariationRegion(HashMap::new())
+    }
+}
+
+impl VariationRegion {
+    /// The scalar multiplier for the provided location for this region
+    ///
+    /// Returns None for no influence, Some(non-zero value) for influence.
+    ///
+    /// In Python, supportScalar. We only implement the ot=True, extrapolate=False paths.
+    /// <https://github.com/fonttools/fonttools/blob/2f1f5e5e7be331d960a0e30d537c2b4c70d89285/Lib/fontTools/varLib/models.py#L123>.
+    fn scalar_at(&self, location: &NormalizedLocation) -> OrderedFloat<f32> {
+        let scalar =
+            self.0
+                .iter()
+                .filter(|(_, ar)| ar.validate())
+                .fold(ONE, |scalar, (axis_name, tent)| {
+                    let v = location
+                        .get(axis_name)
+                        .map(|v| v.into_inner())
+                        .unwrap_or_default();
+                    let lower = tent.lower.into_inner();
+                    let peak = tent.peak.into_inner();
+                    let upper = tent.upper.into_inner();
+
+                    // If we're at the peak by definition we have full influence
+                    if v == peak {
+                        return scalar; // *= 1
+                    }
+
+                    // If the Tent is 0,0,0 it's always in full effect
+                    if (lower, peak, upper) == (ZERO, ZERO, ZERO) {
+                        return scalar; // *= 1
+                    }
+
+                    if v <= lower || upper <= v {
+                        trace!(
+                            "  {:?} => 0 due to {} {:?} at {:?}",
+                            self,
+                            axis_name,
+                            tent,
+                            location
+                        );
+                        return ZERO;
+                    }
+
+                    let subtract_me = if v < peak {
+                        tent.lower.into_inner()
+                    } else {
+                        tent.upper.into_inner()
+                    };
+                    scalar * (v - subtract_me) / (peak - subtract_me)
+                });
+        scalar
+    }
+}
+
+/// The min/peak/max of a masters influence.
+///
+/// Visualize as a tent of influence, starting at lower, peaking at peak,
+/// and dropping off to zero at upper.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+struct Tent {
+    lower: NormalizedCoord,
+    peak: NormalizedCoord,
+    upper: NormalizedCoord,
+}
+
+impl Tent {
+    fn new(mut lower: NormalizedCoord, peak: NormalizedCoord, mut upper: NormalizedCoord) -> Self {
+        let zero = NormalizedCoord::new(0.0);
+        if peak > zero {
+            lower = zero;
+        } else {
+            upper = zero;
+        }
+        Tent { lower, peak, upper }
+    }
+}
+
+impl Tent {
+    /// OT-specific validation of whether we could have any influence
+    ///
+    /// (0,0,0) IS valid, meaning apply my deltas at full scale always
+    ///
+    /// <https://github.com/fonttools/fonttools/blob/2f1f5e5e7be331d960a0e30d537c2b4c70d89285/Lib/fontTools/varLib/models.py#L162>
+    fn validate(&self) -> bool {
+        let lower = self.lower.into_inner();
+        let peak = self.peak.into_inner();
+        let upper = self.upper.into_inner();
+
+        if lower > peak || peak > upper {
+            return false;
+        }
+        // In fonts the influence at zero must be zero so we cannot span zero
+        if lower < ZERO && upper > ZERO {
+            return false;
+        }
+        true
+    }
+}
+
+impl Debug for Tent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{self}"))
+    }
+}
+
+impl Display for Tent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let comment = if self.validate() { "" } else { " (invalid)" };
+        f.write_fmt(format_args!(
+            "Tent {{{}, {}, {}{}}}",
+            self.lower.into_inner(),
+            self.peak.into_inner(),
+            self.upper.into_inner(),
+            comment
+        ))?;
+        Ok(())
+    }
+}
+
+/// Split space into regions.
+///
+/// VariationModel::_locationsToRegions in Python.
+/// <https://github.com/fonttools/fonttools/blob/2f1f5e5e7be331d960a0e30d537c2b4c70d89285/Lib/fontTools/varLib/models.py#L416>
+fn regions_for(locations: &[NormalizedLocation]) -> Vec<VariationRegion> {
+    let mut minmax = HashMap::<&String, (NormalizedCoord, NormalizedCoord)>::new();
+    for location in locations.iter() {
+        for (axis, value) in location.iter() {
+            let (min, max) = minmax
+                .entry(axis)
+                .or_insert_with(|| (NormalizedCoord::new(0.0), NormalizedCoord::new(0.0)));
+            if value < min {
+                *min = *value;
+            }
+            if value > max {
+                *max = *value;
+            }
+        }
+    }
+
+    locations
+        .iter()
+        .map(|location| {
+            let mut region = VariationRegion::new();
+            for (axis, value) in location.iter() {
+                // Python just scrubs 0's out of the location's. We elect to store representative tents.
+                let (min, max) = if value.into_inner() == ZERO {
+                    (NormalizedCoord::new(ZERO), NormalizedCoord::new(ZERO))
+                } else {
+                    *minmax.get(axis).unwrap()
+                };
+                region.0.insert(axis.clone(), Tent::new(min, *value, max));
+            }
+            region
+        })
+        .collect()
+}
+
+/// Compute the influence of each master, if any, on each region.
+///
+/// The regions must have been sorted by the [LocationSortingHat] as this ensures
+/// that for each region we only need to look at preceeding regions for overlaps.
+///
+/// VariationModel::_computeMasterSupports in Python.
+/// <https://github.com/fonttools/fonttools/blob/2f1f5e5e7be331d960a0e30d537c2b4c70d89285/Lib/fontTools/varLib/models.py#L360>
+fn master_influence(regions: Vec<VariationRegion>) -> Vec<VariationRegion> {
+    let mut influence = Vec::new();
+    for (i, region) in regions.iter().enumerate() {
+        let axes: HashSet<&String> = region.0.keys().collect();
+        let mut region = region.clone();
+        for prev_region in regions[..i].iter() {
+            if axes != prev_region.0.keys().collect() {
+                continue;
+            }
+            // If prev doesn't overlap current we aren't interested
+            let overlap = region.0.iter().all(|(axis, axis_region)| {
+                let prev_peak = prev_region.0[axis].peak;
+                prev_peak == axis_region.peak
+                    || (axis_region.lower < prev_peak && prev_peak < axis_region.upper)
+            });
+            if !overlap {
+                continue;
+            }
+
+            // As in Python version, split the box for the new master in the direction with the
+            // largest range ratio. Cut across multiple axes if they have the largest equal ratio.
+            // https://github.com/fonttools/fonttools/commit/7ee81c8821671157968b097f3e55309a1faa511e#commitcomment-31054804
+            let mut axis_regions: HashMap<&String, Tent> = HashMap::new();
+            let mut best_ratio = OrderedFloat(-1.0);
+            for axis in axes.iter() {
+                let prev_peak = prev_region.0[*axis].peak;
+                let mut axis_region = region.0[*axis].clone();
+                let ratio;
+                match prev_peak.cmp(&axis_region.peak) {
+                    Ordering::Less => {
+                        ratio = (prev_peak - axis_region.peak).into_inner()
+                            / (axis_region.lower - axis_region.peak).into_inner();
+                        axis_region.lower = prev_peak;
+                    }
+                    Ordering::Greater => {
+                        ratio = (prev_peak - axis_region.peak).into_inner()
+                            / (axis_region.upper - axis_region.peak).into_inner();
+                        axis_region.upper = prev_peak;
+                    }
+                    Ordering::Equal => continue, // can't split in this direction
+                }
+                if ratio > best_ratio {
+                    axis_regions.clear();
+                    best_ratio = ratio;
+                }
+                if ratio == best_ratio {
+                    axis_regions.insert(axis, axis_region);
+                }
+            }
+            for (axis, axis_region) in axis_regions {
+                region.0.insert(axis.to_owned(), axis_region);
+            }
+        }
+        influence.push(region);
+    }
+    influence
+}
+
+/// Figure out the multipliers to use when applying for deltas from masters.
+///
+/// VariationModel::_computeDeltaWeights in Python.
+/// <https://github.com/fonttools/fonttools/blob/2f1f5e5e7be331d960a0e30d537c2b4c70d89285/Lib/fontTools/varLib/models.py#L438>
+fn delta_weights(
+    locations: &[NormalizedLocation],
+    influencers: &[VariationRegion],
+) -> Vec<Vec<(usize, OrderedFloat<f32>)>> {
+    if log_enabled!(log::Level::Trace) {
+        for (l, i) in locations.iter().zip(influencers) {
+            trace!("{:?}", l);
+            for (axis_name, tent) in i.0.iter() {
+                trace!("  {} {}", axis_name, tent);
+            }
+        }
+    }
+    trace!("Delta Weights");
+    let mut weights = Vec::new();
+    for (loc_idx, location) in locations.iter().enumerate() {
+        weights.push(
+            influencers[..loc_idx]
+                .iter()
+                .enumerate()
+                .filter_map(|(inf_idx, influence)| {
+                    let scalar = influence.scalar_at(location);
+                    if scalar == ZERO {
+                        trace!(
+                            "  no influence: {} {:?} at {:?}",
+                            inf_idx,
+                            influence,
+                            location
+                        );
+                        return None;
+                    }
+                    Some((inf_idx, scalar))
+                })
+                .collect(),
+        );
+        trace!("  {} {:?}", loc_idx, weights.last().unwrap());
+    }
+    weights
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use ordered_float::OrderedFloat;
+
+    use crate::{
+        coords::{NormalizedCoord, NormalizedLocation},
+        variations::{Tent, ONE},
+    };
+
+    use super::{VariationModel, VariationRegion};
+
+    fn norm_loc(positions: &[(&str, f32)]) -> NormalizedLocation {
+        let mut loc = NormalizedLocation::new();
+        for (axis, value) in positions {
+            loc.set_pos(axis.to_owned(), NormalizedCoord::new(*value));
+        }
+        loc
+    }
+
+    fn tent(lower: f32, peak: f32, upper: f32) -> Tent {
+        Tent {
+            lower: NormalizedCoord::new(lower),
+            peak: NormalizedCoord::new(peak),
+            upper: NormalizedCoord::new(upper),
+        }
+    }
+
+    fn default_master_weight() -> Vec<(usize, OrderedFloat<f32>)> {
+        // no locations are contributing deltas
+        Vec::new()
+    }
+
+    /// Python
+    /// >>> supportScalar({}, {})
+    /// 1.0
+    #[test]
+    fn scalar_at_default_for_default() {
+        let loc = NormalizedLocation::new();
+        assert_eq!(ONE, VariationRegion::new().scalar_at(&loc));
+    }
+
+    /// Python
+    /// >>> supportScalar({'wght':.2}, {})
+    /// 1.0
+    #[test]
+    fn scalar_at_off_default_for_default() {
+        let loc = norm_loc(&[("Weight", 0.2)]);
+        assert_eq!(ONE, VariationRegion::new().scalar_at(&loc));
+    }
+
+    /// Python
+    /// >>> supportScalar({'wght':.2}, {'wght':(0,2,3)})
+    /// 0.1
+    #[test]
+    fn scalar_at_off_default_for_simple_weight() {
+        let loc = norm_loc(&[("Weight", 0.2)]);
+        let mut region = VariationRegion::new();
+        region.0.insert("Weight".to_string(), tent(0.0, 2.0, 3.0));
+        assert_eq!(OrderedFloat(0.1), region.scalar_at(&loc));
+    }
+
+    /// Python
+    /// >>> supportScalar({'wght':2.5}, {'wght':(0,2,4)})
+    /// 0.75
+    #[test]
+    fn scalar_at_for_weight() {
+        let loc = norm_loc(&[("Weight", 2.5)]);
+        let mut region = VariationRegion::new();
+        region.0.insert("Weight".to_string(), tent(0.0, 2.0, 4.0));
+        assert_eq!(OrderedFloat(0.75), region.scalar_at(&loc));
+    }
+
+    /// Python
+    /// >>> supportScalar({'wght':2.5, 'wdth':0}, {'wght':(0,2,4), 'wdth':(-1,0,+1)})
+    /// 0.75
+    /// Note that under font rules a peak of 0 means no influence
+    #[test]
+    fn scalar_at_for_weight_width_fixup() {
+        let loc = norm_loc(&[("Weight", 2.5), ("Width", 0.0)]);
+        let mut region = VariationRegion::new();
+        region.0.insert("Weight".to_string(), tent(0.0, 2.0, 4.0));
+        region.0.insert("Width".to_string(), tent(-1.0, 0.0, 1.0));
+        assert_eq!(OrderedFloat(0.75), region.scalar_at(&loc));
+    }
+
+    /// Python
+    /// >>> supportScalar({'wght':1, 'wdth':1}, {'wght':(0, 1, 1)})
+    /// 1.0
+    #[test]
+    fn scalar_at_for_weight_width_corner() {
+        let loc = norm_loc(&[("Weight", 1.0), ("Width", 1.0)]);
+        let mut region = VariationRegion::new();
+        region.0.insert("Weight".to_string(), tent(0.0, 1.0, 1.0));
+        assert_eq!(OrderedFloat(1.0), region.scalar_at(&loc));
+    }
+
+    /// >>> models.VariationModel([{'wght':0}]).locations
+    /// [{}]
+    /// >>> pprint(models.VariationModel([{'wght':0}]).deltaWeights)
+    /// [{}]    
+    #[test]
+    fn delta_weights_for_static_family_one_axis() {
+        let loc = NormalizedLocation::new();
+        let locations = HashSet::from([loc]);
+        let axis_order = vec!["Weight".to_string()];
+        let model = VariationModel::new(locations, axis_order).unwrap();
+
+        assert_eq!(vec![norm_loc(&[("Weight", 0.0)])], model.locations);
+        assert_eq!(vec![default_master_weight()], model.delta_weights);
+    }
+
+    /// >>> models.VariationModel([{'wght':0, 'ital': 0, 'wdth': 0}]).locations
+    /// [{}]
+    /// >>> pprint(models.VariationModel([{'wght':0, 'ital': 0, 'wdth': 0}]).deltaWeights)
+    /// [{}]
+    #[test]
+    fn delta_weights_for_static_family_many_axes() {
+        let loc = norm_loc(&[("Weight", 0.0), ("Italic", 0.0), ("Width", 0.0)]);
+        let locations = HashSet::from([loc.clone()]);
+        let axis_order = vec![
+            "Width".to_string(),
+            "Weight".to_string(),
+            "Italic".to_string(),
+        ];
+        let model = VariationModel::new(locations, axis_order).unwrap();
+
+        assert_eq!(vec![loc], model.locations);
+        assert_eq!(vec![default_master_weight()], model.delta_weights);
+    }
+
+    /// # two-master weight family
+    /// >>> models.VariationModel([{'wght':0}, {'wght': 1}]).locations
+    /// [{}, {'wght': 1}]
+    /// >>> pprint(models.VariationModel([{'wght':0}, {'wght': 1}]).deltaWeights)
+    /// [{}, {0: 1.0}]
+    #[test]
+    fn delta_weights_for_2_master_weight_variable_family() {
+        let weight_0 = norm_loc(&[("Weight", 0.0)]);
+        let weight_1 = norm_loc(&[("Weight", 1.0)]);
+        let locations = HashSet::from([weight_1.clone(), weight_0.clone()]);
+        let axis_order = vec!["Weight".to_string()];
+        let model = VariationModel::new(locations, axis_order).unwrap();
+
+        assert_eq!(vec![weight_0, weight_1], model.locations);
+        assert_eq!(
+            vec![default_master_weight(), vec![(0_usize, OrderedFloat(1.0))]],
+            model.delta_weights
+        );
+    }
+
+    /// # three-master weight family
+    /// >>> models.VariationModel([{'wght':-1}, {'wght': 0}, {'wght': 1}]).locations
+    /// [{}, {'wght': -1}, {'wght': 1}]
+    /// >>> models.VariationModel([{'wght':-1}, {'wght': 0}, {'wght': 1}]).deltaWeights
+    /// [{}, {0: 1.0}, {0: 1.0}]    
+    #[test]
+    fn delta_weights_for_3_master_weight_variable_family() {
+        let weight_minus_1 = norm_loc(&[("Weight", -1.0)]);
+        let weight_0 = norm_loc(&[("Weight", 0.0)]);
+        let weight_1 = norm_loc(&[("Weight", 1.0)]);
+        let locations = HashSet::from([weight_1.clone(), weight_0.clone(), weight_minus_1.clone()]);
+        let axis_order = vec!["Weight".to_string()];
+        let model = VariationModel::new(locations, axis_order).unwrap();
+
+        assert_eq!(vec![weight_0, weight_minus_1, weight_1], model.locations);
+        assert_eq!(
+            vec![
+                default_master_weight(),
+                vec![(0_usize, OrderedFloat(1.0))],
+                vec![(0_usize, OrderedFloat(1.0))]
+            ],
+            model.delta_weights
+        );
+    }
+
+    /// # corner-master weight + width
+    /// >>> models.VariationModel([{'wght':0, 'wdth': 0}, {'wght':1, 'wdth': 0}, {'wght':0, 'wdth': 1}, {'wght':1, 'wdth': 1}]).locations
+    /// [{}, {'wdth': 1}, {'wght': 1}, {'wght': 1, 'wdth': 1}]
+    /// >>> models.VariationModel([{'wght':0, 'wdth': 0}, {'wght':1, 'wdth': 0}, {'wght':0, 'wdth': 1}, {'wght':1, 'wdth': 1}]).deltaWeights
+    /// [{}, {0: 1.0}, {0: 1.0}, {0: 1.0, 1: 1.0, 2: 1.0}]
+    #[test]
+    fn delta_weights_for_corner_master_weight_width_family() {
+        let wght0_wdth0 = norm_loc(&[("Weight", 0.0), ("Width", 0.0)]);
+        let wght0_wdth1 = norm_loc(&[("Weight", 0.0), ("Width", 1.0)]);
+        let wght1_wdth0 = norm_loc(&[("Weight", 1.0), ("Width", 0.0)]);
+        let wght1_wdth1 = norm_loc(&[("Weight", 1.0), ("Width", 1.0)]);
+        let locations = HashSet::from([
+            wght0_wdth0.clone(),
+            wght0_wdth1.clone(),
+            wght1_wdth0.clone(),
+            wght1_wdth1.clone(),
+        ]);
+        let axis_order = vec!["Weight".to_string(), "Width".to_string()];
+        let model = VariationModel::new(locations, axis_order).unwrap();
+
+        assert_eq!(
+            vec![wght0_wdth0, wght1_wdth0, wght0_wdth1, wght1_wdth1],
+            model.locations
+        );
+        assert_eq!(
+            vec![
+                default_master_weight(),
+                vec![(0_usize, OrderedFloat(1.0))],
+                vec![(0_usize, OrderedFloat(1.0))],
+                vec![
+                    (0_usize, OrderedFloat(1.0)),
+                    (1_usize, OrderedFloat(1.0)),
+                    (2_usize, OrderedFloat(1.0))
+                ],
+            ],
+            model.delta_weights
+        );
+    }
+
+    /// # corner-master weight + width rig with a default master and a fixup
+    /// >>> models.VariationModel([{'wght':0, 'wdth': 0}, {'wght':-1, 'wdth': -1}, {'wght':-1, 'wdth': 1}, {'wght':1, 'wdth': -1}, {'wght':1, 'wdth': 1}, {'wght':0.5, 'wdth': 0.5}], axisOrder=['wght', 'wdth']).locations
+    /// [{}, {'wght': -1, 'wdth': -1}, {'wght': -1, 'wdth': 1}, {'wght': 1, 'wdth': -1}, {'wght': 0.5, 'wdth': 0.5}, {'wght': 1, 'wdth': 1}]
+    /// >>> models.VariationModel([{'wght':0, 'wdth': 0}, {'wght':-1, 'wdth': -1}, {'wght':-1, 'wdth': 1}, {'wght':1, 'wdth': -1}, {'wght':1, 'wdth': 1}, {'wght':0.5, 'wdth': 0.5}], axisOrder=['wght', 'wdth']).deltaWeights
+    /// [{}, {0: 1.0}, {0: 1.0}, {0: 1.0}, {0: 1.0}, {0: 1.0}]
+    #[test]
+    fn delta_weights_for_corner_default_and_fixup_master_weight_width_family() {
+        let default_master = norm_loc(&[("Weight", 0.0), ("Width", 0.0)]);
+        let min_wght_min_wdth = norm_loc(&[("Weight", -1.0), ("Width", -1.0)]);
+        let min_wght_max_wdth = norm_loc(&[("Weight", -1.0), ("Width", 1.0)]);
+        let max_wght_min_wdth = norm_loc(&[("Weight", 1.0), ("Width", -1.0)]);
+        let max_wght_max_wdth = norm_loc(&[("Weight", 1.0), ("Width", 1.0)]);
+        let fixup = norm_loc(&[("Weight", 0.5), ("Width", 0.5)]);
+        let locations = HashSet::from([
+            // Default master
+            default_master.clone(),
+            // Corners: the far ends of each axis
+            max_wght_max_wdth.clone(),
+            max_wght_min_wdth.clone(),
+            min_wght_max_wdth.clone(),
+            min_wght_min_wdth.clone(),
+            // A fixup or knockout
+            fixup.clone(),
+        ]);
+        let axis_order = vec!["Weight".to_string(), "Width".to_string()];
+        let model = VariationModel::new(locations, axis_order).unwrap();
+
+        assert_eq!(
+            vec![
+                default_master,
+                min_wght_min_wdth,
+                min_wght_max_wdth,
+                max_wght_min_wdth,
+                fixup,
+                max_wght_max_wdth
+            ],
+            model.locations
+        );
+        assert_eq!(
+            vec![
+                default_master_weight(),
+                vec![(0_usize, OrderedFloat(1.0))],
+                vec![(0_usize, OrderedFloat(1.0))],
+                vec![(0_usize, OrderedFloat(1.0))],
+                vec![(0_usize, OrderedFloat(1.0))],
+                vec![(0_usize, OrderedFloat(1.0))],
+            ],
+            model.delta_weights
+        );
+    }
+}

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -243,7 +243,7 @@ impl FromPlist for Node {
             }
             Plist::Array(value) => {
                 if value.len() != 3 {
-                    panic!("Invalid node content {:?}", plist);
+                    panic!("Invalid node content {plist:?}");
                 };
                 let x = value[0].as_f64().unwrap();
                 let y = value[1].as_f64().unwrap();
@@ -252,7 +252,7 @@ impl FromPlist for Node {
                 Node { pt, node_type }
             }
             _ => {
-                panic!("Invalid node content {:?}", plist);
+                panic!("Invalid node content {plist:?}");
             }
         }
     }
@@ -274,7 +274,7 @@ impl std::str::FromStr for NodeType {
             "o" => Ok(NodeType::OffCurve),
             "c" => Ok(NodeType::Curve),
             "cs" => Ok(NodeType::CurveSmooth),
-            _ => Err(format!("unknown node type {}", s)),
+            _ => Err(format!("unknown node type {s}")),
         }
     }
 }
@@ -282,7 +282,7 @@ impl std::str::FromStr for NodeType {
 fn try_f64(plist: &Plist) -> Result<f64, Error> {
     plist
         .as_f64()
-        .ok_or_else(|| Error::StructuralError(format!("Bad f64:{:?}", plist)))
+        .ok_or_else(|| Error::StructuralError(format!("Bad f64:{plist:?}")))
 }
 
 impl TryFrom<BTreeMap<String, Plist>> for Component {
@@ -296,8 +296,7 @@ impl TryFrom<BTreeMap<String, Plist>> for Component {
             glyph_name
         } else {
             return Err(Error::StructuralError(format!(
-                "Neither ref nor name present: {:?}",
-                dict
+                "Neither ref nor name present: {dict:?}"
             )));
         };
 
@@ -316,7 +315,7 @@ impl TryFrom<BTreeMap<String, Plist>> for Component {
         // Translate
         if let Some(Plist::Array(pos)) = dict.remove("pos") {
             if pos.len() != 2 {
-                return Err(Error::StructuralError(format!("Bad pos: {:?}", pos)));
+                return Err(Error::StructuralError(format!("Bad pos: {pos:?}")));
             }
             transform *= Affine::translate((try_f64(&pos[0])?, try_f64(&pos[1])?));
         }
@@ -329,7 +328,7 @@ impl TryFrom<BTreeMap<String, Plist>> for Component {
         // Scale
         if let Some(Plist::Array(scale)) = dict.remove("scale") {
             if scale.len() != 2 {
-                return Err(Error::StructuralError(format!("Bad scale: {:?}", scale)));
+                return Err(Error::StructuralError(format!("Bad scale: {scale:?}")));
             }
             transform *= Affine::scale_non_uniform(try_f64(&scale[0])?, try_f64(&scale[1])?);
         }
@@ -345,7 +344,7 @@ impl TryFrom<BTreeMap<String, Plist>> for Component {
 impl FromPlist for Component {
     fn from_plist(plist: Plist) -> Self {
         let Plist::Dictionary(dict) = plist else {
-            panic!("Component must be a dict: {:?}", plist);
+            panic!("Component must be a dict: {plist:?}");
         };
         dict.try_into().expect("Unable to parse Component")
     }
@@ -485,8 +484,7 @@ fn glyphs_v2_field_name_and_default(nth_axis: usize) -> Result<(&'static str, f6
         2 => ("customValue", 0_f64),
         _ => {
             return Err(Error::StructuralError(format!(
-                "We don't know what field to use for axis {}",
-                nth_axis
+                "We don't know what field to use for axis {nth_axis}"
             )))
         }
     })
@@ -805,15 +803,15 @@ fn user_to_design_from_axis_mapping(
         return None;
     };
     let Plist::Dictionary(axis_map) = axis_map.get("value").unwrap() else {
-        panic!("Incomprehensible axis map {:?}", axis_map);
+        panic!("Incomprehensible axis map {axis_map:?}");
     };
     let mut axis_mappings: BTreeMap<String, RawUserToDesignMapping> = BTreeMap::new();
     for (axis_tag, mappings) in axis_map.iter() {
         let Plist::Dictionary(mappings) = mappings else {
-            panic!("Incomprehensible mappings {:?}", mappings);
+            panic!("Incomprehensible mappings {mappings:?}");
         };
         let Some(axis_index) = axis_index(from, |a| &a.tag == axis_tag) else {
-            panic!("No such axes: {:?}", axis_tag);
+            panic!("No such axes: {axis_tag:?}");
         };
         // We could not have found an axis index if there are no axes
         let axis_name = &from.axes.as_ref().unwrap().get(axis_index).unwrap().name;
@@ -853,26 +851,26 @@ fn user_to_design_from_axis_location(
     let mut axis_mappings: BTreeMap<String, RawUserToDesignMapping> = BTreeMap::new();
     for (master, axis_locations) in from.font_master.iter().zip(&master_locations) {
         let Plist::Dictionary(axis_locations) = axis_locations else {
-            panic!("Axis Location must be a dict {:?}", axis_locations);
+            panic!("Axis Location must be a dict {axis_locations:?}");
         };
         let Some(Plist::Array(axis_locations)) = axis_locations.get("value") else {
-            panic!("Value must be a dict {:?}", axis_locations);
+            panic!("Value must be a dict {axis_locations:?}");
         };
         for axis_location in axis_locations {
             let Some(Plist::String(axis_name)) = axis_location.get("Axis") else {
-                panic!("Axis name must be a string {:?}", axis_location);
+                panic!("Axis name must be a string {axis_location:?}");
             };
             let Some(user) = axis_location.get("Location") else {
-                panic!("Incomprehensible axis location {:?}", axis_location);
+                panic!("Incomprehensible axis location {axis_location:?}");
             };
             let Some(user) = user.as_f64() else {
-                panic!("Incomprehensible axis location {:?}", axis_location);
+                panic!("Incomprehensible axis location {axis_location:?}");
             };
             let Some(axis_index) = axis_index(from, |a| &a.name == axis_name) else {
-                panic!("Axis has no index {:?}", axis_location);
+                panic!("Axis has no index {axis_location:?}");
             };
             let Some(axis_values) = master.axes_values.as_ref() else {
-                panic!("Master has no axis values {:?}", master);
+                panic!("Master has no axis values {master:?}");
             };
             let user = user as f32;
             let design = axis_values[axis_index].into_inner() as f32;
@@ -985,8 +983,7 @@ impl RawFeature {
             (Some(name), _) => Ok(name.clone()),
             (None, Some(tag)) => Ok(tag.clone()),
             (None, None) => Err(Error::StructuralError(format!(
-                "{:?} missing name and tag",
-                self
+                "{self:?} missing name and tag"
             ))),
         }
     }
@@ -1088,7 +1085,7 @@ impl Font {
         let raw_content = re.replace_all(&raw_content, r#"$prefix"$value";"#);
 
         let mut raw_content = Plist::parse(&raw_content)
-            .map_err(|e| Error::ParseError(glyphs_file.to_path_buf(), format!("{:#?}", e)))?;
+            .map_err(|e| Error::ParseError(glyphs_file.to_path_buf(), format!("{e:#?}")))?;
 
         // Fix any issues with the raw plist
         let Plist::Dictionary(ref mut root_dict) = raw_content else {
@@ -1238,10 +1235,10 @@ mod tests {
         let g3_shape = only_shape_in_only_layer(&g3, glyph_name);
 
         let Shape::Component(g2_shape) = g2_shape else {
-            panic!("{:?} should be a component", g2_shape);
+            panic!("{g2_shape:?} should be a component");
         };
         let Shape::Component(g3_shape) = g3_shape else {
-            panic!("{:?} should be a component", g3_shape);
+            panic!("{g3_shape:?} should be a component");
         };
 
         assert_eq!(expected, round(g2_shape.transform, 4));

--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -283,10 +283,10 @@ impl Plist {
             }
             Plist::String(st) => escape_string(s, st),
             Plist::Integer(i) => {
-                s.push_str(&format!("{}", i));
+                s.push_str(&format!("{i}"));
             }
             Plist::Float(f) => {
-                s.push_str(&format!("{}", f));
+                s.push_str(&format!("{f}"));
             }
         }
     }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -104,7 +104,7 @@ impl Source for GlyphsIrSource {
         let font_info = FontInfo::try_from(Font::load(&self.glyphs_file).map_err(|e| {
             Error::ParseError(
                 self.glyphs_file.clone(),
-                format!("Unable to read glyphs file: {}", e),
+                format!("Unable to read glyphs file: {e}"),
             )
         })?)?;
         let font = &font_info.font;

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -77,9 +77,9 @@ impl Cache {
     }
 }
 
-fn glif_files<'a>(
+fn glif_files(
     ufo_dir: &Path,
-    layer_cache: &'a mut HashMap<String, HashMap<GlyphName, PathBuf>>,
+    layer_cache: &mut HashMap<String, HashMap<GlyphName, PathBuf>>,
     source: &designspace::Source,
 ) -> Result<BTreeMap<GlyphName, PathBuf>, Error> {
     let layer_name = layer_dir(ufo_dir, layer_cache, source)?;
@@ -389,7 +389,7 @@ fn load_lib_plist(ufo_dir: &Path) -> Result<plist::Dictionary, WorkError> {
         return Err(WorkError::FileExpected(lib_plist_file));
     }
     plist::Value::from_file(&lib_plist_file)
-        .map_err(|e| WorkError::ParseError(lib_plist_file.clone(), format!("{}", e)))?
+        .map_err(|e| WorkError::ParseError(lib_plist_file.clone(), format!("{e}")))?
         .into_dictionary()
         .ok_or_else(|| WorkError::ParseError(lib_plist_file, "Not a dictionary".to_string()))
 }

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -123,7 +123,7 @@ pub fn to_ir_glyph(
         let norad_glyph =
             norad::Glyph::load(glif_file).map_err(|e| WorkError::InvalidSourceGlyph {
                 glyph_name: glyph.name.clone(),
-                message: format!("glif load failed due to {}", e),
+                message: format!("glif load failed due to {e}"),
             })?;
         for location in locations {
             glyph.try_add_source(location, to_ir_glyph_instance(&norad_glyph)?)?;


### PR DESCRIPTION
Partial (as far as delta weights) https://github.com/fonttools/fonttools/blob/2f1f5e5e7be331d960a0e30d537c2b4c70d89285/Lib/fontTools/varLib/models.py in Rust. Meant to be used when compiling an IR Glyph (set of outlines at positions in designspace) to binary glyf + gvar.

Comments based on reading the code plus pestering @behdad. Anything helpful is probably his, the errors are mine :)

The three independent parallel vec's don't feel great to me, would like to think more about that. I'd like to land this very close to Python then refine from there.

Built on #118 to avoid noise from clippy; merge that first.