### PR TITLE
Use font_types NameId

### DIFF
--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -41,13 +41,12 @@ impl Work<Context, Error> for FvarWork {
                 .axes
                 .iter()
                 .map(|ir_axis| {
-                    let axis_name_id: u16 = (*reverse_names.get(&ir_axis.name).unwrap()).into();
                     let mut var = VariationAxisRecord {
                         axis_tag: Tag::new(ir_axis.tag.as_bytes()),
                         min_value: ir_axis.min.into(),
                         default_value: ir_axis.default.into(),
                         max_value: ir_axis.max.into(),
-                        axis_name_id: axis_name_id.into(),
+                        axis_name_id: *reverse_names.get(&ir_axis.name).unwrap(),
                         ..Default::default()
                     };
                     if ir_axis.hidden {

--- a/fontbe/src/name.rs
+++ b/fontbe/src/name.rs
@@ -25,15 +25,12 @@ impl Work<Context, Error> for NameWork {
         let name_records = static_metadata
             .names
             .iter()
-            .map(|(key, value)| {
-                let name_id: u16 = key.name_id.into();
-                NameRecord {
-                    name_id: name_id.into(),
-                    platform_id: key.platform_id,
-                    encoding_id: key.encoding_id,
-                    language_id: key.lang_id,
-                    string: OffsetMarker::new(value.clone()),
-                }
+            .map(|(key, value)| NameRecord {
+                name_id: key.name_id,
+                platform_id: key.platform_id,
+                encoding_id: key.encoding_id,
+                language_id: key.lang_id,
+                string: OffsetMarker::new(value.clone()),
             })
             .collect();
 

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -4,8 +4,9 @@ use std::{
 };
 
 use filetime::FileTime;
+use font_types::NameId;
 use ordered_float::OrderedFloat;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
     coords::{CoordConverter, DesignCoord, NormalizedLocation, UserCoord},
@@ -15,6 +16,42 @@ use crate::{
     },
     stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
 };
+
+struct NameIdVisitor;
+
+impl<'de> serde::de::Visitor<'de> for NameIdVisitor {
+    type Value = NameId;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("A valid NameId")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let v = v
+            .parse::<u16>()
+            .map_err(|_| E::invalid_value(serde::de::Unexpected::Str(v), &self))?;
+        Ok(NameId::new(v))
+    }
+}
+
+pub(crate) fn serialize_name_id<S>(name: &NameId, ser: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    ser.serialize_str(&format!("{}", name.to_u16()))
+}
+
+pub(crate) fn deserialize_name_id<'de, D>(de: D) -> Result<NameId, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // For reasons that are not clear to me trying to treat name id as a u16 results in
+    // invalid type: integer `2`. Just use a damn string.
+    de.deserialize_str(NameIdVisitor)
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CoordConverterSerdeRepr {

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -26,6 +26,8 @@ kurbo = { version="0.9.0", features=["serde"] }
 ordered-float = "3.4.0"
 indexmap = "1.9.2"
 
+font-types = "0.1.3"
+
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1,9 +1,10 @@
+use font_types::NameId;
 use fontdrasil::orchestration::Work;
 use fontdrasil::types::GlyphName;
 use fontir::coords::NormalizedCoord;
 use fontir::error::{Error, WorkError};
 use fontir::ir::{
-    self, GlobalMetric, GlobalMetrics, GlyphInstance, NameBuilder, NameId, NameKey, StaticMetadata,
+    self, GlobalMetric, GlobalMetrics, GlyphInstance, NameBuilder, NameKey, StaticMetadata,
 };
 use fontir::orchestration::{Context, IrWork};
 use fontir::source::{Input, Source};
@@ -211,22 +212,22 @@ impl Source for GlyphsIrSource {
 
 fn try_name_id(name: &str) -> Option<NameId> {
     match name {
-        "copyrights" => Some(NameId::Copyright),
-        "familyNames" => Some(NameId::FamilyName),
-        "uniqueID" => Some(NameId::UniqueIdentifier),
-        "postscriptFullName" => Some(NameId::FullName),
-        "version" => Some(NameId::Version),
-        "postscriptFontName" => Some(NameId::PostScriptName),
-        "trademarks" => Some(NameId::Trademark),
-        "manufacturers" => Some(NameId::Manufacturer),
-        "designers" => Some(NameId::Designer),
-        "manufacturerURL" => Some(NameId::ManufacturerUrl),
-        "designerURL" => Some(NameId::DesignerUrl),
-        "licenses" => Some(NameId::License),
-        "licenseURL" => Some(NameId::LicenseUrl),
-        "compatibleFullNames" => Some(NameId::MacCompatibleFullName),
-        "sampleTexts" => Some(NameId::SampleText),
-        "WWSFamilyName" => Some(NameId::WwsFamilyName),
+        "copyrights" => Some(NameId::COPYRIGHT_NOTICE),
+        "familyNames" => Some(NameId::FAMILY_NAME),
+        "uniqueID" => Some(NameId::UNIQUE_ID),
+        "postscriptFullName" => Some(NameId::FULL_NAME),
+        "version" => Some(NameId::VERSION_STRING),
+        "postscriptFontName" => Some(NameId::POSTSCRIPT_NAME),
+        "trademarks" => Some(NameId::TRADEMARK),
+        "manufacturers" => Some(NameId::MANUFACTURER),
+        "designers" => Some(NameId::DESIGNER),
+        "manufacturerURL" => Some(NameId::VENDOR_URL),
+        "designerURL" => Some(NameId::DESIGNER_URL),
+        "licenses" => Some(NameId::LICENSE_DESCRIPTION),
+        "licenseURL" => Some(NameId::LICENSE_URL),
+        "compatibleFullNames" => Some(NameId::COMPATIBLE_FULL_NAME),
+        "sampleTexts" => Some(NameId::SAMPLE_TEXT),
+        "WWSFamilyName" => Some(NameId::WWS_FAMILY_NAME),
         _ => {
             warn!("Unknown 'name' entry {name}");
             None
@@ -443,6 +444,7 @@ mod tests {
         path::{Path, PathBuf},
     };
 
+    use font_types::NameId;
     use fontdrasil::{orchestration::Access, types::GlyphName};
     use fontir::{
         coords::{
@@ -450,7 +452,7 @@ mod tests {
             UserLocation,
         },
         error::WorkError,
-        ir::{self, GlobalMetricsInstance, NameId, NameKey},
+        ir::{self, GlobalMetricsInstance, NameKey},
         orchestration::{Context, WorkId},
         paths::Paths,
         source::Source,
@@ -815,78 +817,75 @@ mod tests {
     fn name_table() {
         let font = Font::load(&glyphs3_dir().join("TheBestNames.glyphs")).unwrap();
         let mut names: Vec<_> = names(&font).into_iter().collect();
-        names.sort_by_key(|(id, v)| {
-            let id: u16 = id.name_id.into();
-            (id, v.clone())
-        });
+        names.sort_by_key(|(id, v)| (id.name_id, v.clone()));
         assert_eq!(
             vec![
                 (
-                    NameKey::new_bmp_only(NameId::Copyright),
+                    NameKey::new_bmp_only(NameId::COPYRIGHT_NOTICE),
                     String::from("Copy!")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::FamilyName),
+                    NameKey::new_bmp_only(NameId::FAMILY_NAME),
                     String::from("FamilyName")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::UniqueIdentifier),
+                    NameKey::new_bmp_only(NameId::UNIQUE_ID),
                     String::from("We are all unique")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::FullName),
+                    NameKey::new_bmp_only(NameId::FULL_NAME),
                     String::from("Full of names")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::Version),
+                    NameKey::new_bmp_only(NameId::VERSION_STRING),
                     String::from("New Value")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::PostScriptName),
+                    NameKey::new_bmp_only(NameId::POSTSCRIPT_NAME),
                     String::from("Postscript Name")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::Trademark),
+                    NameKey::new_bmp_only(NameId::TRADEMARK),
                     String::from("A trade in marks")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::Manufacturer),
+                    NameKey::new_bmp_only(NameId::MANUFACTURER),
                     String::from("Who made you?!")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::Designer),
+                    NameKey::new_bmp_only(NameId::DESIGNER),
                     String::from("Designed by me!")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::ManufacturerUrl),
+                    NameKey::new_bmp_only(NameId::VENDOR_URL),
                     String::from("https://example.com/manufacturer")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::DesignerUrl),
+                    NameKey::new_bmp_only(NameId::DESIGNER_URL),
                     String::from("https://example.com/designer")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::License),
+                    NameKey::new_bmp_only(NameId::LICENSE_DESCRIPTION),
                     String::from("Licensed to thrill")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::LicenseUrl),
+                    NameKey::new_bmp_only(NameId::LICENSE_URL),
                     String::from("https://example.com/my/font/license")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::TypographicFamilyName),
+                    NameKey::new_bmp_only(NameId::TYPOGRAPHIC_FAMILY_NAME),
                     String::from("FamilyName")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::MacCompatibleFullName),
+                    NameKey::new_bmp_only(NameId::COMPATIBLE_FULL_NAME),
                     String::from("For the Mac's only")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::SampleText),
+                    NameKey::new_bmp_only(NameId::SAMPLE_TEXT),
                     String::from("Sam pull text")
                 ),
                 (
-                    NameKey::new_bmp_only(NameId::WwsFamilyName),
+                    NameKey::new_bmp_only(NameId::WWS_FAMILY_NAME),
                     String::from("We Will Slant you")
                 ),
             ],
@@ -900,7 +899,7 @@ mod tests {
         assert_eq!(
             "New Value",
             names(&font)
-                .get(&NameKey::new_bmp_only(NameId::Version))
+                .get(&NameKey::new_bmp_only(NameId::VERSION_STRING))
                 .unwrap()
         );
     }
@@ -911,7 +910,7 @@ mod tests {
         assert_eq!(
             "Version 42.043",
             names(&font)
-                .get(&NameKey::new_bmp_only(NameId::Version))
+                .get(&NameKey::new_bmp_only(NameId::VERSION_STRING))
                 .unwrap()
         );
     }
@@ -922,7 +921,7 @@ mod tests {
         assert_eq!(
             "Version 0.000",
             names(&font)
-                .get(&NameKey::new_bmp_only(NameId::Version))
+                .get(&NameKey::new_bmp_only(NameId::VERSION_STRING))
                 .unwrap()
         );
     }

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1.0.37"
 
 plist = { version =  "1.3.1", features = ["serde"] }
 
+font-types = "0.1.3"
 write-fonts = "0.1.6"  # for ot_round
 
 ordered-float = { version = "3.4.0", features = ["serde"] }


### PR DESCRIPTION
Fixes #196

For some reason serde kept puking when I try to handle name id as a u16 so I made it a string. Ex `'Unable to deserialize "/tmp/.tmpRPdlUn/static_metadata.preliminary.yml" names.name_id: invalid type: integer `2`, expected A valid NameId at line 3 column 14'`