### PR TITLE
Rework AccessFn type

### DIFF
--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, fs, io, path::Path, sync::Arc};
 
 use fontdrasil::{
-    orchestration::{AccessControlList, AccessFn, Work, MISSING_DATA},
+    orchestration::{Access, AccessControlList, Work, MISSING_DATA},
     types::GlyphName,
 };
 use fontir::{
@@ -211,8 +211,8 @@ impl Context {
 
     pub fn copy_for_work(
         &self,
-        read_access: AccessFn<AnyWorkId>,
-        write_access: AccessFn<AnyWorkId>,
+        read_access: Access<AnyWorkId>,
+        write_access: Access<AnyWorkId>,
     ) -> Context {
         self.copy(AccessControlList::read_write(read_access, write_access))
     }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, fs, io, path::Path, sync::Arc};
 
 use fontdrasil::{
-    orchestration::{AccessControlList, Work, MISSING_DATA},
+    orchestration::{AccessControlList, AccessFn, Work, MISSING_DATA},
     types::GlyphName,
 };
 use fontir::{
@@ -211,8 +211,8 @@ impl Context {
 
     pub fn copy_for_work(
         &self,
-        read_access: Arc<dyn Fn(&AnyWorkId) -> bool + Send + Sync>,
-        write_access: Arc<dyn Fn(&AnyWorkId) -> bool + Send + Sync>,
+        read_access: AccessFn<AnyWorkId>,
+        write_access: AccessFn<AnyWorkId>,
     ) -> Context {
         self.copy(AccessControlList::read_write(read_access, write_access))
     }

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 
 use crossbeam_channel::{Receiver, TryRecvError};
 use fontbe::orchestration::{AnyWorkId, Context as BeContext, WorkId as BeWorkIdentifier};
-use fontdrasil::orchestration::AccessFn;
+use fontdrasil::orchestration::Access;
 use fontir::orchestration::{Context as FeContext, WorkId as FeWorkIdentifier};
 
 use crate::{
@@ -31,7 +31,7 @@ pub(crate) struct Job {
     // Things our job needs read access to. Usually all our dependencies.
     pub(crate) read_access: ReadAccess,
     // Things our job needs write access to
-    pub(crate) write_access: AccessFn<AnyWorkId>,
+    pub(crate) write_access: Access<AnyWorkId>,
 }
 
 enum RecvType {

--- a/fontdrasil/src/lib.rs
+++ b/fontdrasil/src/lib.rs
@@ -1,4 +1,5 @@
 //! Helper library for code that is of value to FE and BE of font compilation.
+
 pub mod orchestration;
 pub mod paths;
 pub mod types;

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -22,14 +22,10 @@ thiserror = "1.0.37"
 
 kurbo = { version = "0.9.0", features = ["serde"] }
 ordered-float = { version = "3.4.0", features = ["serde"] }
-
 indexmap = "1.9.2"
-
 blake3 = "1.3.3"
-
 log = "0.4"
 env_logger = "0.10.0"
-
 parking_lot = "0.12.1"
 
 write-fonts = "0.1.4"  # for pens

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -328,7 +328,7 @@ impl Work<Context, WorkError> for FinalizeStaticMetadataWork {
 mod tests {
     use std::{collections::HashSet, path::Path};
 
-    use fontdrasil::{orchestration::AccessFn, types::GlyphName};
+    use fontdrasil::{orchestration::Access, types::GlyphName};
     use indexmap::IndexSet;
     use kurbo::{Affine, BezPath};
     use write_fonts::pens::{write_to_pen, BezPathPen, ReverseContourPen};
@@ -508,8 +508,8 @@ mod tests {
         let coalesce_me = contour_and_component_weight_glyph("coalesce_me");
 
         let context = test_root().copy_for_work(
-            AccessFn::one(WorkId::Glyph("component".into())),
-            AccessFn::all(),
+            Access::one(WorkId::Glyph("component".into())),
+            Access::all(),
         );
         context.set_glyph_ir(contour_glyph("component"));
 
@@ -549,8 +549,8 @@ mod tests {
             WorkId::Glyph(c2.name.clone()),
         ]);
         let context = test_root().copy_for_work(
-            AccessFn::new(move |id| allow_access.contains(id)),
-            AccessFn::all(),
+            Access::custom(move |id| allow_access.contains(id)),
+            Access::all(),
         );
         context.set_glyph_ir(reuse_me);
         context.set_glyph_ir(c1.clone());
@@ -630,8 +630,8 @@ mod tests {
             .unwrap();
 
         let context = test_root().copy_for_work(
-            AccessFn::one(WorkId::Glyph(reuse_me.name.clone())),
-            AccessFn::all(),
+            Access::one(WorkId::Glyph(reuse_me.name.clone())),
+            Access::all(),
         );
         context.set_glyph_ir(reuse_me);
 
@@ -689,8 +689,8 @@ mod tests {
         let glyph = adjust_transform_for_each_instance(&glyph.try_into().unwrap());
 
         let context = test_root().copy_for_work(
-            AccessFn::one(WorkId::Glyph("component".into())),
-            AccessFn::all(),
+            Access::one(WorkId::Glyph("component".into())),
+            Access::all(),
         );
         context.set_glyph_ir(contour_glyph("component"));
 
@@ -704,8 +704,8 @@ mod tests {
         let glyph = adjust_transform_for_each_instance(&glyph);
 
         let context = test_root().copy_for_work(
-            AccessFn::one(WorkId::Glyph("component".into())),
-            AccessFn::all(),
+            Access::one(WorkId::Glyph("component".into())),
+            Access::all(),
         );
         context.set_glyph_ir(contour_glyph("component"));
 

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -326,9 +326,9 @@ impl Work<Context, WorkError> for FinalizeStaticMetadataWork {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, path::Path, sync::Arc};
+    use std::{collections::HashSet, path::Path};
 
-    use fontdrasil::{orchestration::access_one, types::GlyphName};
+    use fontdrasil::{orchestration::AccessFn, types::GlyphName};
     use indexmap::IndexSet;
     use kurbo::{Affine, BezPath};
     use write_fonts::pens::{write_to_pen, BezPathPen, ReverseContourPen};
@@ -508,8 +508,8 @@ mod tests {
         let coalesce_me = contour_and_component_weight_glyph("coalesce_me");
 
         let context = test_root().copy_for_work(
-            access_one(WorkId::Glyph("component".into())),
-            Arc::new(|_| true),
+            AccessFn::one(WorkId::Glyph("component".into())),
+            AccessFn::all(),
         );
         context.set_glyph_ir(contour_glyph("component"));
 
@@ -549,8 +549,8 @@ mod tests {
             WorkId::Glyph(c2.name.clone()),
         ]);
         let context = test_root().copy_for_work(
-            Arc::new(move |id| allow_access.contains(id)),
-            Arc::new(|_| true),
+            AccessFn::new(move |id| allow_access.contains(id)),
+            AccessFn::all(),
         );
         context.set_glyph_ir(reuse_me);
         context.set_glyph_ir(c1.clone());
@@ -630,8 +630,8 @@ mod tests {
             .unwrap();
 
         let context = test_root().copy_for_work(
-            access_one(WorkId::Glyph(reuse_me.name.clone())),
-            Arc::new(|_| true),
+            AccessFn::one(WorkId::Glyph(reuse_me.name.clone())),
+            AccessFn::all(),
         );
         context.set_glyph_ir(reuse_me);
 
@@ -689,8 +689,8 @@ mod tests {
         let glyph = adjust_transform_for_each_instance(&glyph.try_into().unwrap());
 
         let context = test_root().copy_for_work(
-            access_one(WorkId::Glyph("component".into())),
-            Arc::new(|_| true),
+            AccessFn::one(WorkId::Glyph("component".into())),
+            AccessFn::all(),
         );
         context.set_glyph_ir(contour_glyph("component"));
 
@@ -704,8 +704,8 @@ mod tests {
         let glyph = adjust_transform_for_each_instance(&glyph);
 
         let context = test_root().copy_for_work(
-            access_one(WorkId::Glyph("component".into())),
-            Arc::new(|_| true),
+            AccessFn::one(WorkId::Glyph("component".into())),
+            AccessFn::all(),
         );
         context.set_glyph_ir(contour_glyph("component"));
 

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -11,7 +11,7 @@ use std::{
 
 use bitflags::bitflags;
 use fontdrasil::{
-    orchestration::{AccessControlList, AccessFn, Work, MISSING_DATA},
+    orchestration::{Access, AccessControlList, Work, MISSING_DATA},
     types::GlyphName,
 };
 use parking_lot::RwLock;
@@ -150,8 +150,8 @@ impl Context {
 
     pub fn copy_for_work(
         &self,
-        read_access: AccessFn<WorkId>,
-        write_access: AccessFn<WorkId>,
+        read_access: Access<WorkId>,
+        write_access: Access<WorkId>,
     ) -> Context {
         self.copy(AccessControlList::read_write(read_access, write_access))
     }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -11,7 +11,7 @@ use std::{
 
 use bitflags::bitflags;
 use fontdrasil::{
-    orchestration::{AccessControlList, Work, MISSING_DATA},
+    orchestration::{AccessControlList, AccessFn, Work, MISSING_DATA},
     types::GlyphName,
 };
 use parking_lot::RwLock;
@@ -150,8 +150,8 @@ impl Context {
 
     pub fn copy_for_work(
         &self,
-        read_access: Arc<dyn Fn(&WorkId) -> bool + Send + Sync>,
-        write_access: Arc<dyn Fn(&WorkId) -> bool + Send + Sync>,
+        read_access: AccessFn<WorkId>,
+        write_access: AccessFn<WorkId>,
     ) -> Context {
         self.copy(AccessControlList::read_write(read_access, write_access))
     }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -327,10 +327,7 @@ mod tests {
         path::{Path, PathBuf},
     };
 
-    use fontdrasil::{
-        orchestration::{access_none, access_one},
-        types::GlyphName,
-    };
+    use fontdrasil::{orchestration::AccessFn, types::GlyphName};
     use fontir::{
         coords::{
             CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord,
@@ -420,7 +417,7 @@ mod tests {
     fn static_metadata_ir() {
         let (source, context) = context_for(glyphs3_dir().join("WghtVar.glyphs"));
         let task_context =
-            context.copy_for_work(access_none(), access_one(WorkId::InitStaticMetadata));
+            context.copy_for_work(AccessFn::none(), AccessFn::one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -448,7 +445,7 @@ mod tests {
         // Caused index out of bounds due to transposed master and value indices
         let (source, context) = context_for(glyphs2_dir().join("BadIndexing.glyphs"));
         let task_context =
-            context.copy_for_work(access_none(), access_one(WorkId::InitStaticMetadata));
+            context.copy_for_work(AccessFn::none(), AccessFn::one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -460,7 +457,7 @@ mod tests {
     fn loads_axis_mappings_from_glyphs2() {
         let (source, context) = context_for(glyphs2_dir().join("OpszWghtVar_AxisMappings.glyphs"));
         let task_context =
-            context.copy_for_work(access_none(), access_one(WorkId::InitStaticMetadata));
+            context.copy_for_work(AccessFn::none(), AccessFn::one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -515,7 +512,7 @@ mod tests {
         let _ = env_logger::builder().is_test(true).try_init();
         let (source, context) = context_for(glyphs_file);
         let task_context =
-            context.copy_for_work(access_none(), access_one(WorkId::InitStaticMetadata));
+            context.copy_for_work(AccessFn::none(), AccessFn::one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -536,8 +533,8 @@ mod tests {
                 .unwrap();
             for work in work_items.iter() {
                 let task_context = context.copy_for_work(
-                    access_one(WorkId::InitStaticMetadata),
-                    access_one(WorkId::Glyph(glyph_name.clone())),
+                    AccessFn::one(WorkId::InitStaticMetadata),
+                    AccessFn::one(WorkId::Glyph(glyph_name.clone())),
                 );
                 work.exec(&task_context)?;
             }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -327,7 +327,7 @@ mod tests {
         path::{Path, PathBuf},
     };
 
-    use fontdrasil::{orchestration::AccessFn, types::GlyphName};
+    use fontdrasil::{orchestration::Access, types::GlyphName};
     use fontir::{
         coords::{
             CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord,
@@ -417,7 +417,7 @@ mod tests {
     fn static_metadata_ir() {
         let (source, context) = context_for(glyphs3_dir().join("WghtVar.glyphs"));
         let task_context =
-            context.copy_for_work(AccessFn::none(), AccessFn::one(WorkId::InitStaticMetadata));
+            context.copy_for_work(Access::none(), Access::one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -445,7 +445,7 @@ mod tests {
         // Caused index out of bounds due to transposed master and value indices
         let (source, context) = context_for(glyphs2_dir().join("BadIndexing.glyphs"));
         let task_context =
-            context.copy_for_work(AccessFn::none(), AccessFn::one(WorkId::InitStaticMetadata));
+            context.copy_for_work(Access::none(), Access::one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -457,7 +457,7 @@ mod tests {
     fn loads_axis_mappings_from_glyphs2() {
         let (source, context) = context_for(glyphs2_dir().join("OpszWghtVar_AxisMappings.glyphs"));
         let task_context =
-            context.copy_for_work(AccessFn::none(), AccessFn::one(WorkId::InitStaticMetadata));
+            context.copy_for_work(Access::none(), Access::one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -512,7 +512,7 @@ mod tests {
         let _ = env_logger::builder().is_test(true).try_init();
         let (source, context) = context_for(glyphs_file);
         let task_context =
-            context.copy_for_work(AccessFn::none(), AccessFn::one(WorkId::InitStaticMetadata));
+            context.copy_for_work(Access::none(), Access::one(WorkId::InitStaticMetadata));
         source
             .create_static_metadata_work(&context.input)
             .unwrap()
@@ -533,8 +533,8 @@ mod tests {
                 .unwrap();
             for work in work_items.iter() {
                 let task_context = context.copy_for_work(
-                    AccessFn::one(WorkId::InitStaticMetadata),
-                    AccessFn::one(WorkId::Glyph(glyph_name.clone())),
+                    Access::one(WorkId::InitStaticMetadata),
+                    Access::one(WorkId::Glyph(glyph_name.clone())),
                 );
                 work.exec(&task_context)?;
             }


### PR DESCRIPTION
This is a little refactor around the `AccessFn` type.

TLDR: I wanted to make this a struct so that we could replace the free functions used to construct it with some methods, and then in the process of that I decided it would be more efficient to use an enum that could efficiently handle the common none/all/one cases.

This isn't a hugely impactful change, but I think it is at least a modest ergonomics improvement.