### PR TITLE
add pre-push git hook to check for println! or eprintln! statements in Rust files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,9 @@ jobs:
       - name: cargo doc
         run: cargo doc --all-features --document-private-items --no-deps
 
+      - name: check no println! or eprintln! statements
+        run: resources/scripts/check_no_println.sh
+
   clippy-lint:
     name: Clippy lints
     runs-on: ubuntu-latest

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -362,7 +362,7 @@ impl TryFrom<&ir::Glyph> for CheckedGlyph {
                 .sources()
                 .iter()
                 .flat_map(|(location, instance)| {
-                    eprintln!("{} {:?}", glyph.name, instance.components);
+                    trace!("{} {:?}", glyph.name, instance.components);
                     instance
                         .components
                         .iter()

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -242,13 +242,13 @@ impl Workload {
         while !self.jobs_pending.is_empty() {
             let launchable = self.launchable();
             if launchable.is_empty() {
-                eprintln!("Completed:");
+                log::error!("Completed:");
                 for id in self.success.iter() {
-                    eprintln!("  {id:?}");
+                    log::error!("  {id:?}");
                 }
-                eprintln!("Unable to proceed with:");
+                log::error!("Unable to proceed with:");
                 for (id, job) in self.jobs_pending.iter() {
-                    eprintln!("  {:?}, happens-after {:?}", id, job.dependencies);
+                    log::error!("  {:?}, happens-after {:?}", id, job.dependencies);
                 }
                 assert!(
                     !launchable.is_empty(),

--- a/resources/githooks/pre-commit
+++ b/resources/githooks/pre-commit
@@ -2,6 +2,44 @@
 
 set -e
 
+
+search_added_rust_lines_with_prints() {
+    # --diff-filter=A is to list only added files, excluding modified/deleted
+    git diff --cached --name-only --diff-filter=A | \
+    grep '\.rs$' | \
+    while read -r file; do
+        # For each file, get a unified diff with no context (-U0)
+        git diff --cached -U0 -- "$file" | \
+        # Strip lines starting with '+++' containing the file name
+        grep -v -E '^\+\+\+' | \
+        # Select only the added lines, i.e. starting with a plus sign
+        grep -E '^\+' | \
+        # Strip the '+' prefix and all inline comments
+        sed -e 's/^\+//' -e 's://.*$::' | \
+        # Prepend the file name and line number to each line
+        awk -v file="$file" '{ printf "%s:%s: %s\n", file, FNR, $0 }' | \
+        # Grep for print statements
+        grep --color=always -E '\b(println!|eprintln!)' || true
+    done
+}
+
+check_rust_prints() {
+    # Check for println! or eprintln! statements in git-added Rust files, ignoring comments.
+
+    matches=$(search_added_rust_lines_with_prints)
+
+    if [ ! -z "$matches" ]; then
+        echo "Error: The following Rust source files contain println! or eprintln! statements:"
+        echo "$matches"
+        echo "Please remove or comment out the println! and eprintln! statements before committing."
+        return 1
+    fi
+
+    return 0
+}
+
+check_rust_prints
+
 cargo fmt --all -- --check
 cargo check --all --no-default-features
 cargo check --all

--- a/resources/githooks/pre-commit
+++ b/resources/githooks/pre-commit
@@ -2,44 +2,6 @@
 
 set -e
 
-
-search_added_rust_lines_with_prints() {
-    # --diff-filter=A is to list only added files, excluding modified/deleted
-    git diff --cached --name-only --diff-filter=A | \
-    grep '\.rs$' | \
-    while read -r file; do
-        # For each file, get a unified diff with no context (-U0)
-        git diff --cached -U0 -- "$file" | \
-        # Strip lines starting with '+++' containing the file name
-        grep -v -E '^\+\+\+' | \
-        # Select only the added lines, i.e. starting with a plus sign
-        grep -E '^\+' | \
-        # Strip the '+' prefix and all inline comments
-        sed -e 's/^\+//' -e 's://.*$::' | \
-        # Prepend the file name and line number to each line
-        awk -v file="$file" '{ printf "%s:%s: %s\n", file, FNR, $0 }' | \
-        # Grep for print statements
-        grep --color=always -E '\b(println!|eprintln!)' || true
-    done
-}
-
-check_rust_prints() {
-    # Check for println! or eprintln! statements in git-added Rust files, ignoring comments.
-
-    matches=$(search_added_rust_lines_with_prints)
-
-    if [ ! -z "$matches" ]; then
-        echo "Error: The following Rust source files contain println! or eprintln! statements:"
-        echo "$matches"
-        echo "Please remove or comment out the println! and eprintln! statements before committing."
-        return 1
-    fi
-
-    return 0
-}
-
-check_rust_prints
-
 cargo fmt --all -- --check
 cargo check --all --no-default-features
 cargo check --all

--- a/resources/githooks/pre-push
+++ b/resources/githooks/pre-push
@@ -3,6 +3,10 @@
 # Local check that we are likely to pass CI
 # CI is quite slow so it's nice to be able to run locally
 
+
+GITHOOKS_DIR=$(dirname "$(realpath "$0")")
+SCRIPTS_DIR="$GITHOOKS_DIR/../scripts"
+
 set -o errexit
 set -o xtrace
 
@@ -21,45 +25,10 @@ cargo clippy --all-features --all-targets -- -D warnings
 cargo test --all-features
 cargo test --no-default-features
 
-
-grep_rust_lines_with_prints() {
-    for file in $(git ls-files '*.rs'); do
-        # Strip all inline comments
-        sed -e 's://.*$::' "$file" | \
-        # Prepend the file name and line number to each line, with colors
-        awk -v file="$file" '{ printf "\033[35m%s\033[0m:\033[32m%s\033[0m: %s\n", file, FNR, $0 }' | \
-        # Grep for print statements
-        grep --color=always -E '\b(println!|eprintln!)' || true
-    done
-}
-
-
-diff_rust_lines_with_prints() {
-    local from_ref="$1"
-    local to_ref="${2:-HEAD}"
-    # --diff-filter=A is to list only added files, excluding modified/deleted
-    git diff "$from_ref" "$to_ref" --name-only --diff-filter=A | \
-    grep '\.rs$' | \
-    while read -r file; do
-        # For each file, get a unified diff with no context (-U0)
-        git diff "$from_ref" "$to_ref" -U0 -- "$file" | \
-        # Strip lines starting with '+++' containing the file name
-        grep -v -E '^\+\+\+' | \
-        # Select only the added lines, i.e. starting with a plus sign
-        grep -E '^\+' | \
-        # Strip the '+' prefix and the inline comments
-        sed -e 's/^\+//' -e 's://.*$::' | \
-        # Prepend the file name and line number to each line, with colors
-        awk -v file="$file" '{ printf "\033[35m%s\033[0m:\033[32m%s\033[0m: %s\n", file, FNR, $0 }' | \
-        # Grep for print statements
-        grep --color=always -E '\b(println!|eprintln!)' || true
-    done
-}
-
-# xtrace gets in the way here, disable it and don't even print 'set -x' :)
+# shut up xtrace
 { set +x; } 2>/dev/null
 
-# Check for println! or eprintln! in Rust files about to be pushed, ignoring comments.
+# Check against println! or eprintln! in the Rust files about to be pushed.
 # The pre-push git hook receives info about what is to be pushed from stdin, see:
 # https://git-scm.com/docs/githooks#_pre_push
 # The `test` Unix command -t NUM option returns true if the given file descriptor (0 for stdin)
@@ -68,16 +37,9 @@ diff_rust_lines_with_prints() {
 # are searched. When it's run as a hook (input is a pipe) only the added lines from the diff
 # between local and remote refs are searched.
 if [ -t 0 ]; then
-    matches=$(grep_rust_lines_with_prints)
+    "$SCRIPTS_DIR/check_no_println.sh"
 else
     while read -r _local_ref local_sha _remote_ref remote_sha; do
-        matches=$(diff_rust_lines_with_prints "$remote_sha" "$local_sha")
+        "$SCRIPTS_DIR/check_no_println.sh" --from-ref "$remote_sha" --to-ref "$local_sha"
     done
 fi
-if [ ! -z "$matches" ]; then
-    echo "Error: The following Rust source files contain println! or eprintln! statements:"
-    echo "$matches"
-    echo "Please remove or comment out the println! and eprintln! statements before pushing."
-    exit 1
-fi
-exit 0

--- a/resources/githooks/pre-push
+++ b/resources/githooks/pre-push
@@ -20,3 +20,64 @@ cargo clippy --all-features --all-targets -- -D warnings
 
 cargo test --all-features
 cargo test --no-default-features
+
+
+grep_rust_lines_with_prints() {
+    for file in $(git ls-files '*.rs'); do
+        # Strip all inline comments
+        sed -e 's://.*$::' "$file" | \
+        # Prepend the file name and line number to each line, with colors
+        awk -v file="$file" '{ printf "\033[35m%s\033[0m:\033[32m%s\033[0m: %s\n", file, FNR, $0 }' | \
+        # Grep for print statements
+        grep --color=always -E '\b(println!|eprintln!)' || true
+    done
+}
+
+
+diff_rust_lines_with_prints() {
+    local from_ref="$1"
+    local to_ref="${2:-HEAD}"
+    # --diff-filter=A is to list only added files, excluding modified/deleted
+    git diff "$from_ref" "$to_ref" --name-only --diff-filter=A | \
+    grep '\.rs$' | \
+    while read -r file; do
+        # For each file, get a unified diff with no context (-U0)
+        git diff "$from_ref" "$to_ref" -U0 -- "$file" | \
+        # Strip lines starting with '+++' containing the file name
+        grep -v -E '^\+\+\+' | \
+        # Select only the added lines, i.e. starting with a plus sign
+        grep -E '^\+' | \
+        # Strip the '+' prefix and the inline comments
+        sed -e 's/^\+//' -e 's://.*$::' | \
+        # Prepend the file name and line number to each line, with colors
+        awk -v file="$file" '{ printf "\033[35m%s\033[0m:\033[32m%s\033[0m: %s\n", file, FNR, $0 }' | \
+        # Grep for print statements
+        grep --color=always -E '\b(println!|eprintln!)' || true
+    done
+}
+
+# xtrace gets in the way here, disable it and don't even print 'set -x' :)
+{ set +x; } 2>/dev/null
+
+# Check for println! or eprintln! in Rust files about to be pushed, ignoring comments.
+# The pre-push git hook receives info about what is to be pushed from stdin, see:
+# https://git-scm.com/docs/githooks#_pre_push
+# The `test` Unix command -t NUM option returns true if the given file descriptor (0 for stdin)
+# is open and associated with a terminal, and false if the input is piped.
+# When this is run as a regular script (input is a terminal), all the git-tracked *.rs files
+# are searched. When it's run as a hook (input is a pipe) only the added lines from the diff
+# between local and remote refs are searched.
+if [ -t 0 ]; then
+    matches=$(grep_rust_lines_with_prints)
+else
+    while read -r _local_ref local_sha _remote_ref remote_sha; do
+        matches=$(diff_rust_lines_with_prints "$remote_sha" "$local_sha")
+    done
+fi
+if [ ! -z "$matches" ]; then
+    echo "Error: The following Rust source files contain println! or eprintln! statements:"
+    echo "$matches"
+    echo "Please remove or comment out the println! and eprintln! statements before pushing."
+    exit 1
+fi
+exit 0

--- a/resources/scripts/check_no_println.sh
+++ b/resources/scripts/check_no_println.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Script to check for println! or eprintln! in Rust files, ignoring comments.
+#
+# When no args are provided, all the git-tracked *.rs files are searched.
+# When run with two args, respectively --from-ref <ref> and --to-ref <ref>,
+# only the added lines from the git diff between the two refs are searched.
+# The latter is useful when running this as a pre-push git hook.
+
+
+grep_rust_lines_with_prints() {
+    for file in $(git ls-files '*.rs'); do
+        # Strip all inline comments
+        sed -e 's://.*$::' "$file" | \
+        # Prepend the file name and line number to each line, with colors
+        awk -v file="$file" '{ printf "\033[35m%s\033[0m:\033[32m%s\033[0m: %s\n", file, FNR, $0 }' | \
+        # Grep for print statements
+        grep --color=always -E '\b(println!|eprintln!)' || true
+    done
+}
+
+diff_rust_lines_with_prints() {
+    local from_ref="$1"
+    local to_ref="${2:-HEAD}"
+    # --diff-filter=A is to list only added files, excluding modified/deleted
+    git diff "$from_ref" "$to_ref" --name-only --diff-filter=A | \
+    grep '\.rs$' | \
+    while read -r file; do
+        # For each file, get a unified diff with no context (-U0)
+        git diff "$from_ref" "$to_ref" -U0 -- "$file" | \
+        # Strip lines starting with '+++' containing the file name
+        grep -v -E '^\+\+\+' | \
+        # Select only the added lines, i.e. starting with a plus sign
+        grep -E '^\+' | \
+        # Strip the '+' prefix and the inline comments
+        sed -e 's/^\+//' -e 's://.*$::' | \
+        # Prepend the file name and line number to each line, with colors
+        awk -v file="$file" '{ printf "\033[35m%s\033[0m:\033[32m%s\033[0m: %s\n", file, FNR, $0 }' | \
+        # Grep for print statements
+        grep --color=always -E '\b(println!|eprintln!)' || true
+    done
+}
+
+
+opt_error() {
+    local message="$1"
+    echo "Error: $message"
+    echo "Usage: $0 [--from-ref <ref>] [--to-ref <ref>]"
+    exit 1
+}
+
+
+if [ $# -eq 0 ]; then
+    # when no arguments are passed, search all git-tracked files
+    matches=$(grep_rust_lines_with_prints)
+else
+    from_ref=""
+    to_ref=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --from-ref)
+                from_ref="$2"
+                shift 2
+                ;;
+            --to-ref)
+                to_ref="${2:-HEAD}"
+                shift 2
+                ;;
+            *)
+                opt_error "Unknown option: $1"
+                ;;
+        esac
+    done
+
+    if [ -z "$from_ref" ] || [ -z "$to_ref" ]; then
+        opt_error "both --from-ref and --to-ref must be provided, or none at all."
+    fi
+
+    matches=$(diff_rust_lines_with_prints "$from_ref" "$to_ref")
+fi
+
+if [ ! -z "$matches" ]; then
+    echo "Error: The following Rust source files contain println! or eprintln! statements:"
+    echo "$matches"
+    echo "Please remove or comment out the println! and eprintln! statements before pushing."
+    exit 1
+fi
+exit 0

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -628,7 +628,7 @@ impl Work<Context, WorkError> for GlobalMetricsWork {
             metrics.set_if_some(GlobalMetric::CapHeight, pos.clone(), font_info.cap_height);
             metrics.set_if_some(GlobalMetric::XHeight, pos.clone(), font_info.x_height);
 
-            eprintln!("{} {pos:?} {font_info:#?}", source.filename);
+            trace!("{} {pos:?} {font_info:#?}", source.filename);
         }
 
         trace!("{:#?}", metrics);


### PR DESCRIPTION
I did this just to brush up on shell scripting and git hooks, so feel free to reject if you think this is not useful.

Also, note this deliberately only checks the specific lines that are added (cached) to the index, not all the lines in an .rs file. And it strips all `//` inline comments so that a commented-out `println!()` or `eprintln!()` would be allowed. If we wanted to support multi-line /**/ comments, I found a crate/CLI tool called [comment-strip](https://crates.io/crates/comment-strip/) but I don't think it's worth it.

