### PR TITLE
Update kurbo

### DIFF
--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -492,7 +492,7 @@ mod tests {
         for (loc, inst) in simple.sources.iter() {
             assert_eq!(
                 // The original contour, and the component w/transform
-                vec!["M1 1L2 1L2 2Z", "M4 4L5 4L5 5Z",],
+                vec!["M1,1 L2,1 L2,2 Z", "M4,4 L5,4 L5,5 Z",],
                 inst.contours
                     .iter()
                     .map(|bez| bez.to_svg())
@@ -559,13 +559,13 @@ mod tests {
         assert_eq!(
             vec![
                 // The original shape
-                "M1 1L2 1L2 2Z",
+                "M1,1 L2,1 L2,2 Z",
                 // c1: shape rotated 90 degrees ccw
-                "M1 -1L1 -2L2 -2Z",
+                "M1,-1 L1,-2 L2,-2 Z",
                 // c1 moved by (0, 2)
-                "M1 1L1 0L2 0Z",
+                "M1,1 L1,0 L2,0 Z",
                 // c2 moved by (0,5), c2 is c1 moved by (5,0)
-                "M6 4L6 3L7 3Z",
+                "M6,4 L6,3 L7,3 Z",
             ],
             inst.contours
                 .iter()

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -320,7 +320,7 @@ mod tests {
         let mut builder = GlyphPathBuilder::new("test".into());
         builder.move_to((2.0, 2.0)).unwrap();
         builder.qcurve_to((4.0, 2.0)).unwrap();
-        assert_eq!("M2 2L4 2", builder.build().to_svg());
+        assert_eq!("M2,2 L4,2", builder.build().to_svg());
     }
 
     #[test]
@@ -329,7 +329,7 @@ mod tests {
         builder.move_to((2.0, 2.0)).unwrap();
         builder.offcurve((3.0, 0.0)).unwrap();
         builder.qcurve_to((4.0, 2.0)).unwrap();
-        assert_eq!("M2 2Q3 0 4 2", builder.build().to_svg());
+        assert_eq!("M2,2 Q3,0 4,2", builder.build().to_svg());
     }
 
     #[test]
@@ -339,6 +339,6 @@ mod tests {
         builder.offcurve((3.0, 0.0)).unwrap();
         builder.offcurve((5.0, 4.0)).unwrap();
         builder.qcurve_to((6.0, 2.0)).unwrap();
-        assert_eq!("M2 2Q3 0 4 2Q5 4 6 2", builder.build().to_svg());
+        assert_eq!("M2,2 Q3,0 4,2 Q5,4 6,2", builder.build().to_svg());
     }
 }

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -300,6 +300,6 @@ mod tests {
             node_type: glyphs_reader::NodeType::Curve,
         });
         let bez = to_ir_path("test".into(), &path).unwrap();
-        assert_eq!("M32 32C64 64 64 0 32 32Z", bez.to_svg());
+        assert_eq!("M32,32 C64,64 64,0 32,32 Z", bez.to_svg());
     }
 }

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -171,7 +171,7 @@ mod tests {
         ];
         let contour = norad::Contour::new(points, None, None);
         let bez = to_ir_contour("test".into(), &contour).unwrap();
-        assert_eq!("M1 1L9 1L9 2L1 2Z", bez.to_svg());
+        assert_eq!("M1,1 L9,1 L9,2 L1,2 Z", bez.to_svg());
     }
 
     // https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#point-types
@@ -188,6 +188,6 @@ mod tests {
         ];
         let contour = norad::Contour::new(points, None, None);
         let bez = to_ir_contour("test".into(), &contour).unwrap();
-        assert_eq!("M32 32C64 64 64 0 32 32Z", bez.to_svg());
+        assert_eq!("M32,32 C64,64 64,0 32,32 Z", bez.to_svg());
     }
 }


### PR DESCRIPTION
We need https://github.com/linebender/kurbo/pull/236 for glyph compilation. Split out because the svg format change makes the diff noisy.