### PR TITLE
Try to de-duplicate some of our Context helpers

### DIFF
--- a/fontbe/src/cmap.rs
+++ b/fontbe/src/cmap.rs
@@ -19,7 +19,7 @@ impl Work<Context, Error> for CmapWork {
     /// Generate [cmap](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         // cmap only accomodates single codepoint : glyph mappings; collect all of those
-        let static_metadata = context.ir.get_static_metadata();
+        let static_metadata = context.ir.get_final_static_metadata();
 
         let mappings = static_metadata
             .glyph_order

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -119,7 +119,7 @@ impl Work<Context, Error> for FeatureWork {
             context.set_features(FontBuilder::default());
             return Ok(());
         }
-        let glyph_order = &context.ir.get_static_metadata().glyph_order;
+        let glyph_order = &context.ir.get_final_static_metadata().glyph_order;
         if glyph_order.is_empty() {
             warn!("Glyph order is empty; feature compile improbable");
         }

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -37,7 +37,7 @@ fn create_component(
     // Obtain glyph id from static metadata
     let gid = context
         .ir
-        .get_static_metadata()
+        .get_final_static_metadata()
         .glyph_id(ref_glyph_name)
         .ok_or(GlyphProblem::NotInGlyphOrder)?;
     let gid = GlyphId::new(gid as u16);
@@ -117,7 +117,7 @@ impl Work<Context, Error> for GlyphWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         trace!("BE glyph work for {}", self.glyph_name);
 
-        let static_metadata = context.ir.get_static_metadata();
+        let static_metadata = context.ir.get_final_static_metadata();
         let var_model = &static_metadata.variation_model;
         let default_location = var_model.default_location();
         let ir_glyph = &*context.ir.get_glyph_ir(&self.glyph_name);
@@ -422,7 +422,7 @@ pub fn create_glyf_loca_work() -> Box<BeWork> {
 }
 
 fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
-    let static_metadata = context.ir.get_static_metadata();
+    let static_metadata = context.ir.get_final_static_metadata();
     let glyph_order = &static_metadata.glyph_order;
 
     let glyphs: HashMap<_, _> = glyph_order
@@ -527,7 +527,7 @@ impl Work<Context, Error> for GlyfLocaWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         compute_composite_bboxes(context)?;
 
-        let static_metadata = context.ir.get_static_metadata();
+        let static_metadata = context.ir.get_final_static_metadata();
         let glyph_order = &static_metadata.glyph_order;
 
         // Glue together glyf and loca

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -219,6 +219,10 @@ impl Context {
         if !self.flags.contains(Flags::EMIT_IR) {
             return;
         }
+        self.persist(file, content);
+    }
+
+    fn persist(&self, file: &Path, content: &[u8]) {
         fs::write(file, content)
             .map_err(|e| panic!("Unable to write {file:?} {e}"))
             .unwrap();

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -8,7 +8,7 @@ use fontdrasil::{
 };
 use fontir::{
     context_accessors,
-    orchestration::{Context as FeContext, Flags, WorkId as FeWorkIdentifier},
+    orchestration::{Context as FeContext, ContextItem, Flags, WorkId as FeWorkIdentifier},
 };
 use parking_lot::RwLock;
 use read_fonts::{FontData, FontRead};
@@ -135,9 +135,9 @@ pub struct Context {
     // TODO: variations
     glyphs: Arc<RwLock<HashMap<GlyphName, Arc<Glyph>>>>,
 
-    glyf_loca: Arc<RwLock<Option<Arc<GlyfLoca>>>>,
-    cmap: Arc<RwLock<Option<Arc<Cmap>>>>,
-    post: Arc<RwLock<Option<Arc<Post>>>>,
+    glyf_loca: ContextItem<GlyfLoca>,
+    cmap: ContextItem<Cmap>,
+    post: ContextItem<Post>,
 }
 
 impl Context {

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -6,13 +6,18 @@ use fontdrasil::{
     orchestration::{AccessControlList, Work, MISSING_DATA},
     types::GlyphName,
 };
-use fontir::orchestration::{Context as FeContext, Flags, WorkId as FeWorkIdentifier};
+use fontir::{
+    get_from_context,
+    orchestration::{Context as FeContext, Flags, WorkId as FeWorkIdentifier},
+    set_from_context,
+};
 use parking_lot::RwLock;
 use read_fonts::{FontData, FontRead};
 use write_fonts::{
     dump_table,
     tables::{cmap::Cmap, glyf::SimpleGlyph, post::Post},
-    FontBuilder,
+    validate::Validate,
+    FontBuilder, FontWrite,
 };
 use write_fonts::{from_obj::FromTableRef, tables::glyf::CompositeGlyph};
 
@@ -132,8 +137,8 @@ pub struct Context {
     glyphs: Arc<RwLock<HashMap<GlyphName, Arc<Glyph>>>>,
 
     glyf_loca: Arc<RwLock<Option<Arc<GlyfLoca>>>>,
-    cmap: Arc<RwLock<Option<Arc<Vec<u8>>>>>,
-    post: Arc<RwLock<Option<Arc<Vec<u8>>>>>,
+    cmap: Arc<RwLock<Option<Arc<Cmap>>>>,
+    post: Arc<RwLock<Option<Arc<Post>>>>,
 }
 
 impl Context {
@@ -183,6 +188,27 @@ fn set_cached<T>(lock: &Arc<RwLock<Option<Arc<T>>>>, value: T) {
     *wl = Some(Arc::from(value));
 }
 
+fn to_bytes<T>(table: &T) -> Vec<u8>
+where
+    T: FontWrite + Validate,
+{
+    dump_table(table).unwrap()
+}
+
+fn read_entire_file(file: &Path) -> Vec<u8> {
+    fs::read(file)
+        .map_err(|e| panic!("Unable to read {file:?} {e}"))
+        .unwrap()
+}
+
+fn read_cmap(file: &Path) -> Cmap {
+    Cmap::read(FontData::new(&read_entire_file(file))).unwrap()
+}
+
+fn read_post(file: &Path) -> Post {
+    Post::read(FontData::new(&read_entire_file(file))).unwrap()
+}
+
 impl Context {
     /// A reasonable place to write extra files to help someone debugging
     pub fn debug_dir(&self) -> &Path {
@@ -198,12 +224,6 @@ impl Context {
             .unwrap();
     }
 
-    fn restore(&self, file: &Path) -> Vec<u8> {
-        fs::read(file)
-            .map_err(|e| panic!("Unable to read {file:?} {e}"))
-            .unwrap()
-    }
-
     pub fn get_features(&self) -> Arc<Vec<u8>> {
         let id = WorkId::Features;
         self.acl.assert_read_access(&id.clone().into());
@@ -213,7 +233,7 @@ impl Context {
                 return rl.as_ref().unwrap().clone();
             }
         }
-        let font = self.restore(&self.paths.target_file(&id));
+        let font = read_entire_file(&self.paths.target_file(&id));
         set_cached(&self.features, font);
         let rl = self.features.read();
         rl.as_ref().expect(MISSING_DATA).clone()
@@ -243,7 +263,7 @@ impl Context {
         }
 
         // Vec[u8] => read type => write type == all the right type
-        let glyph = self.restore(&self.paths.target_file(&id));
+        let glyph = read_entire_file(&self.paths.target_file(&id));
         let glyph = read_fonts::tables::glyf::SimpleGlyph::read(FontData::new(&glyph)).unwrap();
         let glyph = SimpleGlyph::from_table_ref(&glyph);
 
@@ -269,12 +289,11 @@ impl Context {
             }
         }
 
-        let loca = self
-            .restore(&self.paths.target_file(&WorkId::Loca))
+        let loca = read_entire_file(&self.paths.target_file(&WorkId::Loca))
             .chunks_exact(std::mem::size_of::<u32>())
             .map(|bytes| u32::from_be_bytes(bytes.try_into().unwrap()))
             .collect();
-        let glyf = self.restore(&self.paths.target_file(&WorkId::Glyf));
+        let glyf = read_entire_file(&self.paths.target_file(&WorkId::Glyf));
 
         set_cached(&self.glyf_loca, (glyf, loca));
         let rl = self.glyf_loca.read();
@@ -298,49 +317,9 @@ impl Context {
         set_cached(&self.glyf_loca, (glyf, loca));
     }
 
-    pub fn get_cmap(&self) -> Arc<Vec<u8>> {
-        let id = WorkId::Cmap;
-        self.acl.assert_read_access(&id.clone().into());
-        {
-            let rl = self.cmap.read();
-            if rl.is_some() {
-                return rl.as_ref().unwrap().clone();
-            }
-        }
-        let cmap = self.restore(&self.paths.target_file(&id));
-        set_cached(&self.cmap, cmap);
-        let rl = self.cmap.read();
-        rl.as_ref().expect(MISSING_DATA).clone()
-    }
+    get_from_context! { get_cmap, cmap, Cmap, WorkId::Cmap, read_cmap }
+    set_from_context! { set_cmap, cmap, Cmap, WorkId::Cmap, to_bytes }
 
-    pub fn set_cmap(&self, cmap: Cmap) {
-        let id = WorkId::Cmap;
-        self.acl.assert_write_access(&id.clone().into());
-        let cmap = dump_table(&cmap).unwrap();
-        self.maybe_persist(&self.paths.target_file(&id), &cmap);
-        set_cached(&self.cmap, cmap);
-    }
-
-    pub fn get_post(&self) -> Arc<Vec<u8>> {
-        let id = WorkId::Post;
-        self.acl.assert_read_access(&id.clone().into());
-        {
-            let rl = self.post.read();
-            if rl.is_some() {
-                return rl.as_ref().unwrap().clone();
-            }
-        }
-        let post = self.restore(&self.paths.target_file(&id));
-        set_cached(&self.post, post);
-        let rl = self.post.read();
-        rl.as_ref().expect(MISSING_DATA).clone()
-    }
-
-    pub fn set_post(&self, post: Post) {
-        let id = WorkId::Post;
-        self.acl.assert_write_access(&id.clone().into());
-        let post = dump_table(&post).unwrap();
-        self.maybe_persist(&self.paths.target_file(&id), &post);
-        set_cached(&self.post, post);
-    }
+    get_from_context! { get_post, post, Post, WorkId::Post, read_post }
+    set_from_context! { set_post, post, Post, WorkId::Post, to_bytes }
 }

--- a/fontbe/src/post.rs
+++ b/fontbe/src/post.rs
@@ -19,7 +19,10 @@ impl Work<Context, Error> for PostWork {
     /// Generate [post](https://learn.microsoft.com/en-us/typography/opentype/spec/post)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         // TODO a more serious post
-        let post = Post { version: Version16Dot16::VERSION_3_0, ..Default::default() };
+        let post = Post {
+            version: Version16Dot16::VERSION_3_0,
+            ..Default::default()
+        };
         context.set_post(post);
         Ok(())
     }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -33,6 +33,8 @@ regex = "1.7.1"
 
 indexmap = "1.9.2"
 
+write-fonts = "0.1.1"
+
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -239,7 +239,7 @@ impl Work<Context, WorkError> for FinalizeStaticMetadataWork {
         // We should now have access to *all* the glyph IR
         // Some of it may need to be massaged to produce BE glyphs
         // In particular, glyphs with both paths and components need to push the path into a component
-        let current_metadata = context.get_static_metadata();
+        let current_metadata = context.get_init_static_metadata();
         let mut new_glyph_order = current_metadata.glyph_order.clone();
 
         // Glyphs with paths and components, and glyphs whose components are transformed vary over designspace
@@ -311,7 +311,10 @@ impl Work<Context, WorkError> for FinalizeStaticMetadataWork {
             }
             let mut updated_metadata = (*current_metadata).clone();
             updated_metadata.glyph_order = new_glyph_order;
-            context.set_static_metadata(updated_metadata);
+            context.set_final_static_metadata(updated_metadata);
+        } else {
+            trace!("No new glyphs; final static metadata is unchanged");
+            context.set_final_static_metadata((*current_metadata).clone());
         }
 
         Ok(())

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -30,10 +30,12 @@ bitflags! {
     }
 }
 
+pub type ContextItem<T> = Arc<RwLock<Option<Arc<T>>>>;
+
 /// Generates fn $getter_name(&self) -> Arc<$value_type>.
 ///
 /// Assumes we are in an impl block for a Context and that
-/// self.$lock_name is an Arc<RwLock<Option<Arc<$ir_type>>>>
+/// self.$lock_name is a ContextItem<$ir_type>
 ///
 /// <https://veykril.github.io/tlborm/decl-macros/minutiae/fragment-specifiers.html>
 #[macro_export]
@@ -107,10 +109,10 @@ pub struct Context {
 
     // work results we've completed or restored from disk
     // We create individual caches so we can return typed results from get fns
-    init_static_metadata: Arc<RwLock<Option<Arc<ir::StaticMetadata>>>>,
-    final_static_metadata: Arc<RwLock<Option<Arc<ir::StaticMetadata>>>>,
+    init_static_metadata: ContextItem<ir::StaticMetadata>,
+    final_static_metadata: ContextItem<ir::StaticMetadata>,
     glyph_ir: Arc<RwLock<HashMap<GlyphName, Arc<ir::Glyph>>>>,
-    feature_ir: Arc<RwLock<Option<Arc<ir::Features>>>>,
+    feature_ir: ContextItem<ir::Features>,
 }
 
 pub fn set_cached<T>(lock: &Arc<RwLock<Option<Arc<T>>>>, value: T) {

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -30,6 +30,50 @@ bitflags! {
     }
 }
 
+/// Generates fn $getter_name(&self) -> Arc<$value_type>.
+///
+/// Assumes we are in an impl block for a Context and that
+/// self.$lock_name is an Arc<RwLock<Option<Arc<$ir_type>>>>
+///
+/// <https://veykril.github.io/tlborm/decl-macros/minutiae/fragment-specifiers.html>
+#[macro_export]
+macro_rules! get_from_context {
+    ($getter_name:ident, $lock_name:ident, $value_type:ty, $id:expr, $restore_fn:ident) => {
+        pub fn $getter_name(&self) -> Arc<$value_type> {
+            let id = $id;
+            self.acl.assert_read_access(&id.clone().into());
+            {
+                let rl = self.$lock_name.read();
+                if rl.is_some() {
+                    return rl.as_ref().unwrap().clone();
+                }
+            }
+            set_cached(&self.$lock_name, $restore_fn(&self.paths.target_file(&id)));
+            let rl = self.$lock_name.read();
+            rl.as_ref().expect(MISSING_DATA).clone()
+        }
+    };
+}
+
+/// Generates fn $setter_name(&self, $value_type)
+///
+/// Assumes we are in an impl block for a Context and that
+/// self.$lock_name is an Arc<RwLock<Option<Arc<$value_type>>>>
+///
+/// <https://veykril.github.io/tlborm/decl-macros/minutiae/fragment-specifiers.html>
+#[macro_export]
+macro_rules! set_from_context {
+    ($setter_name:ident, $lock_name:ident, $value_type:ty, $id:expr, $to_bytes:ident) => {
+        pub fn $setter_name(&self, value: $value_type) {
+            let id = $id;
+            self.acl.assert_write_access(&id.clone().into());
+            let buf = $to_bytes(&value);
+            self.maybe_persist(&self.paths.target_file(&id), &buf);
+            set_cached(&self.$lock_name, value);
+        }
+    };
+}
+
 impl Default for Flags {
     fn default() -> Self {
         Flags::MATCH_LEGACY
@@ -72,9 +116,15 @@ pub struct Context {
 
     // work results we've completed or restored from disk
     // We create individual caches so we can return typed results from get fns
-    static_metadata: Arc<RwLock<Option<Arc<ir::StaticMetadata>>>>,
+    init_static_metadata: Arc<RwLock<Option<Arc<ir::StaticMetadata>>>>,
+    final_static_metadata: Arc<RwLock<Option<Arc<ir::StaticMetadata>>>>,
     glyph_ir: Arc<RwLock<HashMap<GlyphName, Arc<ir::Glyph>>>>,
     feature_ir: Arc<RwLock<Option<Arc<ir::Features>>>>,
+}
+
+pub fn set_cached<T>(lock: &Arc<RwLock<Option<Arc<T>>>>, value: T) {
+    let mut wl = lock.write();
+    *wl = Some(Arc::from(value));
 }
 
 impl Context {
@@ -84,7 +134,8 @@ impl Context {
             paths: self.paths.clone(),
             input: self.input.clone(),
             acl,
-            static_metadata: self.static_metadata.clone(),
+            init_static_metadata: self.init_static_metadata.clone(),
+            final_static_metadata: self.final_static_metadata.clone(),
             glyph_ir: self.glyph_ir.clone(),
             feature_ir: self.feature_ir.clone(),
         }
@@ -96,7 +147,8 @@ impl Context {
             paths: Arc::from(paths),
             input: Arc::from(input),
             acl: AccessControlList::read_only(),
-            static_metadata: Arc::from(RwLock::new(None)),
+            init_static_metadata: Arc::from(RwLock::new(None)),
+            final_static_metadata: Arc::from(RwLock::new(None)),
             glyph_ir: Arc::from(RwLock::new(HashMap::new())),
             feature_ir: Arc::from(RwLock::new(None)),
         }
@@ -112,6 +164,24 @@ impl Context {
 
     pub fn read_only(&self) -> Context {
         self.copy(AccessControlList::read_only())
+    }
+}
+
+fn nop<T>(v: &T) -> &T {
+    v
+}
+
+fn restore<V>(file: &Path) -> V
+where
+    V: ?Sized + DeserializeOwned,
+{
+    let raw_file = File::open(file)
+        .map_err(|e| panic!("Unable to read {file:?} {e}"))
+        .unwrap();
+    let buf_io = BufReader::new(raw_file);
+    match serde_yaml::from_reader(buf_io) {
+        Ok(v) => v,
+        Err(e) => panic!("Unable to deserialize {file:?} {e}"),
     }
 }
 
@@ -132,46 +202,6 @@ impl Context {
             .unwrap();
     }
 
-    fn restore<V>(&self, file: &Path) -> V
-    where
-        V: ?Sized + DeserializeOwned,
-    {
-        let raw_file = File::open(file)
-            .map_err(|e| panic!("Unable to read {file:?} {e}"))
-            .unwrap();
-        let buf_io = BufReader::new(raw_file);
-        match serde_yaml::from_reader(buf_io) {
-            Ok(v) => v,
-            Err(e) => panic!("Unable to deserialize {file:?} {e}"),
-        }
-    }
-
-    fn set_cached_static_metadata(&self, ir: ir::StaticMetadata) {
-        let mut wl = self.static_metadata.write();
-        *wl = Some(Arc::from(ir));
-    }
-
-    pub fn get_static_metadata(&self) -> Arc<ir::StaticMetadata> {
-        let ids = [WorkId::InitStaticMetadata, WorkId::FinalizeStaticMetadata];
-        self.acl.assert_read_access_to_any(&ids);
-        {
-            let rl = self.static_metadata.read();
-            if rl.is_some() {
-                return rl.as_ref().unwrap().clone();
-            }
-        }
-        self.set_cached_static_metadata(self.restore(&self.paths.target_file(&ids[0])));
-        let rl = self.static_metadata.read();
-        rl.as_ref().expect(MISSING_DATA).clone()
-    }
-
-    pub fn set_static_metadata(&self, ir: ir::StaticMetadata) {
-        let ids = [WorkId::InitStaticMetadata, WorkId::FinalizeStaticMetadata];
-        self.acl.assert_write_access_to_any(&ids);
-        self.maybe_persist(&self.paths.target_file(&ids[0]), &ir);
-        self.set_cached_static_metadata(ir);
-    }
-
     fn set_cached_glyph(&self, ir: ir::Glyph) {
         let mut wl = self.glyph_ir.write();
         wl.insert(ir.name.clone(), Arc::from(ir));
@@ -186,7 +216,7 @@ impl Context {
                 return glyph.clone();
             }
         }
-        self.set_cached_glyph(self.restore(&self.paths.target_file(&id)));
+        self.set_cached_glyph(restore(&self.paths.target_file(&id)));
         let rl = self.glyph_ir.read();
         rl.get(glyph_name).expect(MISSING_DATA).clone()
     }
@@ -198,29 +228,12 @@ impl Context {
         self.set_cached_glyph(ir);
     }
 
-    fn set_cached_features(&self, ir: ir::Features) {
-        let mut wl = self.feature_ir.write();
-        *wl = Some(Arc::from(ir));
-    }
+    get_from_context! { get_init_static_metadata, init_static_metadata, ir::StaticMetadata, WorkId::InitStaticMetadata, restore }
+    set_from_context! { set_init_static_metadata, init_static_metadata, ir::StaticMetadata, WorkId::InitStaticMetadata, nop }
 
-    pub fn get_features(&self) -> Arc<ir::Features> {
-        let id = WorkId::Features;
-        self.acl.assert_read_access(&id);
-        {
-            let rl = self.feature_ir.read();
-            if rl.is_some() {
-                return rl.as_ref().unwrap().clone();
-            }
-        }
-        self.set_cached_features(self.restore(&self.paths.target_file(&id)));
-        let rl = self.feature_ir.read();
-        rl.as_ref().expect(MISSING_DATA).clone()
-    }
+    get_from_context! { get_final_static_metadata, final_static_metadata, ir::StaticMetadata, WorkId::FinalizeStaticMetadata, restore }
+    set_from_context! { set_final_static_metadata, final_static_metadata, ir::StaticMetadata, WorkId::FinalizeStaticMetadata, nop }
 
-    pub fn set_features(&self, ir: ir::Features) {
-        let id = WorkId::Features;
-        self.acl.assert_write_access(&id);
-        self.maybe_persist(&self.paths.target_file(&id), &ir);
-        self.set_cached_features(ir);
-    }
+    get_from_context! { get_features, feature_ir, ir::Features, WorkId::Features, restore }
+    set_from_context! { set_features, feature_ir, ir::Features, WorkId::Features, nop }
 }

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -43,7 +43,7 @@ impl Paths {
 
     pub fn target_file(&self, id: &WorkId) -> PathBuf {
         match id {
-            WorkId::InitStaticMetadata => self.build_dir.join("static_metadata.yml"),
+            WorkId::InitStaticMetadata => self.build_dir.join("static_metadata.preliminary.yml"),
             WorkId::FinalizeStaticMetadata => self.build_dir.join("static_metadata.yml"),
             WorkId::Glyph(name) => self.glyph_ir_file(name.as_str()),
             WorkId::GlyphIrDelete => self.build_dir.join("delete.yml"),

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -462,7 +462,7 @@ impl Work<Context, WorkError> for StaticMetadataWork {
             self.designspace_file.parent().unwrap(),
             &self.glyph_names,
         )?;
-        context.set_static_metadata(
+        context.set_init_static_metadata(
             StaticMetadata::new(axes, glyph_order, glyph_locations)
                 .map_err(WorkError::VariationModelError)?,
         );
@@ -508,7 +508,7 @@ impl Work<Context, WorkError> for GlyphIrWork {
             self.glyph_name,
             self.glif_files
         );
-        let static_metadata = context.get_static_metadata();
+        let static_metadata = context.get_init_static_metadata();
 
         // Migrate glif_files into internal coordinates
         let axes_by_name = static_metadata.axes.iter().map(|a| (&a.name, a)).collect();


### PR DESCRIPTION
Instead of hand-writing Context::get/set x try to use a macro. To make that work cleanly separate some things I'd been lazy about like not having explicitly separate init/final static metadata.

In `fontbe/src/orchestration.rs` I could not seem to hit on the right magic incantation to avoid writing per-type read functions. I end up wanting a constraint to FontRead and then I have a lifetime and then it's mad at me.