### PR TITLE
Add get deltas method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
-[patch.crates-io]
-font-types = {path="../fontations/font-types"}
-read-fonts = {path="../fontations/read-fonts"}
-write-fonts = {path="../fontations/write-fonts"}
-
 [workspace]
 
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[patch.crates-io]
+font-types = {path="../fontations/font-types"}
+read-fonts = {path="../fontations/read-fonts"}
+write-fonts = {path="../fontations/write-fonts"}
+
 [workspace]
 
 members = [

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -35,3 +35,4 @@ write-fonts = "0.1.8"  # for pens
 diff = "0.1.12"
 ansi_term = "0.12.1"
 tempfile = "3.3.0"
+pretty_assertions = "1.3.0"

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -38,7 +38,7 @@ pub struct NormalizedCoord(OrderedFloat<f32>);
 ///
 /// E.g. a user location is a `Location<UserCoord>`. Hashable so it can do things like be
 /// the key for a map of sources by location.
-#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Location<T>(BTreeMap<String, T>);
 
 pub type DesignLocation = Location<DesignCoord>;

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -5,6 +5,7 @@ use std::{
     fmt::{Debug, Display},
 };
 
+use kurbo::{Point, Vec2};
 use log::{log_enabled, trace};
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
@@ -89,6 +90,13 @@ impl VariationModel {
         let influence = master_influence(regions);
         let delta_weights = delta_weights(&locations, &influence);
 
+        let idx_of_location = locations
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(idx, loc)| (loc, idx))
+            .collect();
+
         Ok(VariationModel {
             default,
             locations,
@@ -113,6 +121,75 @@ impl VariationModel {
     pub fn default_location(&self) -> &NormalizedLocation {
         &self.default
     }
+
+    /// Convert absolute positions at master locations to offsets.
+    ///
+    /// <ul>
+    ///     <li>All keys in points must be known to the variation model.</li>
+    ///     <li>All point vectors must have the same length.</li>
+    ///     <li>A point vector for the default location is required</li>
+    /// </ul>
+    ///
+    /// Note that it is NOT required to provide a point sequence for every location known
+    /// to the variation model.
+    ///
+    /// Returns a delta, in the form of a [Vec2], for every input point. Intended use is to support
+    /// construction of a variation store.
+    ///
+    /// Rust version of <https://github.com/fonttools/fonttools/blob/3b9a73ff8379ab49d3ce35aaaaf04b3a7d9d1655/Lib/fontTools/varLib/models.py#L449-L461>
+    pub fn deltas(
+        &self,
+        point_seqs: HashMap<NormalizedLocation, Vec<Point>>,
+    ) -> Result<HashMap<NormalizedLocation, Vec<Vec2>>, DeltaError> {
+        let Some(defaults) = point_seqs.get(&self.default) else {
+            return Err(DeltaError::DefaultUndefined);
+        };
+        if point_seqs.values().any(|pts| pts.len() != defaults.len()) {
+            return Err(DeltaError::InconsistentNumbersOfPoints);
+        }
+
+        let mut result: HashMap<NormalizedLocation, Vec<Vec2>> = HashMap::new();
+        // self.locations is sorted such that[i] is only influenced by[i+1..N]
+        // so we know subsequent spins won't invalidate our delta if we go in the same order
+        for (loc_idx, points) in self
+            .locations
+            .iter()
+            .filter_map(|loc| point_seqs.get(loc))
+            .enumerate()
+        {
+            let master_influences = &self.delta_weights[loc_idx];
+
+            let mut deltas = Vec::new();
+            for (idx, point) in points.iter().enumerate() {
+                deltas.push(
+                    // Find other masters that are active (have influence)
+                    master_influences
+                        .iter()
+                        .map(|(loc_idx, w)| (&self.locations[*loc_idx], w.into_inner()))
+                        .filter_map(|(loc, w)| result.get(loc).map(|deltas| (deltas, w)))
+                        .filter_map(|(deltas, w)| deltas.get(idx).map(|delta| (delta, w)))
+                        // Start with a vector to our destination, then subtract away influence from other active masters
+                        .fold(point.to_vec2(), |acc, (other, other_weight)| {
+                            acc - if other_weight != 1.0 {
+                                *other * other_weight.into()
+                            } else {
+                                *other
+                            }
+                        }),
+                );
+            }
+            result.insert(self.locations[loc_idx].clone(), deltas);
+        }
+
+        Ok(result)
+    }
+}
+
+#[derive(Debug)]
+pub enum DeltaError {
+    DefaultUndefined,
+    InconsistentNumbersOfPoints,
+    UnknownLocation(NormalizedLocation),
 }
 
 /// Gryffindor!
@@ -550,9 +627,12 @@ fn delta_weights(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
+    use kurbo::{Point, Vec2};
     use ordered_float::OrderedFloat;
+
+    use pretty_assertions::assert_eq;
 
     use crate::{
         coords::{NormalizedCoord, NormalizedLocation},
@@ -985,5 +1065,61 @@ mod tests {
             ],
             model.delta_weights
         );
+    }
+
+    #[test]
+    fn compute_simple_delta_corner_masters() {
+        let origin = norm_loc(&[("wght", 0.0), ("wdth", 0.0)]);
+        let max_wght = norm_loc(&[("wght", 1.0), ("wdth", 0.0)]);
+        let max_wdth = norm_loc(&[("wght", 0.0), ("wdth", 1.0)]);
+        let max_wght_wdth = norm_loc(&[("wght", 1.0), ("wdth", 1.0)]);
+        let locations = HashSet::from([
+            origin.clone(),
+            max_wght.clone(),
+            max_wdth.clone(),
+            max_wght_wdth.clone(),
+        ]);
+        let axis_order = vec!["wght".to_string(), "wdth".to_string()];
+        let model = VariationModel::new(locations, axis_order).unwrap();
+
+        let point_seqs = HashMap::from([
+            (origin.clone(), vec![Point::new(10.0, 10.0)]),
+            (max_wght.clone(), vec![Point::new(12.0, 11.0)]),
+            (max_wdth.clone(), vec![Point::new(11.0, 12.0)]),
+            (max_wght_wdth.clone(), vec![Point::new(14.0, 11.0)]),
+        ]);
+
+        let mut deltas: Vec<_> = model.deltas(point_seqs).unwrap().into_iter().collect();
+        deltas.sort_by_key(|(loc, _)| loc.clone());
+
+        assert_eq!(
+            vec![
+                // default
+                (origin, vec![Vec2::new(10.0, 10.0)]),
+                // at max weight/width no other master has influence so it's just delta from default
+                (max_wght, vec![Vec2::new(2.0, 1.0)]),
+                (max_wdth, vec![Vec2::new(1.0, 2.0)]),
+                // at max wdth and wght the deltas for max_wght and max_wdth are in full effect
+                // so we get (10+2+1, 10+1+2) "for free" and our delta is from there to (14, 11)
+                (max_wght_wdth, vec![Vec2::new(1.0, -2.0)]),
+            ],
+            deltas
+        );
+    }
+
+    fn assert_modelling_error(_num_locations: usize, _num_samples: usize) {
+        // TODO: anything whatsoever
+    }
+
+    /// 127, 509 from <https://github.com/fonttools/fonttools/blob/3b9a73ff8379ab49d3ce35aaaaf04b3a7d9d1655/Tests/varLib/models_test.py#L160-L192>
+    #[test]
+    fn check_modelling_error_slow() {
+        assert_modelling_error(127, 509);
+    }
+
+    /// 31, 251 from <https://github.com/fonttools/fonttools/blob/3b9a73ff8379ab49d3ce35aaaaf04b3a7d9d1655/Tests/varLib/models_test.py#L160-L192>
+    #[test]
+    fn check_modelling_error_fast() {
+        assert_modelling_error(31, 251);
     }
 }

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -127,7 +127,10 @@ impl VariationModel {
     /// to the variation model.
     ///
     /// P is the point type, meant to be absolute position in 1 or 2 dimensional space.
-    /// V is the vector type, such as [Vec2].
+    /// V is the vector type.
+    ///
+    /// For 2d [kurbo::Point] and [kurbo::Vec2] would be typical choices. For 1d a floating
+    /// point primitive should suffice.
     ///
     /// Returns a delta, as the vector type, for every input point. Intended use is to support
     /// construction of a variation store.

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -9,6 +9,7 @@ use std::{
 use log::{log_enabled, trace};
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::{
     coords::{NormalizedCoord, NormalizedLocation},
@@ -201,10 +202,13 @@ impl VariationModel {
     }
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum DeltaError {
+    #[error("The default must have a point sequence")]
     DefaultUndefined,
+    #[error("Every point sequence must have the same length")]
     InconsistentNumbersOfPoints,
+    #[error("{0:?} is not present in the variation model")]
     UnknownLocation(NormalizedLocation),
 }
 


### PR DESCRIPTION
Intended use is to produce data to feed into a future `Gvar::from_glyph_variations` method that will be added in https://github.com/googlefonts/fontations/pull/319 or perhaps a follow-on.

Does not yet implement rounding properly; see https://github.com/googlefonts/fontmake-rs/issues/235.