### PR TITLE
Remove unnecessary bounds on types

### DIFF
--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -25,10 +25,7 @@ pub trait Work<C, E> {
 ///
 /// Not meant to prevent malicious access, merely to detect mistakes
 /// because the result of mistaken concurrent access can be confusing to track down.
-pub struct AccessControlList<I>
-where
-    I: Eq + Hash + Debug,
-{
+pub struct AccessControlList<I> {
     // Returns true if you can write to the provided id
     write_access: AccessFn<I>,
 

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -38,9 +38,7 @@ pub struct NormalizedCoord(OrderedFloat<f32>);
 /// E.g. a user location is a `Location<UserCoord>`. Hashable so it can do things like be
 /// the key for a map of sources by location.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
-pub struct Location<T>(BTreeMap<String, T>)
-where
-    T: Copy;
+pub struct Location<T>(BTreeMap<String, T>);
 
 pub type DesignLocation = Location<DesignCoord>;
 pub type UserLocation = Location<UserCoord>;


### PR DESCRIPTION
If needed, these bounds can be added to the relevant impl blocks (although we seem to compile fine without them)


JMM