### PR TITLE
Require Glyph to have a default location, make that instance easy to get

### DIFF
--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -279,7 +279,7 @@ impl TryFrom<&ir::Glyph> for CheckedGlyph {
     fn try_from(glyph: &ir::Glyph) -> Result<Self, Self::Error> {
         // every instance must have consistent component glyphs
         let components: HashSet<BTreeSet<GlyphName>> = glyph
-            .sources
+            .sources()
             .values()
             .map(|s| s.components.iter().map(|c| c.base.clone()).collect())
             .collect();
@@ -293,7 +293,7 @@ impl TryFrom<&ir::Glyph> for CheckedGlyph {
 
         // every instance must have consistent path element types
         let path_els: HashSet<String> = glyph
-            .sources
+            .sources()
             .values()
             .map(|s| {
                 s.contours
@@ -332,7 +332,7 @@ impl TryFrom<&ir::Glyph> for CheckedGlyph {
         let name = glyph.name.clone();
         Ok(if components.is_empty() {
             let contours = glyph
-                .sources
+                .sources()
                 .iter()
                 .map(|(location, instance)| {
                     if instance.contours.len() > 1 {
@@ -355,7 +355,7 @@ impl TryFrom<&ir::Glyph> for CheckedGlyph {
             CheckedGlyph::Contour { name, contours }
         } else {
             let components = glyph
-                .sources
+                .sources()
                 .iter()
                 .flat_map(|(location, instance)| {
                     eprintln!("{} {:?}", glyph.name, instance.components);

--- a/fontbe/src/hmetrics.rs
+++ b/fontbe/src/hmetrics.rs
@@ -26,8 +26,6 @@ impl Work<Context, Error> for HMetricWork {
     /// and [hhea](https://learn.microsoft.com/en-us/typography/opentype/spec/hhea)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_final_static_metadata();
-        let var_model = &static_metadata.variation_model;
-        let default_location = var_model.default_location();
 
         let mut min_left_side_bearing = None;
         let mut min_right_side_bearing = None;
@@ -40,9 +38,7 @@ impl Work<Context, Error> for HMetricWork {
                 let glyph = context.get_glyph(gn);
                 let bbox = glyph.bbox();
                 let ir_glyph = context.ir.get_glyph_ir(gn);
-                let Some(ir_instance) = ir_glyph.sources.get(default_location) else {
-                    panic!("{gn} is not defined at the default location.");
-                };
+                let ir_instance = ir_glyph.default_instance();
                 let advance: u16 = ir_instance.width.ot_round();
                 let left_side_bearing = bbox.x_min;
                 // aw - (lsb + xMax - xMin) ... but if lsb == xMin then just advance - xMax?

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     coords::{CoordConverter, DesignCoord, NormalizedLocation, UserCoord},
-    ir::{Axis, Glyph, GlyphInstance, StaticMetadata},
+    ir::{Axis, Glyph, GlyphBuilder, GlyphInstance, StaticMetadata},
     stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
 };
 
@@ -96,7 +96,7 @@ pub struct GlyphSerdeRepr {
 
 impl From<GlyphSerdeRepr> for Glyph {
     fn from(from: GlyphSerdeRepr) -> Self {
-        Glyph {
+        GlyphBuilder {
             name: from.name.into(),
             codepoints: from.codepoints,
             sources: from
@@ -105,11 +105,14 @@ impl From<GlyphSerdeRepr> for Glyph {
                 .map(|g| (g.location, g.instance))
                 .collect(),
         }
+        .try_into()
+        .unwrap()
     }
 }
 
 impl From<Glyph> for GlyphSerdeRepr {
     fn from(from: Glyph) -> Self {
+        let from: GlyphBuilder = from.into();
         GlyphSerdeRepr {
             name: from.name.as_str().to_string(),
             codepoints: from.codepoints,

--- a/resources/testdata/glyphs3/Unicode-UnquotedDec.glyphs
+++ b/resources/testdata/glyphs3/Unicode-UnquotedDec.glyphs
@@ -1,13 +1,29 @@
 {
 .formatVersion = 3;
-familyName = WghtVar;
-fontMaster = ();
-glyphs = (
+familyName = "Unquoted Dec";
+axes = (
 	{
-		glyphname = name;
-		layers = ();
-		unicode = 182;
+		name = Weight;
+		tag = wght;
 	}
+);
+fontMaster = (
+    {
+        id = m01;
+		axesValues = (400);
+    }
+);
+glyphs = (
+{
+    glyphname = name;
+    layers = (
+        {
+            layerId = m01;
+            width = 420;
+        }
+    );
+    unicode = 182;
+}
 );
 unitsPerEm = 1000;
 }

--- a/resources/testdata/glyphs3/Unicode-UnquotedDecSequence.glyphs
+++ b/resources/testdata/glyphs3/Unicode-UnquotedDecSequence.glyphs
@@ -1,11 +1,27 @@
 {
 .formatVersion = 3;
-familyName = WghtVar;
-fontMaster = ();
+familyName = "Unquoted Dec Sequence";
+axes = (
+	{
+		name = Weight;
+		tag = wght;
+	}
+);
+fontMaster = (
+    {
+        id = m01;
+		axesValues = (400);
+    }
+);
 glyphs = (
 	{
 		glyphname = name;
-		layers = ();
+		layers = (
+			{
+				layerId = m01;
+				width = 420;
+			}
+		);
 		unicode = (1619,1764);
 	}
 );

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -564,8 +564,7 @@ impl Work<Context, WorkError> for GlyphIrWork {
             glif_files.insert(path, normalized_locations);
         }
 
-        let glyph_ir = to_ir_glyph(self.glyph_name.clone(), &glif_files)
-            .map_err(|e| WorkError::GlyphIrWorkError(self.glyph_name.clone(), e.to_string()))?;
+        let glyph_ir = to_ir_glyph(self.glyph_name.clone(), &glif_files)?;
         context.set_glyph_ir(glyph_ir);
         Ok(())
     }

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -133,7 +133,7 @@ pub fn to_ir_glyph(
     glyph_name: GlyphName,
     glif_files: &HashMap<&PathBuf, Vec<NormalizedLocation>>,
 ) -> Result<ir::Glyph, WorkError> {
-    let mut glyph = ir::Glyph::new(glyph_name);
+    let mut glyph = ir::GlyphBuilder::new(glyph_name);
     for (glif_file, locations) in glif_files {
         let norad_glyph =
             norad::Glyph::load(glif_file).map_err(|e| WorkError::InvalidSourceGlyph {
@@ -147,7 +147,7 @@ pub fn to_ir_glyph(
             glyph.try_add_source(location, to_ir_glyph_instance(&norad_glyph)?)?;
         }
     }
-    Ok(glyph)
+    glyph.try_into()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`Glyph::default_location -> GlyphInstance` is added and used by hmtx. Various other files are modified for the sheer joy of it.

Fixes #164. Feel free to merge if it seems OK. 