### PR TITLE
Store a VariationModel in StaticMetadata

### DIFF
--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -99,6 +99,8 @@ pub enum WorkError {
     },
     #[error("Path conversion error")]
     PathConversionError(#[from] PathConversionError),
+    #[error("Variation model error")]
+    VariationModelError(#[from] VariationModelError),
 }
 
 /// An async work error, hence one that must be Send

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -23,8 +23,13 @@ use std::{
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(from = "StaticMetadataSerdeRepr", into = "StaticMetadataSerdeRepr")]
 pub struct StaticMetadata {
+    /// Every axis used by the font being compiled
     pub axes: Vec<Axis>,
+    /// The name of every glyph, in the order it will be emitted
+    ///
+    /// <https://rsheeter.github.io/font101/#glyph-ids-and-the-cmap-table>
     pub glyph_order: IndexSet<GlyphName>,
+    /// A model of how the space defined by [Self::axes] is split into regions that have deltas.
     pub variation_model: VariationModel,
 }
 

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -30,6 +30,10 @@ pub struct StaticMetadata {
     /// <https://rsheeter.github.io/font101/#glyph-ids-and-the-cmap-table>
     pub glyph_order: IndexSet<GlyphName>,
     /// A model of how the space defined by [Self::axes] is split into regions that have deltas.
+    ///
+    /// This copy includes all locations used in the entire font. Users, such as glyph BE, may wish
+    /// to narrow (submodel in FontTools terms) to the set of locations they actually use. Use of a
+    /// location not in the global model is an error.
     pub variation_model: VariationModel,
 }
 

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     coords::{CoordConverter, NormalizedLocation, UserCoord},
-    error::{PathConversionError, WorkError},
+    error::{PathConversionError, VariationModelError, WorkError},
     serde::{GlyphSerdeRepr, StaticMetadataSerdeRepr},
     variations::VariationModel,
 };
@@ -11,7 +11,7 @@ use indexmap::IndexSet;
 use kurbo::{Affine, BezPath, Point};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt::Debug,
     path::{Path, PathBuf},
 };
@@ -29,12 +29,18 @@ pub struct StaticMetadata {
 }
 
 impl StaticMetadata {
-    pub fn new(axes: Vec<Axis>, glyph_order: IndexSet<GlyphName>) -> StaticMetadata {
-        StaticMetadata {
+    pub fn new(
+        axes: Vec<Axis>,
+        glyph_order: IndexSet<GlyphName>,
+        glyph_locations: HashSet<NormalizedLocation>,
+    ) -> Result<StaticMetadata, VariationModelError> {
+        let axis_names = axes.iter().map(|a| a.name.clone()).collect();
+        let variation_model = VariationModel::new(glyph_locations, axis_names)?;
+        Ok(StaticMetadata {
             axes,
             glyph_order,
-            variation_model: VariationModel::empty(),
-        }
+            variation_model,
+        })
     }
 }
 

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -46,6 +46,7 @@ impl From<CoordConverter> for CoordConverterSerdeRepr {
 pub struct StaticMetadataSerdeRepr {
     pub axes: Vec<Axis>,
     pub glyph_order: Vec<String>,
+    pub glyph_locations: Vec<NormalizedLocation>,
 }
 
 impl From<StaticMetadataSerdeRepr> for StaticMetadata {
@@ -53,7 +54,9 @@ impl From<StaticMetadataSerdeRepr> for StaticMetadata {
         StaticMetadata::new(
             from.axes,
             from.glyph_order.into_iter().map(|s| s.into()).collect(),
+            from.glyph_locations.into_iter().collect(),
         )
+        .unwrap()
     }
 }
 
@@ -66,6 +69,7 @@ impl From<StaticMetadata> for StaticMetadataSerdeRepr {
                 .into_iter()
                 .map(|n| n.as_str().to_string())
                 .collect(),
+            glyph_locations: from.variation_model.locations().cloned().collect(),
         }
     }
 }

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -97,6 +97,10 @@ impl VariationModel {
             delta_weights: Vec::new(),
         }
     }
+
+    pub fn locations(&self) -> impl Iterator<Item = &NormalizedLocation> {
+        self.locations.iter()
+    }
 }
 
 /// Gryffindor!

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -182,10 +182,13 @@ impl Work<Context, WorkError> for StaticMetadataWork {
         let font_info = self.font_info.as_ref();
         let font = &font_info.font;
         debug!("Static metadata for {}", font.family_name);
-        context.set_static_metadata(StaticMetadata::new(
-            font_info.axes.clone(),
-            font.glyph_order.iter().map(|s| s.into()).collect(),
-        ));
+        let axes = font_info.axes.clone();
+        let glyph_locations = font_info.master_locations.values().cloned().collect();
+        let glyph_order = font.glyph_order.iter().map(|s| s.into()).collect();
+        context.set_static_metadata(
+            StaticMetadata::new(axes, glyph_order, glyph_locations)
+                .map_err(WorkError::VariationModelError)?,
+        );
         Ok(())
     }
 }

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use fontdrasil::types::GlyphName;
@@ -75,6 +75,21 @@ fn to_ir_glyph_instance(glyph: &norad::Glyph) -> Result<ir::GlyphInstance, WorkE
         contours,
         components: glyph.components.iter().map(to_ir_component).collect(),
     })
+}
+
+pub fn to_normalized_locations(
+    axes: &[ir::Axis],
+    sources: &[designspace::Source],
+) -> HashSet<NormalizedLocation> {
+    let axes = axes.iter().map(|a| (&a.name, a)).collect();
+    sources
+        .iter()
+        .map(|s| to_design_location(&s.location).to_normalized(&axes))
+        .collect()
+}
+
+pub fn to_ir_axes(axes: &[designspace::Axis]) -> Vec<ir::Axis> {
+    axes.iter().map(to_ir_axis).collect()
 }
 
 pub fn to_ir_axis(axis: &designspace::Axis) -> ir::Axis {


### PR DESCRIPTION
Building on #117, construct and retain a variation model along with static metadata. For example, Lexend produces

```yml
glyph_locations:
- Hyper Expansion: 0.0
  Weight: 0.0
- Hyper Expansion: 0.0
  Weight: 0.14432989
- Hyper Expansion: 0.0
  Weight: 0.44329897
- Hyper Expansion: 0.0
  Weight: 1.0
- Hyper Expansion: 1.0
  Weight: 0.0
- Hyper Expansion: 1.0
  Weight: 0.44329897
- Hyper Expansion: 1.0
  Weight: 1.0
```