### PR TITLE
Make ACL system more flexible (static glyf, 1 of 3)

### DIFF
--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -1,9 +1,9 @@
 //! Helps coordinate the graph execution for BE
 
-use std::{collections::HashSet, fs, path::Path, sync::Arc};
+use std::{fs, path::Path, sync::Arc};
 
 use fontdrasil::{
-    orchestration::{access_one, AccessControlList, Work, MISSING_DATA},
+    orchestration::{AccessControlList, Work, MISSING_DATA},
     types::GlyphName,
 };
 use fontir::orchestration::{Context as FeContext, Flags, WorkId as FeWorkIdentifier};
@@ -105,13 +105,10 @@ impl Context {
 
     pub fn copy_for_work(
         &self,
-        work_id: WorkId,
-        dependencies: Option<HashSet<AnyWorkId>>,
+        read_access: Arc<dyn Fn(&AnyWorkId) -> bool + Send + Sync>,
+        write_access: Arc<dyn Fn(&AnyWorkId) -> bool + Send + Sync>,
     ) -> Context {
-        self.copy(AccessControlList::read_write(
-            dependencies.unwrap_or_default(),
-            access_one(work_id.into()),
-        ))
+        self.copy(AccessControlList::read_write(read_access, write_access))
     }
 
     pub fn copy_read_only(&self) -> Context {

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -677,7 +677,7 @@ mod tests {
 
     use std::{
         collections::HashSet,
-        fs::{self},
+        fs,
         path::{Path, PathBuf},
     };
 

--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -1,6 +1,10 @@
 //! Common parts of work orchestration.
 
-use std::{collections::HashSet, fmt::Debug, hash::Hash, sync::Arc};
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+    sync::Arc,
+};
 
 pub const MISSING_DATA: &str = "Missing data, dependency management failed us?";
 
@@ -28,28 +32,28 @@ where
     // Returns true if you can write to the provided id
     write_access: AccessFn<I>,
 
-    // If present, what you can access through this context
-    // Intent is root has None, task-specific Context only allows access to dependencies
-    read_mask: Option<HashSet<I>>,
+    // Returns true if you can read the provided id
+    read_access: AccessFn<I>,
 }
 
-impl<I: Eq + Hash + Debug> AccessControlList<I> {
+impl<I: Eq + Hash + Debug + Send + Sync + 'static> AccessControlList<I> {
     pub fn read_only() -> AccessControlList<I> {
         AccessControlList {
-            write_access: Arc::new(|_| false),
-            read_mask: None,
+            write_access: access_none(),
+            read_access: access_all(),
         }
     }
 
-    pub fn read_write(
-        read: HashSet<I>,
-        write_access: Arc<dyn Fn(&I) -> bool + Send + Sync>,
-    ) -> AccessControlList<I> {
+    pub fn read_write(read_access: AccessFn<I>, write_access: AccessFn<I>) -> AccessControlList<I> {
         AccessControlList {
             write_access,
-            read_mask: Some(read),
+            read_access,
         }
     }
+}
+
+pub fn access_all<I: Eq + Send + Sync + 'static>() -> AccessFn<I> {
+    Arc::new(move |_| true)
 }
 
 pub fn access_one<I: Eq + Send + Sync + 'static>(id: I) -> AccessFn<I> {
@@ -60,38 +64,64 @@ pub fn access_none<I: Eq + Send + Sync + 'static>() -> AccessFn<I> {
     Arc::new(move |_| false)
 }
 
-impl<I: Eq + Hash + Debug> AccessControlList<I> {
-    pub fn assert_read_access_to_any(&self, ids: &[I]) {
-        if self.read_mask.is_none() {
-            return;
-        }
-        let read_mask = self.read_mask.as_ref().unwrap();
+enum AccessCheck {
+    Any,
+    All,
+}
 
-        if !ids.iter().any(|id| read_mask.contains(id)) {
-            panic!("Illegal access to {ids:?}");
+impl Display for AccessCheck {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AccessCheck::All => write!(f, "all"),
+            AccessCheck::Any => write!(f, "any"),
         }
+    }
+}
+
+fn assert_access_many<I: Eq + Hash + Debug>(
+    demand: AccessCheck,
+    access_fn: &AccessFn<I>,
+    ids: &[I],
+    desc: &str,
+) {
+    let allow = match demand {
+        AccessCheck::All => ids.iter().all(|id| access_fn(id)),
+        AccessCheck::Any => ids.iter().any(|id| access_fn(id)),
+    };
+    if !allow {
+        panic!("Illegal {desc} of {demand} {ids:?}");
+    }
+}
+
+fn assert_access_one<I: Eq + Hash + Debug>(access_fn: &AccessFn<I>, id: &I, desc: &str) {
+    let allow = access_fn(id);
+    if !allow {
+        panic!("Illegal {desc} of {id:?}");
+    }
+}
+
+impl<I: Eq + Hash + Debug> AccessControlList<I> {
+    pub fn assert_read_access_to_all(&self, ids: &[I]) {
+        assert_access_many(AccessCheck::All, &self.read_access, ids, "read");
+    }
+
+    pub fn assert_read_access_to_any(&self, ids: &[I]) {
+        assert_access_many(AccessCheck::Any, &self.read_access, ids, "read");
     }
 
     pub fn assert_read_access(&self, id: &I) {
-        if !self
-            .read_mask
-            .as_ref()
-            .map(|mask| mask.contains(id))
-            .unwrap_or(true)
-        {
-            panic!("Illegal access to {id:?}");
-        }
+        assert_access_one(&self.read_access, id, "read");
+    }
+
+    pub fn assert_write_access_to_all(&self, ids: &[I]) {
+        assert_access_many(AccessCheck::All, &self.write_access, ids, "write");
     }
 
     pub fn assert_write_access_to_any(&self, ids: &[I]) {
-        if !ids.iter().any(|id| (self.write_access)(id)) {
-            panic!("Illegal access to {ids:?}");
-        }
+        assert_access_many(AccessCheck::Any, &self.write_access, ids, "write");
     }
 
     pub fn assert_write_access(&self, id: &I) {
-        if !(self.write_access)(id) {
-            panic!("Illegal access to {id:?}");
-        }
+        assert_access_one(&self.write_access, id, "write");
     }
 }

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -309,7 +309,7 @@ mod tests {
         sync::Arc,
     };
 
-    use fontdrasil::types::GlyphName;
+    use fontdrasil::{orchestration::access_one, types::GlyphName};
     use indexmap::IndexSet;
     use kurbo::{Affine, BezPath};
     use write_fonts::pens::{write_to_pen, BezPathPen, ReverseContourPen};
@@ -480,7 +480,7 @@ mod tests {
         let coalesce_me = contour_and_component_weight_glyph("coalesce_me");
 
         let context = test_root().copy_for_work(
-            Some(HashSet::from([WorkId::Glyph("component".into())])),
+            access_one(WorkId::Glyph("component".into())),
             Arc::new(|_| true),
         );
         context.set_glyph_ir(contour_glyph("component"));
@@ -515,12 +515,13 @@ mod tests {
         // add c2, reusing c1 w/translation
         let c2 = component_glyph("c2", c1.name.clone(), Affine::translate((5.0, 0.0)));
 
+        let allow_access = HashSet::from([
+            WorkId::Glyph(reuse_me.name.clone()),
+            WorkId::Glyph(c1.name.clone()),
+            WorkId::Glyph(c2.name.clone()),
+        ]);
         let context = test_root().copy_for_work(
-            Some(HashSet::from([
-                WorkId::Glyph(reuse_me.name.clone()),
-                WorkId::Glyph(c1.name.clone()),
-                WorkId::Glyph(c2.name.clone()),
-            ])),
+            Arc::new(move |id| allow_access.contains(id)),
             Arc::new(|_| true),
         );
         context.set_glyph_ir(reuse_me);
@@ -599,7 +600,7 @@ mod tests {
         };
 
         let context = test_root().copy_for_work(
-            Some(HashSet::from([WorkId::Glyph(reuse_me.name.clone())])),
+            access_one(WorkId::Glyph(reuse_me.name.clone())),
             Arc::new(|_| true),
         );
         context.set_glyph_ir(reuse_me);
@@ -656,7 +657,7 @@ mod tests {
         let glyph = adjust_transform_for_each_instance(&glyph);
 
         let context = test_root().copy_for_work(
-            Some(HashSet::from([WorkId::Glyph("component".into())])),
+            access_one(WorkId::Glyph("component".into())),
             Arc::new(|_| true),
         );
         context.set_glyph_ir(contour_glyph("component"));
@@ -671,7 +672,7 @@ mod tests {
         let glyph = adjust_transform_for_each_instance(&glyph);
 
         let context = test_root().copy_for_work(
-            Some(HashSet::from([WorkId::Glyph("component".into())])),
+            access_one(WorkId::Glyph("component".into())),
             Arc::new(|_| true),
         );
         context.set_glyph_ir(contour_glyph("component"));

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -134,7 +134,7 @@ impl Glyph {
 pub struct GlyphInstance {
     /// Advance width.
     pub width: f64,
-    /// Advance height; if None, assumed to equal font's ascender - descende.
+    /// Advance height; if None, assumed to equal font's ascender - descender.
     pub height: Option<f64>,
     /// List of glyph contours.
     pub contours: Vec<BezPath>,

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -1,7 +1,7 @@
 //! Helps coordinate the graph execution for IR
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt::Debug,
     fs::File,
     io::{BufReader, BufWriter},
@@ -104,13 +104,10 @@ impl Context {
 
     pub fn copy_for_work(
         &self,
-        dependencies: Option<HashSet<WorkId>>,
+        read_access: Arc<dyn Fn(&WorkId) -> bool + Send + Sync>,
         write_access: Arc<dyn Fn(&WorkId) -> bool + Send + Sync>,
     ) -> Context {
-        self.copy(AccessControlList::read_write(
-            dependencies.unwrap_or_default(),
-            write_access,
-        ))
+        self.copy(AccessControlList::read_write(read_access, write_access))
     }
 
     pub fn read_only(&self) -> Context {

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -318,7 +318,10 @@ mod tests {
         path::{Path, PathBuf},
     };
 
-    use fontdrasil::{orchestration::access_one, types::GlyphName};
+    use fontdrasil::{
+        orchestration::{access_none, access_one},
+        types::GlyphName,
+    };
     use fontir::{
         coords::{
             CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord,
@@ -407,7 +410,8 @@ mod tests {
     #[test]
     fn static_metadata_ir() {
         let (source, context) = context_for(glyphs3_dir().join("WghtVar.glyphs"));
-        let task_context = context.copy_for_work(None, access_one(WorkId::InitStaticMetadata));
+        let task_context =
+            context.copy_for_work(access_none(), access_one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -434,7 +438,8 @@ mod tests {
     fn static_metadata_ir_multi_axis() {
         // Caused index out of bounds due to transposed master and value indices
         let (source, context) = context_for(glyphs2_dir().join("BadIndexing.glyphs"));
-        let task_context = context.copy_for_work(None, access_one(WorkId::InitStaticMetadata));
+        let task_context =
+            context.copy_for_work(access_none(), access_one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -445,7 +450,8 @@ mod tests {
     #[test]
     fn loads_axis_mappings_from_glyphs2() {
         let (source, context) = context_for(glyphs2_dir().join("OpszWghtVar_AxisMappings.glyphs"));
-        let task_context = context.copy_for_work(None, access_one(WorkId::InitStaticMetadata));
+        let task_context =
+            context.copy_for_work(access_none(), access_one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -498,7 +504,8 @@ mod tests {
 
     fn build_static_metadata(glyphs_file: PathBuf) -> (impl Source, Context) {
         let (source, context) = context_for(glyphs_file);
-        let task_context = context.copy_for_work(None, access_one(WorkId::InitStaticMetadata));
+        let task_context =
+            context.copy_for_work(access_none(), access_one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -519,7 +526,7 @@ mod tests {
                 .unwrap();
             for work in work_items.iter() {
                 let task_context = context.copy_for_work(
-                    Some(HashSet::from([WorkId::InitStaticMetadata])),
+                    access_one(WorkId::InitStaticMetadata),
                     access_one(WorkId::Glyph(glyph_name.clone())),
                 );
                 work.exec(&task_context)?;


### PR DESCRIPTION
Upcoming changes, such as merging glyphs, need to be able to read and/or write things not readily expressed as a set of specific ids such as "all glyphs." To accomodate this update read access (previously done for write) controlled by a function rather than a fixed set of identifiers.

Hoisted out of #120 in hopes of turning that into a series of small more reviewable PRs.