### PR TITLE
Add a phase that eliminates mixed contour+component glyphs; legal in source but not binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [patch.crates-io]
-read-fonts = { git="https://github.com/googlefonts/fontations.git" }
-write-fonts = { git="https://github.com/googlefonts/fontations.git" }
+read-fonts = { git="https://github.com/googlefonts/fontations.git", branch="pathel" }
+write-fonts = { git="https://github.com/googlefonts/fontations.git", branch="pathel" }
 
 [workspace]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,3 @@
-[patch.crates-io]
-read-fonts = { git="https://github.com/googlefonts/fontations.git", branch="pathel" }
-write-fonts = { git="https://github.com/googlefonts/fontations.git", branch="pathel" }
-
 [workspace]
 
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[patch.crates-io]
+read-fonts = { git="https://github.com/googlefonts/fontations.git", branch="glyf" }
+write-fonts = { git="https://github.com/googlefonts/fontations.git", branch="glyf" }
+
 [workspace]
 
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [patch.crates-io]
-read-fonts = { git="https://github.com/googlefonts/fontations.git", branch="glyf" }
-write-fonts = { git="https://github.com/googlefonts/fontations.git", branch="glyf" }
+read-fonts = { git="https://github.com/googlefonts/fontations.git" }
+write-fonts = { git="https://github.com/googlefonts/fontations.git" }
 
 [workspace]
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -26,9 +26,10 @@ env_logger = "0.9.0"
 
 parking_lot = "0.12.1"
 
-read-fonts = "0.0.5"
-write-fonts = "0.0.5"
-fea-rs = "0.2.0"
+read-fonts = "0.1.0"
+write-fonts = "0.1.0"
+
+fea-rs = "0.3.0"
 smol_str = "0.1.18"
 
 [dev-dependencies]

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -11,7 +11,7 @@ use fea_rs::{
     parse::{SourceLoadError, SourceResolver},
     Compiler, GlyphMap, GlyphName as FeaRsGlyphName,
 };
-use fontir::ir::Features;
+use fontir::{ir::Features, orchestration::Flags};
 use log::{debug, error, trace, warn};
 use write_fonts::FontBuilder;
 
@@ -129,7 +129,7 @@ impl Work<Context, Error> for FeatureWork {
             .collect();
 
         let result = self.compile(&features, glyph_map);
-        if result.is_err() || context.emit_debug {
+        if result.is_err() || context.flags.contains(Flags::EMIT_DEBUG) {
             if let Features::Memory(fea_content) = &*features {
                 write_debug_fea(context, result.is_err(), "compile failed", fea_content);
             }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashSet, fs, path::Path, sync::Arc};
 
 use fontdrasil::{
-    orchestration::{AccessControlList, Work, MISSING_DATA},
+    orchestration::{access_one, AccessControlList, Work, MISSING_DATA},
     types::GlyphName,
 };
 use fontir::orchestration::{Context as FeContext, WorkId as FeWorkIdentifier};
@@ -113,7 +113,10 @@ impl Context {
             emit_debug: self.emit_debug,
             paths: self.paths.clone(),
             ir: self.ir.clone(),
-            acl: AccessControlList::read_write(dependencies.unwrap_or_default(), work_id.into()),
+            acl: AccessControlList::read_write(
+                dependencies.unwrap_or_default(),
+                access_one(work_id.into()),
+            ),
             features: self.features.clone(),
         }
     }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -74,6 +74,9 @@ pub struct Context {
     // If set additional debug files will be emitted to disk
     pub emit_debug: bool,
 
+    // If set seek to match fontmake (python) behavior even at cost of abandoning optimizations
+    match_legacy: bool,
+
     paths: Arc<Paths>,
 
     // The final, fully populated, read-only FE context
@@ -90,12 +93,14 @@ impl Context {
     pub fn new_root(
         emit_ir: bool,
         emit_debug: bool,
+        match_legacy: bool,
         paths: Paths,
         ir: &fontir::orchestration::Context,
     ) -> Context {
         Context {
             emit_ir,
             emit_debug,
+            match_legacy,
             paths: Arc::from(paths),
             ir: Arc::from(ir.read_only()),
             acl: AccessControlList::read_only(),
@@ -111,6 +116,7 @@ impl Context {
         Context {
             emit_ir: self.emit_ir,
             emit_debug: self.emit_debug,
+            match_legacy: self.match_legacy,
             paths: self.paths.clone(),
             ir: self.ir.clone(),
             acl: AccessControlList::read_write(

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -90,6 +90,18 @@ pub struct Context {
 }
 
 impl Context {
+    fn copy(&self, acl: AccessControlList<AnyWorkId>) -> Context {
+        Context {
+            emit_ir: self.emit_ir,
+            emit_debug: self.emit_debug,
+            match_legacy: self.match_legacy,
+            paths: self.paths.clone(),
+            ir: self.ir.clone(),
+            acl,
+            features: self.features.clone(),
+        }
+    }
+
     pub fn new_root(
         emit_ir: bool,
         emit_debug: bool,
@@ -113,18 +125,14 @@ impl Context {
         work_id: WorkId,
         dependencies: Option<HashSet<AnyWorkId>>,
     ) -> Context {
-        Context {
-            emit_ir: self.emit_ir,
-            emit_debug: self.emit_debug,
-            match_legacy: self.match_legacy,
-            paths: self.paths.clone(),
-            ir: self.ir.clone(),
-            acl: AccessControlList::read_write(
-                dependencies.unwrap_or_default(),
-                access_one(work_id.into()),
-            ),
-            features: self.features.clone(),
-        }
+        self.copy(AccessControlList::read_write(
+            dependencies.unwrap_or_default(),
+            access_one(work_id.into()),
+        ))
+    }
+
+    pub fn read_only(&self) -> Context {
+        self.copy(AccessControlList::read_only())
     }
 }
 

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -6,7 +6,7 @@ use fontdrasil::{
     orchestration::{access_one, AccessControlList, Work, MISSING_DATA},
     types::GlyphName,
 };
-use fontir::orchestration::{Context as FeContext, WorkId as FeWorkIdentifier};
+use fontir::orchestration::{Context as FeContext, Flags, WorkId as FeWorkIdentifier};
 use parking_lot::RwLock;
 use write_fonts::FontBuilder;
 
@@ -68,14 +68,7 @@ pub type BeWork = dyn Work<Context, Error> + Send;
 /// access with spawned tasks. Copies with access control are created to detect bad
 /// execution order / mistakes, not to block actual bad actors.
 pub struct Context {
-    // If set artifacts prior to final binary will be emitted to disk when written into Context
-    pub emit_ir: bool,
-
-    // If set additional debug files will be emitted to disk
-    pub emit_debug: bool,
-
-    // If set seek to match fontmake (python) behavior even at cost of abandoning optimizations
-    match_legacy: bool,
+    pub flags: Flags,
 
     paths: Arc<Paths>,
 
@@ -92,9 +85,7 @@ pub struct Context {
 impl Context {
     fn copy(&self, acl: AccessControlList<AnyWorkId>) -> Context {
         Context {
-            emit_ir: self.emit_ir,
-            emit_debug: self.emit_debug,
-            match_legacy: self.match_legacy,
+            flags: self.flags,
             paths: self.paths.clone(),
             ir: self.ir.clone(),
             acl,
@@ -102,17 +93,9 @@ impl Context {
         }
     }
 
-    pub fn new_root(
-        emit_ir: bool,
-        emit_debug: bool,
-        match_legacy: bool,
-        paths: Paths,
-        ir: &fontir::orchestration::Context,
-    ) -> Context {
+    pub fn new_root(flags: Flags, paths: Paths, ir: &fontir::orchestration::Context) -> Context {
         Context {
-            emit_ir,
-            emit_debug,
-            match_legacy,
+            flags,
             paths: Arc::from(paths),
             ir: Arc::from(ir.read_only()),
             acl: AccessControlList::read_only(),
@@ -131,7 +114,7 @@ impl Context {
         ))
     }
 
-    pub fn read_only(&self) -> Context {
+    pub fn copy_read_only(&self) -> Context {
         self.copy(AccessControlList::read_only())
     }
 }
@@ -143,7 +126,7 @@ impl Context {
     }
 
     fn maybe_persist(&self, file: &Path, content: &[u8]) {
-        if !self.emit_ir {
+        if !self.flags.contains(Flags::EMIT_IR) {
             return;
         }
         fs::write(file, content)
@@ -164,7 +147,7 @@ impl Context {
 
     pub fn get_features(&self) -> Arc<Vec<u8>> {
         let id = WorkId::Features;
-        self.acl.check_read_access(&id.clone().into());
+        self.acl.assert_read_access(&id.clone().into());
         {
             let rl = self.features.read();
             if rl.is_some() {
@@ -179,7 +162,7 @@ impl Context {
 
     pub fn set_features(&self, mut font: FontBuilder) {
         let id = WorkId::Features;
-        self.acl.check_write_access(&id.clone().into());
+        self.acl.assert_write_access(&id.clone().into());
         let font = font.build();
         self.maybe_persist(&self.paths.target_file(&id), &font);
         self.set_cached_features(font);

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -52,6 +52,14 @@ struct Args {
     #[clap(default_value = "false")]
     emit_debug: bool,
 
+    /// Whether to Try Hard(tm) to match fontmake (Python) behavior in cases where there are other options.
+    ///
+    /// See https://github.com/googlefonts/fontmake-rs/pull/123 for an example of
+    /// where this matters.
+    #[arg(long)]
+    #[clap(default_value = "true")]
+    match_legacy: bool,
+
     /// Working directory for the build process. If emit-ir is on, written here.
     #[arg(short, long)]
     #[clap(default_value = "build")]
@@ -612,12 +620,14 @@ fn main() -> Result<(), Error> {
     let fe_root = FeContext::new_root(
         config.args.emit_ir,
         config.args.emit_debug,
+        config.args.match_legacy,
         ir_paths,
         change_detector.current_inputs.clone(),
     );
     let be_root = BeContext::new_root(
         config.args.emit_ir,
         config.args.emit_debug,
+        config.args.match_legacy,
         be_paths,
         &fe_root,
     );
@@ -671,6 +681,7 @@ mod tests {
             emit_ir: true,
             emit_debug: false,
             build_dir: build_dir.to_path_buf(),
+            match_legacy: true,
         }
     }
 
@@ -766,12 +777,14 @@ mod tests {
         let fe_root = FeContext::new_root(
             config.args.emit_ir,
             config.args.emit_debug,
+            config.args.match_legacy,
             ir_paths,
             change_detector.current_inputs.clone(),
         );
         let be_root = BeContext::new_root(
             config.args.emit_ir,
             config.args.emit_debug,
+            config.args.match_legacy,
             be_paths,
             &fe_root.read_only(),
         );
@@ -900,5 +913,15 @@ mod tests {
 
         let feature_ttf = build_dir.join("features.ttf");
         assert!(feature_ttf.is_file(), "Should have written {feature_ttf:?}");
+    }
+
+    #[test]
+    fn resolve_contour_and_composite_glyph() {
+        todo!()
+    }
+
+    #[test]
+    fn resolve_contour_and_composite_glyph_in_legacy_mode() {
+        todo!()
     }
 }

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -32,7 +32,7 @@ env_logger = "0.9.0"
 
 parking_lot = "0.12.1"
 
-write-fonts = "0.0.5"  # for pens
+write-fonts = "0.1.0"  # for pens
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -32,6 +32,8 @@ env_logger = "0.9.0"
 
 parking_lot = "0.12.1"
 
+write-fonts = "0.0.5"  # for pens
+
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -106,6 +106,8 @@ pub enum WorkError {
     PathConversionError(#[from] PathConversionError),
     #[error("Variation model error")]
     VariationModelError(#[from] VariationModelError),
+    #[error("Contour reversal error {0}")]
+    ContourReversalError(String),
 }
 
 /// An async work error, hence one that must be Send

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -87,6 +87,11 @@ pub enum WorkError {
         axis: String,
         pos: NormalizedCoord,
     },
+    #[error("{glyph_name} undefined at required position {pos:?}")]
+    GlyphUndefAtNormalizedLocation {
+        glyph_name: GlyphName,
+        pos: NormalizedLocation,
+    },
     #[error("Duplicate location for {what}: {loc:?}")]
     DuplicateNormalizedLocation {
         what: String,

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -1,0 +1,219 @@
+//! IR glyph processing.
+//!
+//! Notably includes splitting glyphs with contours and components into one new glyph with
+//! the contours and one updated glyph with no contours that references the new gyph as a component.
+
+use fontdrasil::{orchestration::Work, types::GlyphName};
+use indexmap::IndexSet;
+use kurbo::Affine;
+use log::debug;
+
+use crate::{
+    error::WorkError,
+    ir::{Component, Glyph},
+    orchestration::{Context, IrWork},
+};
+
+pub fn create_finalize_static_metadata_work() -> Box<IrWork> {
+    Box::new(FinalizeStaticMetadataWork {})
+}
+
+struct FinalizeStaticMetadataWork {}
+
+/// Glyph should split if it has components *and* contours.
+///
+/// Such a glyph turns into a simple glyf with the contours and a
+/// composite glyph that references the simple glyph as a component.
+///
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/glyf>
+fn should_split(glyph: &Glyph) -> bool {
+    glyph
+        .sources
+        .values()
+        .any(|inst| !inst.components.is_empty() && !inst.contours.is_empty())
+}
+
+fn name_for_derivative(base_name: &GlyphName, names_in_use: &IndexSet<GlyphName>) -> GlyphName {
+    let mut i = 0;
+    let base_name = base_name.as_str();
+    loop {
+        let new_name: GlyphName = format!("{base_name}.{i}").into();
+        if !names_in_use.contains(&new_name) {
+            return new_name;
+        }
+        i += 1;
+    }
+}
+
+fn split_glyph(glyph_order: &IndexSet<GlyphName>, original: &Glyph) -> (Glyph, Glyph) {
+    // Make a simple glyph by erasing the components from it
+    let mut simple_glyph = original.clone();
+    simple_glyph.sources.iter_mut().for_each(|(_, inst)| {
+        inst.components.clear();
+    });
+
+    // Find a free name for the contour glyph
+    let simple_glyph_name = name_for_derivative(&original.name, glyph_order);
+    simple_glyph.name = simple_glyph_name.clone();
+
+    // Use the contour glyph as a component in the original glyph and erase it's contours
+    let mut composite_glyph = original.clone();
+    composite_glyph.sources.iter_mut().for_each(|(_, inst)| {
+        inst.contours.clear();
+        inst.components.push(Component {
+            base: simple_glyph_name.clone(),
+            transform: Affine::IDENTITY,
+        });
+    });
+
+    (simple_glyph, composite_glyph)
+}
+
+impl Work<Context, WorkError> for FinalizeStaticMetadataWork {
+    fn exec(&self, context: &Context) -> Result<(), WorkError> {
+        // We should now have access to *all* the glyph IR
+        // Some of it may need to be massaged to produce BE glyphs
+        // In particular, glyphs with both paths and components need to push the path into a component
+        let current_metadata = context.get_static_metadata();
+        let mut new_glyph_order = current_metadata.glyph_order.clone();
+
+        // Glyphs with paths and components need to push their paths to a new glyph that is a component
+        for glyph_to_split in current_metadata
+            .glyph_order
+            .iter()
+            .map(|gn| context.get_glyph_ir(gn))
+            .filter(|glyph| should_split(glyph))
+        {
+            debug!(
+                "Splitting '{0}' because it has contours and components",
+                glyph_to_split.name
+            );
+            let (simple, composite) = split_glyph(&new_glyph_order, &glyph_to_split);
+
+            // Capture the updated/new IR and update glyph order
+            debug_assert!(composite.name == glyph_to_split.name);
+            debug_assert!(simple.name != glyph_to_split.name);
+
+            new_glyph_order.insert(simple.name.clone());
+            context.set_glyph_ir(simple.name.clone(), simple);
+            context.set_glyph_ir(composite.name.clone(), composite);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use fontdrasil::types::GlyphName;
+    use indexmap::IndexSet;
+    use kurbo::{Affine, BezPath};
+
+    use crate::{
+        coords::{NormalizedCoord, NormalizedLocation},
+        ir::{Component, Glyph, GlyphInstance},
+    };
+
+    use super::{name_for_derivative, should_split, split_glyph};
+
+    fn norm_loc(positions: &[(&str, f32)]) -> NormalizedLocation {
+        positions
+            .iter()
+            .map(|(axis_name, value)| (axis_name.to_string(), NormalizedCoord::new(*value)))
+            .collect()
+    }
+
+    fn component_instance() -> GlyphInstance {
+        GlyphInstance {
+            components: vec![Component {
+                base: "my_component".into(),
+                transform: Affine::IDENTITY,
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn contour_instance() -> GlyphInstance {
+        GlyphInstance {
+            contours: vec![BezPath::new()],
+            ..Default::default()
+        }
+    }
+
+    fn contour_and_component_instance() -> GlyphInstance {
+        GlyphInstance {
+            contours: contour_instance().contours,
+            components: component_instance().components,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn contours_xor_components_nop() {
+        let glyph = Glyph {
+            name: "duck".into(),
+            sources: HashMap::from([
+                // Just component
+                (norm_loc(&[("W", 0.0)]), component_instance()),
+                // Just contour
+                (norm_loc(&[("W", 1.0)]), contour_instance()),
+            ]),
+        };
+        assert!(!should_split(&glyph));
+    }
+
+    #[test]
+    fn contours_and_components_split() {
+        let glyph = Glyph {
+            name: "duck".into(),
+            sources: HashMap::from([(norm_loc(&[("W", 0.0)]), contour_and_component_instance())]),
+        };
+        assert!(should_split(&glyph));
+    }
+
+    #[test]
+    fn names_for_derivatives() {
+        let mut names = IndexSet::new();
+        assert_eq!(
+            GlyphName::from("duck.0"),
+            name_for_derivative(&"duck".into(), &names)
+        );
+
+        names.insert(GlyphName::from("mallard"));
+        names.insert(GlyphName::from("duck.2"));
+        names.insert(GlyphName::from("duck.0"));
+        assert_eq!(
+            GlyphName::from("duck.1"),
+            name_for_derivative(&"duck".into(), &names)
+        );
+    }
+
+    #[test]
+    fn split_a_glyph() {
+        let split_me = Glyph {
+            name: "duck".into(),
+            sources: HashMap::from([
+                (norm_loc(&[("W", 0.0)]), contour_and_component_instance()),
+                (norm_loc(&[("W", 1.0)]), contour_and_component_instance()),
+            ]),
+        };
+        let (simple, composite) = split_glyph(&IndexSet::new(), &split_me);
+
+        let expected_locs = split_me.sources.keys().collect::<HashSet<_>>();
+        assert_eq!(expected_locs, simple.sources.keys().collect::<HashSet<_>>());
+        assert_eq!(
+            expected_locs,
+            composite.sources.keys().collect::<HashSet<_>>()
+        );
+
+        assert!(simple.sources.values().all(|gi| gi.components.is_empty()));
+        assert!(simple.sources.values().all(|gi| !gi.contours.is_empty()));
+        assert!(composite.sources.values().all(|gi| gi.contours.is_empty()));
+        assert!(composite
+            .sources
+            .values()
+            .all(|gi| !gi.components.is_empty()));
+    }
+}

--- a/fontir/src/lib.rs
+++ b/fontir/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod coords;
 pub mod error;
+pub mod glyph;
 pub mod ir;
 pub mod orchestration;
 pub mod paths;

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -43,7 +43,8 @@ impl Paths {
 
     pub fn target_file(&self, id: &WorkId) -> PathBuf {
         match id {
-            WorkId::StaticMetadata => self.build_dir.join("static_metadata.yml"),
+            WorkId::InitStaticMetadata => self.build_dir.join("static_metadata.yml"),
+            WorkId::FinalizeStaticMetadata => self.build_dir.join("static_metadata.yml"),
             WorkId::Glyph(name) => self.glyph_ir_file(name.as_str()),
             WorkId::GlyphIrDelete => self.build_dir.join("delete.yml"),
             WorkId::Features => self.build_dir.join("features.yml"),

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -25,6 +25,8 @@ const ONE: OrderedFloat<f32> = OrderedFloat(1.0);
 /// See `class VariationModel` in <https://github.com/fonttools/fonttools/blob/main/Lib/fontTools/varLib/models.py>
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct VariationModel {
+    default: NormalizedLocation,
+
     // TODO: why isn't this a Map<Loc, Region>
     // All Vec's have same length and items at the same index refer to the same master
     // Which sounds a *lot* like we should have a Vec or Map of Some Struct.
@@ -47,6 +49,10 @@ impl VariationModel {
         axis_order: Vec<String>,
     ) -> Result<Self, VariationModelError> {
         let axes = axis_order.iter().collect::<HashSet<&String>>();
+        let default = axes
+            .iter()
+            .map(|axis_name| (axis_name.to_string(), NormalizedCoord::new(ZERO)))
+            .collect();
 
         let mut expanded_locations = HashSet::new();
         for mut location in locations.into_iter() {
@@ -84,6 +90,7 @@ impl VariationModel {
         let delta_weights = delta_weights(&locations, &influence);
 
         Ok(VariationModel {
+            default,
             locations,
             influence,
             delta_weights,
@@ -92,6 +99,7 @@ impl VariationModel {
 
     pub fn empty() -> Self {
         VariationModel {
+            default: NormalizedLocation::new(),
             locations: Vec::new(),
             influence: Vec::new(),
             delta_weights: Vec::new(),
@@ -100,6 +108,10 @@ impl VariationModel {
 
     pub fn locations(&self) -> impl Iterator<Item = &NormalizedLocation> {
         self.locations.iter()
+    }
+
+    pub fn default_location(&self) -> &NormalizedLocation {
+        &self.default
     }
 }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -386,9 +386,7 @@ mod tests {
         (
             source,
             Context::new_root(
-                false,
-                false,
-                true,
+                Default::default(),
                 Paths::new(Path::new("/nothing/should/write/here")),
                 input,
             ),

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -307,7 +307,7 @@ mod tests {
         path::{Path, PathBuf},
     };
 
-    use fontdrasil::types::GlyphName;
+    use fontdrasil::{orchestration::access_one, types::GlyphName};
     use fontir::{
         coords::{
             CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord,
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn static_metadata_ir() {
         let (source, context) = context_for(glyphs3_dir().join("WghtVar.glyphs"));
-        let task_context = context.copy_for_work(WorkId::StaticMetadata, None);
+        let task_context = context.copy_for_work(None, access_one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -424,7 +424,7 @@ mod tests {
     fn static_metadata_ir_multi_axis() {
         // Caused index out of bounds due to transposed master and value indices
         let (source, context) = context_for(glyphs2_dir().join("BadIndexing.glyphs"));
-        let task_context = context.copy_for_work(WorkId::StaticMetadata, None);
+        let task_context = context.copy_for_work(None, access_one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -435,7 +435,7 @@ mod tests {
     #[test]
     fn loads_axis_mappings_from_glyphs2() {
         let (source, context) = context_for(glyphs2_dir().join("OpszWghtVar_AxisMappings.glyphs"));
-        let task_context = context.copy_for_work(WorkId::StaticMetadata, None);
+        let task_context = context.copy_for_work(None, access_one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -488,7 +488,7 @@ mod tests {
 
     fn build_static_metadata(glyphs_file: PathBuf) -> (impl Source, Context) {
         let (source, context) = context_for(glyphs_file);
-        let task_context = context.copy_for_work(WorkId::StaticMetadata, None);
+        let task_context = context.copy_for_work(None, access_one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -509,8 +509,8 @@ mod tests {
                 .unwrap();
             for work in work_items.iter() {
                 let task_context = context.copy_for_work(
-                    WorkId::Glyph(glyph_name.clone()),
-                    Some(HashSet::from([WorkId::StaticMetadata])),
+                    Some(HashSet::from([WorkId::InitStaticMetadata])),
+                    access_one(WorkId::Glyph(glyph_name.clone())),
                 );
                 work.exec(&task_context)?;
             }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -295,7 +295,7 @@ impl Work<Context, WorkError> for GlyphIrWork {
             check_pos(&self.glyph_name, positions, axis, &max)?;
         }
 
-        context.set_glyph_ir(self.glyph_name.clone(), ir_glyph);
+        context.set_glyph_ir(ir_glyph);
         Ok(())
     }
 }
@@ -388,6 +388,7 @@ mod tests {
             Context::new_root(
                 false,
                 false,
+                true,
                 Paths::new(Path::new("/nothing/should/write/here")),
                 input,
             ),

--- a/resources/testdata/glyphs2/MixedContourComponent.glyphs
+++ b/resources/testdata/glyphs2/MixedContourComponent.glyphs
@@ -1,0 +1,62 @@
+{
+.appVersion = "3151";
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+}
+);
+glyphs = (
+{
+glyphname = shape;
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"238 0 LINE",
+"362 0 LINE",
+"362 112 LINE",
+"238 112 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 002E;
+},
+{
+glyphname = contour_and_component;
+layers = (
+{
+paths = (
+{
+closed = 1;
+nodes = (
+"238 0 LINE",
+"362 0 LINE",
+"362 112 LINE",
+"238 112 LINE"
+);
+}
+);
+components = (
+{
+name = shape;
+transform = "{1, 0, 0, 1, 25, 25}";
+}
+);
+layerId = m01;
+width = 600;
+}
+);
+unicode = 002C;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -525,7 +525,7 @@ impl Work<Context, WorkError> for GlyphIrWork {
 
         let glyph_ir = to_ir_glyph(self.glyph_name.clone(), &glif_files)
             .map_err(|e| WorkError::GlyphIrWorkError(self.glyph_name.clone(), e.to_string()))?;
-        context.set_glyph_ir(self.glyph_name.clone(), glyph_ir);
+        context.set_glyph_ir(glyph_ir);
         Ok(())
     }
 }


### PR DESCRIPTION
Split IR glyphs with contours and components - observed in Lexend - apart such that a glyph with both migrates its contours into a new glyph then references that glyph as a component.

Update the ACL rigging to accomodate; we need the ability to express the ability to write to any glyph including those we've never seen before because we're creating them.

Fixes #125 by converting glyphs with different component definitions at different positions in designspace to simple glyphs.

Split out from #120 to make review more tractable.

The most interesting changes are in fontir/src/glyph.rs.