### PR TITLE
Add a minimal head table. Our fonts now ttx.

### DIFF
--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -18,6 +18,7 @@ pub fn create_font_work() -> Box<BeWork> {
 // TODO the tables have the tag, but I'm not sure how to access it
 const TABLES_TO_MERGE: &[(WorkId, Tag)] = &[
     (WorkId::Cmap, Tag::new(b"cmap")),
+    (WorkId::Head, Tag::new(b"head")),
     (WorkId::Hmtx, Tag::new(b"hmtx")),
     (WorkId::Glyf, Tag::new(b"glyf")),
     (WorkId::Loca, Tag::new(b"loca")),

--- a/fontbe/src/head.rs
+++ b/fontbe/src/head.rs
@@ -1,4 +1,4 @@
-//! Generates a [maxp](https://learn.microsoft.com/en-us/typography/opentype/spec/maxp) table.
+//! Generates a [head](https://learn.microsoft.com/en-us/typography/opentype/spec/head) table.
 
 use fontdrasil::orchestration::Work;
 use write_fonts::tables::head::Head;

--- a/fontbe/src/head.rs
+++ b/fontbe/src/head.rs
@@ -15,7 +15,7 @@ pub fn create_head_work() -> Box<BeWork> {
 }
 
 impl Work<Context, Error> for HeadWork {
-    /// Generate [maxp](https://learn.microsoft.com/en-us/typography/opentype/spec/maxp)
+    /// Generate [head](https://learn.microsoft.com/en-us/typography/opentype/spec/head)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_final_static_metadata();
         let head = Head {

--- a/fontbe/src/head.rs
+++ b/fontbe/src/head.rs
@@ -1,0 +1,29 @@
+//! Generates a [maxp](https://learn.microsoft.com/en-us/typography/opentype/spec/maxp) table.
+
+use fontdrasil::orchestration::Work;
+use write_fonts::tables::head::Head;
+
+use crate::{
+    error::Error,
+    orchestration::{BeWork, Context},
+};
+
+struct HeadWork {}
+
+pub fn create_head_work() -> Box<BeWork> {
+    Box::new(HeadWork {})
+}
+
+impl Work<Context, Error> for HeadWork {
+    /// Generate [maxp](https://learn.microsoft.com/en-us/typography/opentype/spec/maxp)
+    fn exec(&self, context: &Context) -> Result<(), Error> {
+        let static_metadata = context.ir.get_final_static_metadata();
+        let head = Head {
+            units_per_em: static_metadata.units_per_em,
+            index_to_loc_format: 1, // TODO: set based on num glyphs
+            ..Default::default()
+        };
+        context.set_head(head);
+        Ok(())
+    }
+}

--- a/fontbe/src/lib.rs
+++ b/fontbe/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod features;
 pub mod font;
 pub mod glyphs;
+pub mod head;
 pub mod hmtx;
 pub mod maxp;
 pub mod orchestration;

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -17,6 +17,7 @@ use write_fonts::{
     tables::{
         cmap::Cmap,
         glyf::{Bbox, SimpleGlyph},
+        head::Head,
         maxp::Maxp,
         post::Post,
     },
@@ -45,6 +46,7 @@ pub enum WorkId {
     Glyph(GlyphName),
     Cmap,
     Glyf,
+    Head,
     Hmtx,
     Loca,
     Maxp,
@@ -153,6 +155,7 @@ pub struct Context {
     cmap: ContextItem<Cmap>,
     post: ContextItem<Post>,
     maxp: ContextItem<Maxp>,
+    head: ContextItem<Head>,
     hmtx: ContextItem<Bytes>,
     font: ContextItem<Bytes>,
 }
@@ -170,6 +173,7 @@ impl Context {
             cmap: self.cmap.clone(),
             post: self.post.clone(),
             maxp: self.maxp.clone(),
+            head: self.head.clone(),
             hmtx: self.hmtx.clone(),
             font: self.font.clone(),
         }
@@ -187,6 +191,7 @@ impl Context {
             cmap: Arc::from(RwLock::new(None)),
             post: Arc::from(RwLock::new(None)),
             maxp: Arc::from(RwLock::new(None)),
+            head: Arc::from(RwLock::new(None)),
             hmtx: Arc::from(RwLock::new(None)),
             font: Arc::from(RwLock::new(None)),
         }
@@ -375,6 +380,7 @@ impl Context {
     context_accessors! { get_cmap, set_cmap, cmap, Cmap, WorkId::Cmap, from_file, to_bytes }
     context_accessors! { get_maxp, set_maxp, maxp, Maxp, WorkId::Maxp, from_file, to_bytes }
     context_accessors! { get_post, set_post, post, Post, WorkId::Post, from_file, to_bytes }
+    context_accessors! { get_head, set_head, head, Head, WorkId::Head, from_file, to_bytes }
 
     // Accessors where value is raw bytes
     context_accessors! { get_hmtx, set_hmtx, hmtx, Bytes, WorkId::Hmtx, raw_from_file, raw_to_bytes }

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -48,6 +48,7 @@ impl Paths {
             WorkId::Glyf => self.build_dir.join("glyf.table"),
             WorkId::Loca => self.build_dir.join("loca.table"),
             WorkId::Cmap => self.build_dir.join("cmap.table"),
+            WorkId::Head => self.build_dir.join("head.table"),
             WorkId::Hmtx => self.build_dir.join("hmtx.table"),
             WorkId::Maxp => self.build_dir.join("maxp.table"),
             WorkId::Post => self.build_dir.join("post.table"),

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -14,6 +14,7 @@ use fontbe::{
     features::FeatureWork,
     font::create_font_work,
     glyphs::{create_glyf_loca_work, create_glyph_work},
+    head::create_head_work,
     hmtx::create_hmtx_work,
     maxp::create_maxp_work,
     orchestration::{AnyWorkId, Context as BeContext, WorkId as BeWorkIdentifier},
@@ -519,6 +520,30 @@ fn add_post_be_job(
     Ok(())
 }
 
+fn add_head_be_job(
+    change_detector: &mut ChangeDetector,
+    workload: &mut Workload,
+) -> Result<(), Error> {
+    if change_detector.final_static_metadata_ir_change() {
+        let mut dependencies = HashSet::new();
+        dependencies.insert(FeWorkIdentifier::FinalizeStaticMetadata.into());
+
+        let id: AnyWorkId = BeWorkIdentifier::Head.into();
+        workload.insert(
+            id.clone(),
+            Job {
+                work: create_head_work().into(),
+                dependencies,
+                read_access: ReadAccess::Dependencies,
+                write_access: access_one(id),
+            },
+        );
+    } else {
+        workload.mark_success(BeWorkIdentifier::Head);
+    }
+    Ok(())
+}
+
 fn add_maxp_be_job(
     change_detector: &mut ChangeDetector,
     workload: &mut Workload,
@@ -599,6 +624,7 @@ fn add_font_be_job(
         dependencies.insert(BeWorkIdentifier::Features.into());
         dependencies.insert(BeWorkIdentifier::Cmap.into());
         dependencies.insert(BeWorkIdentifier::Glyf.into());
+        dependencies.insert(BeWorkIdentifier::Head.into());
         dependencies.insert(BeWorkIdentifier::Hmtx.into());
         dependencies.insert(BeWorkIdentifier::Loca.into());
         dependencies.insert(BeWorkIdentifier::Maxp.into());
@@ -935,6 +961,7 @@ fn create_workload(change_detector: &mut ChangeDetector) -> Result<Workload, Err
     add_feature_be_job(change_detector, &mut workload)?;
     add_glyf_loca_be_job(change_detector, &mut workload)?;
     add_cmap_be_job(change_detector, &mut workload)?;
+    add_head_be_job(change_detector, &mut workload)?;
     add_hmtx_be_job(change_detector, &mut workload)?;
     add_maxp_be_job(change_detector, &mut workload)?;
     add_post_be_job(change_detector, &mut workload)?;
@@ -1031,9 +1058,9 @@ mod tests {
     use crate::{
         add_cmap_be_job, add_feature_be_job, add_feature_ir_job,
         add_finalize_static_metadata_ir_job, add_font_be_job, add_glyf_loca_be_job,
-        add_glyph_ir_jobs, add_hmtx_be_job, add_init_static_metadata_ir_job, add_maxp_be_job,
-        add_post_be_job, finish_successfully, init, require_dir, Args, ChangeDetector, Config,
-        Workload,
+        add_glyph_ir_jobs, add_head_be_job, add_hmtx_be_job, add_init_static_metadata_ir_job,
+        add_maxp_be_job, add_post_be_job, finish_successfully, init, require_dir, Args,
+        ChangeDetector, Config, Workload,
     };
 
     fn testdata_dir() -> PathBuf {
@@ -1158,6 +1185,7 @@ mod tests {
 
         add_glyf_loca_be_job(&mut change_detector, &mut workload).unwrap();
         add_cmap_be_job(&mut change_detector, &mut workload).unwrap();
+        add_head_be_job(&mut change_detector, &mut workload).unwrap();
         add_hmtx_be_job(&mut change_detector, &mut workload).unwrap();
         add_maxp_be_job(&mut change_detector, &mut workload).unwrap();
         add_post_be_job(&mut change_detector, &mut workload).unwrap();
@@ -1240,6 +1268,7 @@ mod tests {
                 BeWorkIdentifier::Glyph("plus".into()).into(),
                 BeWorkIdentifier::Cmap.into(),
                 BeWorkIdentifier::Glyf.into(),
+                BeWorkIdentifier::Head.into(),
                 BeWorkIdentifier::Hmtx.into(),
                 BeWorkIdentifier::Loca.into(),
                 BeWorkIdentifier::Maxp.into(),
@@ -1647,6 +1676,7 @@ mod tests {
             vec![
                 Tag::new(b"cmap"),
                 Tag::new(b"glyf"),
+                Tag::new(b"head"),
                 Tag::new(b"hmtx"),
                 Tag::new(b"loca"),
                 Tag::new(b"maxp"),

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -110,6 +110,12 @@ pub enum WorkError {
     VariationModelError(#[from] VariationModelError),
     #[error("Contour reversal error {0}")]
     ContourReversalError(String),
+    #[error("Unable to determine units per em")]
+    NoUnitsPerEm,
+    #[error("Invalid units per em {0}")]
+    InvalidUpem(String),
+    #[error("Must have exactly one units per em, got {0:?}")]
+    InconsistentUpem(Vec<u16>),
 }
 
 /// An async work error, hence one that must be Send

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -23,6 +23,8 @@ use std::{
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(from = "StaticMetadataSerdeRepr", into = "StaticMetadataSerdeRepr")]
 pub struct StaticMetadata {
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/head>.
+    pub units_per_em: u16,
     /// Every axis used by the font being compiled
     pub axes: Vec<Axis>,
     /// The name of every glyph, in the order it will be emitted
@@ -39,6 +41,7 @@ pub struct StaticMetadata {
 
 impl StaticMetadata {
     pub fn new(
+        units_per_em: u16,
         axes: Vec<Axis>,
         glyph_order: IndexSet<GlyphName>,
         glyph_locations: HashSet<NormalizedLocation>,
@@ -46,6 +49,7 @@ impl StaticMetadata {
         let axis_names = axes.iter().map(|a| a.name.clone()).collect();
         let variation_model = VariationModel::new(glyph_locations, axis_names)?;
         Ok(StaticMetadata {
+            units_per_em,
             axes,
             glyph_order,
             variation_model,

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -47,6 +47,7 @@ impl From<CoordConverter> for CoordConverterSerdeRepr {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StaticMetadataSerdeRepr {
+    pub units_per_em: u16,
     pub axes: Vec<Axis>,
     pub glyph_order: Vec<String>,
     pub glyph_locations: Vec<NormalizedLocation>,
@@ -55,6 +56,7 @@ pub struct StaticMetadataSerdeRepr {
 impl From<StaticMetadataSerdeRepr> for StaticMetadata {
     fn from(from: StaticMetadataSerdeRepr) -> Self {
         StaticMetadata::new(
+            from.units_per_em,
             from.axes,
             from.glyph_order.into_iter().map(|s| s.into()).collect(),
             from.glyph_locations.into_iter().collect(),
@@ -66,6 +68,7 @@ impl From<StaticMetadataSerdeRepr> for StaticMetadata {
 impl From<StaticMetadata> for StaticMetadataSerdeRepr {
     fn from(from: StaticMetadata) -> Self {
         StaticMetadataSerdeRepr {
+            units_per_em: from.units_per_em,
             axes: from.axes,
             glyph_order: from
                 .glyph_order

--- a/glyphs-reader/src/error.rs
+++ b/glyphs-reader/src/error.rs
@@ -1,4 +1,4 @@
-use std::{io, path::PathBuf};
+use std::{io, num::TryFromIntError, path::PathBuf};
 
 use thiserror::Error;
 
@@ -10,4 +10,8 @@ pub enum Error {
     ParseError(PathBuf, String),
     #[error("Unexpected file structure {0}")]
     StructuralError(String),
+    #[error("No upem")]
+    NoUnitsPerEm,
+    #[error("Invalid upem")]
+    InvalidUpem(#[from] TryFromIntError),
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -69,6 +69,7 @@ impl GlyphsIrSource {
         // Wipe out glyph-related fields, track the rest
         // Explicitly field by field so if we add more compiler will force us to update here
         let font = Font {
+            units_per_em: font.units_per_em,
             family_name: font.family_name.clone(),
             axes: font.axes.clone(),
             font_master: font.font_master.clone(),
@@ -197,7 +198,7 @@ impl Work<Context, WorkError> for StaticMetadataWork {
             .filter(|gn| self.glyph_names.contains(gn))
             .collect();
         context.set_init_static_metadata(
-            StaticMetadata::new(axes, glyph_order, glyph_locations)
+            StaticMetadata::new(font.units_per_em, axes, glyph_order, glyph_locations)
                 .map_err(WorkError::VariationModelError)?,
         );
         Ok(())
@@ -667,7 +668,8 @@ mod tests {
 
     // It's so minimal it's a good test
     #[test]
-    fn loads_hmtx_one_glyph() {
-        build_static_metadata(glyphs2_dir().join("NotDef.glyphs"));
+    fn loads_minimal() {
+        let (_, context) = build_static_metadata(glyphs2_dir().join("NotDef.glyphs"));
+        assert_eq!(1000, context.get_init_static_metadata().units_per_em);
     }
 }

--- a/resources/testdata/FloatUpem-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/FloatUpem-Regular.ufo/fontinfo.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <real>255.5</real>
+  </dict>
+</plist>

--- a/resources/testdata/FloatUpem-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/FloatUpem-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict/>
+</plist>

--- a/resources/testdata/FloatUpem-Regular.ufo/lib.plist
+++ b/resources/testdata/FloatUpem-Regular.ufo/lib.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array/>
+  </dict>
+</plist>

--- a/resources/testdata/float_upem.designspace
+++ b/resources/testdata/float_upem.designspace
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Derived from Noto Sans Adlam -->
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="400" default="400"/>
+  </axes>
+  <sources>
+    <source filename="FloatUpem-Regular.ufo" name="Float Upem Regular" familyname="Float Upem" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance name="FloatUpem Regular" familyname="Float Upem" stylename="Regular" filename="instance_ufos/Static-Regular.ufo" stylemapfamilyname="Static" stylemapstylename="regular">
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </instance>
+  </instances>
+</designspace>

--- a/resources/testdata/glyphs3/infinity.glyphs
+++ b/resources/testdata/glyphs3/infinity.glyphs
@@ -8,4 +8,5 @@ glyphs = (
 	}
 );
 fontMaster = ();
+unitsPerEm = 1000;
 }

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -28,6 +28,8 @@ thiserror = "1.0.37"
 
 plist = { version =  "1.3.1", features = ["serde"] }
 
+write-fonts = "0.1.2"  # for ot_round
+
 ordered-float = { version = "3.4.0", features = ["serde"] }
 indexmap = "1.9.2"
 

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -16,6 +16,7 @@ use fontir::{
 use indexmap::IndexSet;
 use log::{debug, trace, warn};
 use norad::designspace::{self, DesignSpaceDocument};
+use write_fonts::OtRound;
 
 use crate::toir::{to_design_location, to_ir_axes, to_ir_glyph, to_normalized_locations};
 
@@ -435,27 +436,23 @@ fn glyph_order(
     Ok(glyph_order)
 }
 
-fn units_per_em(
-    designspace: &DesignSpaceDocument,
-    designspace_dir: &Path,
-) -> Result<u16, WorkError> {
+fn units_per_em(font_infos: &[plist::Dictionary]) -> Result<u16, WorkError> {
     let mut upems: HashSet<u16> = HashSet::new();
-    for source in designspace.sources.iter() {
-        let ufo_dir = designspace_dir.join(&source.filename);
-        if !ufo_dir.join("fontinfo.plist").exists() {
-            continue;
-        }
-        let fontinfo = load_plist(&ufo_dir, "fontinfo.plist")?;
-        let Some(plist::Value::Integer(upem)) = fontinfo.get("unitsPerEm") else {
-            return Err(WorkError::NoUnitsPerEm);
+    for font_info in font_infos.iter() {
+        let raw_upem = font_info.get("unitsPerEm");
+        let upem = match raw_upem {
+            Some(plist::Value::Real(value)) => *value,
+            Some(plist::Value::Integer(value)) => match value.as_unsigned() {
+                Some(value) => value as f64,
+                None => return Err(WorkError::InvalidUpem(format!("{value}"))),
+            },
+            Some(..) => return Err(WorkError::InvalidUpem(format!("{raw_upem:?}"))),
+            _ => return Err(WorkError::NoUnitsPerEm),
         };
-        let upem = upem
-            .as_unsigned()
-            .ok_or_else(|| WorkError::InvalidUpem(format!("{upem} outside u64 range")))?;
-        let upem = upem
-            .try_into()
-            .map_err(|e| WorkError::InvalidUpem(format!("{upem} failed into u16: {e}")))?;
-        upems.insert(upem);
+        if upem > (u16::MAX as f64 + 0.5) {
+            return Err(WorkError::InvalidUpem(format!("{upem} out of bounds")));
+        }
+        upems.insert(upem.ot_round());
     }
 
     if upems.len() != 1 {
@@ -481,12 +478,28 @@ fn files_identical(f1: &Path, f2: &Path) -> Result<bool, WorkError> {
     Ok(true)
 }
 
+fn font_infos(
+    designspace_dir: &Path,
+    designspace: &DesignSpaceDocument,
+) -> Result<Vec<plist::Dictionary>, WorkError> {
+    let mut results = Vec::new();
+    for source in designspace.sources.iter() {
+        let ufo_dir = designspace_dir.join(&source.filename);
+        if !ufo_dir.join("fontinfo.plist").exists() {
+            continue;
+        }
+        results.push(load_plist(&ufo_dir, "fontinfo.plist")?);
+    }
+    Ok(results)
+}
+
 impl Work<Context, WorkError> for StaticMetadataWork {
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         debug!("Static metadata for {:#?}", self.designspace_file);
         let designspace_dir = self.designspace_file.parent().unwrap();
 
-        let units_per_em = units_per_em(&self.designspace, designspace_dir)?;
+        let font_infos = font_infos(designspace_dir, &self.designspace)?;
+        let units_per_em = units_per_em(&font_infos)?;
         let axes = to_ir_axes(&self.designspace.axes);
         let glyph_locations = to_normalized_locations(&axes, &self.designspace.sources);
 
@@ -573,7 +586,7 @@ mod tests {
     use indexmap::IndexSet;
     use norad::designspace;
 
-    use crate::toir::to_design_location;
+    use crate::{source::font_infos, toir::to_design_location};
 
     use super::{default_master, glif_files, glyph_order, units_per_em, DesignSpaceIrSource};
 
@@ -621,10 +634,14 @@ mod tests {
         );
     }
 
-    fn test_source() -> (DesignSpaceIrSource, Input) {
-        let mut source = DesignSpaceIrSource::new(testdata_dir().join("wght_var.designspace"));
+    fn load_designspace(name: &str) -> (DesignSpaceIrSource, Input) {
+        let mut source = DesignSpaceIrSource::new(testdata_dir().join(name));
         let input = source.inputs().unwrap();
         (source, input)
+    }
+
+    fn load_wght_var() -> (DesignSpaceIrSource, Input) {
+        load_designspace("wght_var.designspace")
     }
 
     fn add_design_location(
@@ -643,7 +660,7 @@ mod tests {
 
     #[test]
     pub fn create_work() {
-        let (ir_source, input) = test_source();
+        let (ir_source, input) = load_wght_var();
 
         let work = ir_source
             .create_work_for_one_glyph(&"bar".into(), &input)
@@ -673,7 +690,7 @@ mod tests {
 
     #[test]
     pub fn create_sparse_work() {
-        let (ir_source, input) = test_source();
+        let (ir_source, input) = load_wght_var();
 
         let work = ir_source
             .create_work_for_one_glyph(&"plus".into(), &input)
@@ -698,14 +715,14 @@ mod tests {
 
     #[test]
     pub fn only_glyphs_present_in_default() {
-        let (_, inputs) = test_source();
+        let (_, inputs) = load_wght_var();
         // bonus_bar is not present in the default master; should discard
         assert!(!inputs.glyphs.contains_key(&"bonus_bar".into()));
     }
 
     #[test]
     pub fn find_default_master() {
-        let (source, _) = test_source();
+        let (source, _) = load_wght_var();
         let ds = source.load_designspace().unwrap();
         let mut loc = DesignLocation::new();
         loc.set_pos("Weight", DesignCoord::new(400.0));
@@ -719,7 +736,7 @@ mod tests {
     pub fn builds_glyph_order_for_wght_var() {
         // Only WghtVar-Regular.ufo has a lib.plist, and it only lists a subset of glyphs
         // Should still work.
-        let (source, _) = test_source();
+        let (source, _) = load_wght_var();
         let ds = source.load_designspace().unwrap();
         let go = glyph_order(
             &ds,
@@ -737,10 +754,20 @@ mod tests {
 
     #[test]
     pub fn fetches_upem() {
-        let (source, _) = test_source();
+        let (source, _) = load_wght_var();
+        let font_infos =
+            font_infos(&source.designspace_dir, &source.load_designspace().unwrap()).unwrap();
+        assert_eq!(1000, units_per_em(&font_infos).unwrap());
+    }
+
+    #[test]
+    pub fn ot_rounds_upem() {
+        let (source, _) = load_designspace("float_upem.designspace");
+        let font_infos =
+            font_infos(&source.designspace_dir, &source.load_designspace().unwrap()).unwrap();
         assert_eq!(
-            1000,
-            units_per_em(&source.load_designspace().unwrap(), &source.designspace_dir).unwrap()
+            256, // 255.5 rounded toward +infinity
+            units_per_em(&font_infos).unwrap()
         );
     }
 }


### PR DESCRIPTION
Contributes to #138.

Put upem into it because hey, we might need that. Turns out we weren't capturing it from source so... do so.

ttx now runs to completion on fontc produced fonts. I'm mildly amazed. Try it yourself!

```shell
cargo run -p fontc -- --source resources/testdata/static.designspace
ttx build/font.ttf
```