### PR TITLE
Remove doc(hidden) from test helper

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -1,6 +1,6 @@
 //! Command line arguments
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::Parser;
 use fontir::orchestration::Flags;
@@ -55,8 +55,8 @@ impl Args {
     }
 
     /// Manually create args for testing
-    #[doc(hidden)]
-    pub fn for_test(build_dir: &Path, source: &str) -> Args {
+    #[cfg(test)]
+    pub fn for_test(build_dir: &std::path::Path, source: &str) -> Args {
         fn testdata_dir() -> PathBuf {
             let path = PathBuf::from("../resources/testdata")
                 .canonicalize()


### PR DESCRIPTION
This was necessary when it was called from another crate, but now all tests live in the lib.


Just Merge Me