### PR TITLE
bump write fonts to 0.1.7, fixes building cmap with large idDeltas

### DIFF
--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -27,7 +27,7 @@ env_logger = "0.10.0"
 parking_lot = "0.12.1"
 
 read-fonts = "0.1.3"
-write-fonts = "0.1.6"
+write-fonts = "0.1.7"
 
 kurbo = { version = "0.9.2", features = ["serde"] }
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -32,7 +32,7 @@ write-fonts = "0.1.7"
 kurbo = { version = "0.9.2", features = ["serde"] }
 
 fea-rs = "0.3.1"
-smol_str = { version = "0.1.25", features = ["serde"] }
+smol_str = { version = "0.1.24", features = ["serde"] }
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -33,7 +33,7 @@ regex = "1.7.1"
 
 indexmap = "1.9.2"
 
-write-fonts = "0.1.6"
+write-fonts = "0.1.7"
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-smol_str = { version = "0.1.25", features = ["serde"] }
+smol_str = { version = "0.1.24", features = ["serde"] }
 
 serde = {version = "1.0", features = ["derive"] }
 

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -29,7 +29,7 @@ env_logger = "0.10.0"
 parking_lot = "0.12.1"
 
 font-types = "0.1.3"
-write-fonts = "0.1.6"  # for pens
+write-fonts = "0.1.7"  # for pens
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1.0.37"
 plist = { version =  "1.3.1", features = ["serde"] }
 
 font-types = "0.1.3"
-write-fonts = "0.1.6"  # for ot_round
+write-fonts = "0.1.7"  # for ot_round
 
 ordered-float = { version = "3.4.0", features = ["serde"] }
 indexmap = "1.9.2"


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontmake-rs/issues/223