### PR TITLE
Compile simple VFs w/gvar that works in a browser

### DIFF
--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -15,7 +15,7 @@ fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontir = { version = "0.0.1", path = "../fontir" }
 
 serde = {version = "1.0", features = ["derive"] }
-serde_yaml = "0.9.14"
+bincode = "1.3.3"
 
 thiserror = "1.0.37"
 ordered-float = { version = "3.4.0", features = ["serde"] }
@@ -26,9 +26,9 @@ env_logger = "0.10.0"
 
 parking_lot = "0.12.1"
 
-font-types = "0.1.3"
-read-fonts = "0.1.3"
-write-fonts = "0.1.8"
+font-types = "0.1.4"
+read-fonts = "0.1.4"
+write-fonts = "0.1.9"
 
 kurbo = { version = "0.9.2", features = ["serde"] }
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -28,7 +28,7 @@ parking_lot = "0.12.1"
 
 font-types = "0.1.4"
 read-fonts = "0.1.4"
-write-fonts = "0.1.9"
+write-fonts = "0.1.11"
 
 kurbo = { version = "0.9.2", features = ["serde"] }
 

--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -59,13 +59,17 @@ impl Work<Context, Error> for AvarWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_init_static_metadata();
         // Guard clause: don't produce avar for a static font
-        if static_metadata.axes.is_empty() {
+        if static_metadata.variable_axes.is_empty() {
             trace!("Skip avar; this is not a variable font");
             return Ok(());
         }
         context.set_avar(Avar::new(
             MajorMinor::VERSION_1_0,
-            static_metadata.axes.iter().map(to_segment_map).collect(),
+            static_metadata
+                .variable_axes
+                .iter()
+                .map(to_segment_map)
+                .collect(),
         ));
         Ok(())
     }

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -2,8 +2,13 @@ use std::{fmt::Display, io};
 
 use fea_rs::compile::error::{BinaryCompilationError, CompilerError};
 use fontdrasil::types::GlyphName;
+use fontir::variations::DeltaError;
+use read_fonts::ReadError;
 use thiserror::Error;
-use write_fonts::{tables::glyf::BadKurbo, validate::ValidationReport};
+use write_fonts::{
+    tables::{glyf::BadKurbo, gvar::GvarInputError},
+    validate::ValidationReport,
+};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -39,6 +44,12 @@ pub enum Error {
     },
     #[error("{what} out of bounds: {value}")]
     OutOfBounds { what: String, value: String },
+    #[error("Unable to compute deltas for {0}: {1}")]
+    GlyphDeltaError(GlyphName, DeltaError),
+    #[error("Unable to assemble gvar")]
+    GvarError(#[from] GvarInputError),
+    #[error("Unable to read")]
+    ReadFontsReadError(#[from] ReadError),
 }
 
 #[derive(Debug)]

--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -51,7 +51,11 @@ impl Work<Context, Error> for FontWork {
         let mut builder = FontBuilder::default();
 
         // A fancier implementation would mmap the files. We basic.
-        let is_static = context.ir.get_init_static_metadata().is_static();
+        let is_static = context
+            .ir
+            .get_init_static_metadata()
+            .variable_axes
+            .is_empty();
         for (work_id, tag, table_type) in TABLES_TO_MERGE {
             if is_static && matches!(table_type, TableType::Variable) {
                 trace!("Skip {tag} because this is a static font");

--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -4,8 +4,8 @@ use fontdrasil::orchestration::Work;
 use log::trace;
 use read_fonts::{
     tables::{
-        cmap::Cmap, fvar::Fvar, glyf::Glyf, head::Head, hhea::Hhea, hmtx::Hmtx, loca::Loca,
-        maxp::Maxp, name::Name, os2::Os2, post::Post,
+        cmap::Cmap, fvar::Fvar, glyf::Glyf, gvar::Gvar, head::Head, hhea::Hhea, hmtx::Hmtx,
+        loca::Loca, maxp::Maxp, name::Name, os2::Os2, post::Post,
     },
     types::Tag,
     TopLevelTable,
@@ -36,6 +36,7 @@ const TABLES_TO_MERGE: &[(WorkId, Tag, TableType)] = &[
     (WorkId::Hhea, Hhea::TAG, TableType::Static),
     (WorkId::Hmtx, Hmtx::TAG, TableType::Static),
     (WorkId::Glyf, Glyf::TAG, TableType::Static),
+    (WorkId::Gvar, Gvar::TAG, TableType::Variable),
     (WorkId::Loca, Loca::TAG, TableType::Static),
     (WorkId::Maxp, Maxp::TAG, TableType::Static),
     (WorkId::Name, Name::TAG, TableType::Static),

--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -23,12 +23,7 @@ pub fn create_fvar_work() -> Box<BeWork> {
 
 fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
     // Guard clause: don't produce fvar for a static font
-    let axes: Vec<_> = static_metadata
-        .axes
-        .iter()
-        .filter(|a| !a.is_static())
-        .collect();
-    if axes.is_empty() {
+    if static_metadata.variable_axes.is_empty() {
         trace!("Skip fvar; this is not a variable font");
         return None;
     }
@@ -40,7 +35,9 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
         .collect();
 
     let axes_and_instances = AxisInstanceArrays::new(
-        axes.iter()
+        static_metadata
+            .variable_axes
+            .iter()
             .map(|ir_axis| {
                 let mut var = VariationAxisRecord {
                     axis_tag: ir_axis.tag,
@@ -61,6 +58,7 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
 
     let axis_count = axes_and_instances.axes.len().try_into().unwrap();
     let instance_count = axes_and_instances.instances.len().try_into().unwrap();
+
     Some(Fvar::new(
         MajorMinor::VERSION_1_0,
         axes_and_instances,

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -216,7 +216,7 @@ impl Work<Context, Error> for GlyphWork {
             }
         };
 
-        // Everybody loves gvar!
+        // Contour (aka Simple) and Composite both need gvar
         let deltas = var_model
             .deltas(&point_seqs)
             .map_err(|e| Error::GlyphDeltaError(self.glyph_name.clone(), e))?;

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -1,28 +1,34 @@
-//! 'glyf' Glyph binary compilation
+//! 'glyf' and 'gvar' compilation
+//!
+//! Each glyph is built in isolation and then the fragments are collected
+//! and glued together to form a final table.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use fontdrasil::{orchestration::Work, types::GlyphName};
 use fontir::{coords::NormalizedLocation, ir};
-use kurbo::{cubics_to_quadratic_splines, Affine, BezPath, CubicBez, PathEl, Rect};
+use kurbo::{cubics_to_quadratic_splines, Affine, BezPath, CubicBez, PathEl, Point, Rect};
 use log::{trace, warn};
 
 use read_fonts::{
     tables::glyf::{self, Anchor, Transform},
     types::{F2Dot14, GlyphId},
 };
-use write_fonts::tables::glyf::{Bbox, Component, ComponentFlags, CompositeGlyph, SimpleGlyph};
+use write_fonts::{
+    tables::glyf::{Bbox, Component, ComponentFlags, CompositeGlyph, SimpleGlyph},
+    OtRound,
+};
 
 use crate::{
     error::{Error, GlyphProblem},
-    orchestration::{BeWork, Context, Glyph},
+    orchestration::{BeWork, Context, Glyph, GvarFragment},
 };
 
 struct GlyphWork {
     glyph_name: GlyphName,
 }
 
-pub fn create_glyph_work(glyph_name: GlyphName) -> Box<BeWork> {
+pub fn create_glyf_work(glyph_name: GlyphName) -> Box<BeWork> {
     Box::new(GlyphWork { glyph_name })
 }
 
@@ -110,6 +116,58 @@ fn create_composite(
     Ok(composite.unwrap())
 }
 
+/// * <https://github.com/fonttools/fonttools/blob/3b9a73ff8379ab49d3ce35aaaaf04b3a7d9d1655/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L335-L367>
+/// * <https://docs.microsoft.com/en-us/typography/opentype/spec/tt_instructing_glyphs#phantoms>
+fn add_phantom_points(advance: u16, points: &mut Vec<Point>) {
+    // FontTools says
+    //      leftSideX = glyph.xMin - leftSideBearing
+    //      rightSideX = leftSideX + horizontalAdvanceWidth
+    // We currently always set lsb to xMin so leftSideX = 0, rightSideX = advance.
+    points.push(Point::new(0.0, 0.0)); // leftSideX, 0
+    points.push(Point::new(advance as f64, 0.0)); // rightSideX, 0
+
+    // TODO: vertical phantom points
+    points.push(Point::new(0.0, 0.0));
+    points.push(Point::new(0.0, 0.0));
+}
+
+fn point_seqs_for_simple_glyph(
+    ir_glyph: &ir::Glyph,
+    instances: HashMap<NormalizedLocation, SimpleGlyph>,
+) -> HashMap<NormalizedLocation, Vec<Point>> {
+    instances
+        .into_iter()
+        .map(|(loc, glyph)| {
+            let mut points = glyph
+                .contours()
+                .iter()
+                .flat_map(|c| c.iter())
+                .map(|cp| Point::new(cp.x as f64, cp.y as f64))
+                .collect();
+
+            add_phantom_points(ir_glyph.sources()[&loc].width.ot_round(), &mut points);
+
+            (loc, points)
+        })
+        .collect()
+}
+
+fn point_seqs_for_composite_glyph(ir_glyph: &ir::Glyph) -> HashMap<NormalizedLocation, Vec<Point>> {
+    ir_glyph
+        .sources()
+        .iter()
+        .map(|(loc, inst)| {
+            let mut points = Vec::new();
+
+            // TODO: composites arguably need more than just phantoms
+
+            add_phantom_points(inst.width.ot_round(), &mut points);
+
+            (loc.clone(), points)
+        })
+        .collect()
+}
+
 impl Work<Context, Error> for GlyphWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         trace!("BE glyph work for {}", self.glyph_name);
@@ -123,33 +181,50 @@ impl Work<Context, Error> for GlyphWork {
         // Hopefully in time https://github.com/harfbuzz/boring-expansion-spec means we can drop this
         let glyph = cubics_to_quadratics(glyph);
 
-        // TODO refine (submodel) var model if glyph locations is a subset of var model locations
-
-        match glyph {
+        let (name, point_seqs) = match glyph {
             CheckedGlyph::Composite { name, components } => {
                 let composite = create_composite(context, &name, default_location, &components)?;
-                context.set_glyph(name, composite.into());
+                context.set_glyph(name.clone(), composite.into());
+                (name, point_seqs_for_composite_glyph(ir_glyph))
             }
-            CheckedGlyph::Contour { name, contours } => {
-                // Draw the default outline of our simple glyph
-                let Some(path) = contours.get(default_location) else {
+            CheckedGlyph::Contour { name, paths } => {
+                // Convert paths to SimpleGlyph so we can get consistent point streams
+                let instances = paths
+                    .into_iter()
+                    .map(|(loc, path)| {
+                        match SimpleGlyph::from_kurbo(&path).map_err(|e| Error::KurboError {
+                            glyph_name: self.glyph_name.clone(),
+                            kurbo_problem: e,
+                            context: path.to_svg(),
+                        }) {
+                            Ok(glyph) => Ok((loc, glyph)),
+                            Err(e) => Err(e),
+                        }
+                    })
+                    .collect::<Result<HashMap<_, _>, Error>>()?;
+
+                // Establish the default outline of our simple glyph
+                let Some(base_glyph) = instances.get(default_location) else {
                     return Err(Error::GlyphError(ir_glyph.name.clone(), GlyphProblem::MissingDefault));
                 };
-                let base_glyph = SimpleGlyph::from_kurbo(path).map_err(|e| Error::KurboError {
-                    glyph_name: self.glyph_name.clone(),
-                    kurbo_problem: e,
-                    context: path.to_svg(),
-                })?;
-                context.set_glyph(name, base_glyph.into());
+                context.set_glyph(name.clone(), base_glyph.clone().into());
+
+                (name, point_seqs_for_simple_glyph(ir_glyph, instances))
             }
-        }
+        };
+
+        // Everybody loves gvar!
+        let deltas = var_model
+            .deltas(&point_seqs)
+            .map_err(|e| Error::GlyphDeltaError(self.glyph_name.clone(), e))?;
+        context.set_gvar_fragment(name, GvarFragment { deltas });
 
         Ok(())
     }
 }
 
 fn cubics_to_quadratics(glyph: CheckedGlyph) -> CheckedGlyph {
-    let CheckedGlyph::Contour { name, contours } = glyph else {
+    let CheckedGlyph::Contour { name, paths: contours } = glyph else {
         return glyph;  // nop for composite
     };
 
@@ -256,7 +331,7 @@ fn cubics_to_quadratics(glyph: CheckedGlyph) -> CheckedGlyph {
 
     CheckedGlyph::Contour {
         name,
-        contours: new_contours,
+        paths: new_contours,
     }
 }
 
@@ -273,7 +348,7 @@ enum CheckedGlyph {
     },
     Contour {
         name: GlyphName,
-        contours: HashMap<NormalizedLocation, BezPath>,
+        paths: HashMap<NormalizedLocation, BezPath>,
     },
 }
 
@@ -356,7 +431,10 @@ impl TryFrom<&ir::Glyph> for CheckedGlyph {
                     (location.clone(), path)
                 })
                 .collect();
-            CheckedGlyph::Contour { name, contours }
+            CheckedGlyph::Contour {
+                name,
+                paths: contours,
+            }
         } else {
             let components = glyph
                 .sources()

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -87,15 +87,17 @@ impl Work<Context, Error> for GvarWork {
         // We built the gvar fragments alongside glyphs, now we need to glue them together into a gvar table
         let static_metadata = context.ir.get_final_static_metadata();
 
+        let mut gids_and_deltas = Vec::new();
+
         let variations: Vec<_> = static_metadata
             .glyph_order
             .iter()
             .enumerate()
             .map(|(gid, gn)| {
-                (
-                    GlyphId::new(gid as u16),
-                    to_deltas(&context.get_gvar_fragment(gn)),
-                )
+                let gid = GlyphId::new(gid as u16);
+                let gvar_fragment = context.get_gvar_fragment(gn);
+                gids_and_deltas.push((gid, gvar_fragment.deltas.clone()));
+                (gid, to_deltas(&gvar_fragment))
             })
             .map(|(gid, deltas)| GlyphVariations::new(gid, deltas))
             .collect();

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -1,21 +1,15 @@
 //! Generates a [gvar](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar) table.
 
-use log::trace;
-
-use font_types::{F2Dot14, GlyphId};
+use font_types::GlyphId;
 use fontdrasil::orchestration::Work;
-use fontir::variations::VariationRegion;
 use write_fonts::{
     dump_table,
-    tables::{
-        gvar::{GlyphDeltas, GlyphVariations, Gvar},
-        variations::Tuple,
-    },
+    tables::gvar::{GlyphVariations, Gvar},
 };
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Bytes, Context, GvarFragment},
+    orchestration::{BeWork, Bytes, Context},
 };
 
 struct GvarWork {}
@@ -24,70 +18,11 @@ pub fn create_gvar_work() -> Box<BeWork> {
     Box::new(GvarWork {})
 }
 
-/// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#variation-data>
-#[derive(Debug, Default)]
-struct TupleBuilder {
-    axis_names: Vec<String>,
-    min: Vec<F2Dot14>,
-    peak: Vec<F2Dot14>,
-    max: Vec<F2Dot14>,
-}
-
-impl TupleBuilder {
-    fn build(self) -> (Tuple, Tuple, Tuple) {
-        (
-            Tuple::new(self.min),
-            Tuple::new(self.peak),
-            Tuple::new(self.max),
-        )
-    }
-}
-
-impl From<&VariationRegion> for TupleBuilder {
-    fn from(region: &VariationRegion) -> Self {
-        let mut builder = TupleBuilder::default();
-        for (axis_name, tent) in region.iter() {
-            builder.axis_names.push(axis_name.clone());
-            builder.min.push(F2Dot14::from_f32(tent.lower.to_f32()));
-            builder.peak.push(F2Dot14::from_f32(tent.peak.to_f32()));
-            builder.max.push(F2Dot14::from_f32(tent.upper.to_f32()));
-        }
-        trace!("{builder:?}");
-        builder
-    }
-}
-
-fn to_deltas(fragment: &GvarFragment) -> Vec<GlyphDeltas> {
-    fragment
-        .deltas
-        .iter()
-        .filter_map(|(region, deltas)| {
-            if region.is_default() {
-                return None;
-            }
-
-            // Variation of no point has limited entertainment value
-            if deltas.is_empty() {
-                return None;
-            }
-
-            // TODO: nice rounding on deltas
-            let deltas: Vec<_> = deltas.iter().map(|v| (v.x as i16, v.y as i16)).collect();
-
-            let tuple_builder: TupleBuilder = region.into();
-            let (min, peak, max) = tuple_builder.build();
-            Some(GlyphDeltas::new(peak, deltas, Some((min, max))))
-        })
-        .collect()
-}
-
 impl Work<Context, Error> for GvarWork {
     /// Generate [gvar](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         // We built the gvar fragments alongside glyphs, now we need to glue them together into a gvar table
         let static_metadata = context.ir.get_final_static_metadata();
-
-        let mut gids_and_deltas = Vec::new();
 
         let variations: Vec<_> = static_metadata
             .glyph_order
@@ -96,8 +31,7 @@ impl Work<Context, Error> for GvarWork {
             .map(|(gid, gn)| {
                 let gid = GlyphId::new(gid as u16);
                 let gvar_fragment = context.get_gvar_fragment(gn);
-                gids_and_deltas.push((gid, gvar_fragment.deltas.clone()));
-                (gid, to_deltas(&gvar_fragment))
+                (gid, gvar_fragment.to_deltas())
             })
             .map(|(gid, deltas)| GlyphVariations::new(gid, deltas))
             .collect();

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -1,0 +1,112 @@
+//! Generates a [gvar](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar) table.
+
+use log::trace;
+
+use font_types::{F2Dot14, GlyphId};
+use fontdrasil::orchestration::Work;
+use fontir::variations::VariationRegion;
+use write_fonts::{
+    dump_table,
+    tables::{
+        gvar::{GlyphDeltas, GlyphVariations, Gvar},
+        variations::Tuple,
+    },
+};
+
+use crate::{
+    error::Error,
+    orchestration::{BeWork, Bytes, Context, GvarFragment},
+};
+
+struct GvarWork {}
+
+pub fn create_gvar_work() -> Box<BeWork> {
+    Box::new(GvarWork {})
+}
+
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#variation-data>
+#[derive(Debug, Default)]
+struct TupleBuilder {
+    axis_names: Vec<String>,
+    min: Vec<F2Dot14>,
+    peak: Vec<F2Dot14>,
+    max: Vec<F2Dot14>,
+}
+
+impl TupleBuilder {
+    fn build(self) -> (Tuple, Tuple, Tuple) {
+        (
+            Tuple::new(self.min),
+            Tuple::new(self.peak),
+            Tuple::new(self.max),
+        )
+    }
+}
+
+impl From<&VariationRegion> for TupleBuilder {
+    fn from(region: &VariationRegion) -> Self {
+        let mut builder = TupleBuilder::default();
+        for (axis_name, tent) in region.iter() {
+            builder.axis_names.push(axis_name.clone());
+            builder.min.push(F2Dot14::from_f32(tent.lower.to_f32()));
+            builder.peak.push(F2Dot14::from_f32(tent.peak.to_f32()));
+            builder.max.push(F2Dot14::from_f32(tent.upper.to_f32()));
+        }
+        trace!("{builder:?}");
+        builder
+    }
+}
+
+fn to_deltas(fragment: &GvarFragment) -> Vec<GlyphDeltas> {
+    fragment
+        .deltas
+        .iter()
+        .filter_map(|(region, deltas)| {
+            if region.is_default() {
+                return None;
+            }
+
+            // Variation of no point has limited entertainment value
+            if deltas.is_empty() {
+                return None;
+            }
+
+            // TODO: nice rounding on deltas
+            let deltas: Vec<_> = deltas.iter().map(|v| (v.x as i16, v.y as i16)).collect();
+
+            let tuple_builder: TupleBuilder = region.into();
+            let (min, peak, max) = tuple_builder.build();
+            Some(GlyphDeltas::new(peak, deltas, Some((min, max))))
+        })
+        .collect()
+}
+
+impl Work<Context, Error> for GvarWork {
+    /// Generate [gvar](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar)
+    fn exec(&self, context: &Context) -> Result<(), Error> {
+        // We built the gvar fragments alongside glyphs, now we need to glue them together into a gvar table
+        let static_metadata = context.ir.get_final_static_metadata();
+
+        let variations: Vec<_> = static_metadata
+            .glyph_order
+            .iter()
+            .enumerate()
+            .map(|(gid, gn)| {
+                (
+                    GlyphId::new(gid as u16),
+                    to_deltas(&context.get_gvar_fragment(gn)),
+                )
+            })
+            .map(|(gid, deltas)| GlyphVariations::new(gid, deltas))
+            .collect();
+        let gvar = Gvar::new(variations).map_err(Error::GvarError)?;
+
+        let raw_gvar = Bytes::new(dump_table(&gvar).map_err(|report| Error::DumpTableError {
+            report,
+            context: "gvar".into(),
+        })?);
+        context.set_gvar(raw_gvar);
+
+        Ok(())
+    }
+}

--- a/fontbe/src/lib.rs
+++ b/fontbe/src/lib.rs
@@ -5,6 +5,7 @@ pub mod features;
 pub mod font;
 pub mod fvar;
 pub mod glyphs;
+pub mod gvar;
 pub mod head;
 pub mod maxp;
 pub mod metrics_and_limits;

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -9,9 +9,12 @@ use fontdrasil::{
 use fontir::{
     context_accessors,
     orchestration::{Context as FeContext, ContextItem, Flags, WorkId as FeWorkIdentifier},
+    variations::VariationRegion,
 };
+use kurbo::Vec2;
 use parking_lot::RwLock;
 use read_fonts::{FontData, FontRead};
+use serde::{Deserialize, Serialize};
 use write_fonts::{
     dump_table,
     tables::{
@@ -48,11 +51,13 @@ pub enum GlyphMerge {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WorkId {
     Features,
-    Glyph(GlyphName),
     Avar,
     Cmap,
     Fvar,
     Glyf,
+    GlyfFragment(GlyphName),
+    Gvar,
+    GvarFragment(GlyphName),
     Head,
     Hhea,
     Hmtx,
@@ -143,6 +148,15 @@ impl Glyph {
     }
 }
 
+/// Unusually we store something other than the binary gvar per glyph.
+///
+///
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/gvar>
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GvarFragment {
+    pub deltas: Vec<(VariationRegion, Vec<Vec2>)>,
+}
+
 pub type BeWork = dyn Work<Context, Error> + Send;
 type GlyfLoca = (Vec<u8>, Vec<u32>);
 
@@ -165,13 +179,14 @@ pub struct Context {
     // We create individual caches so we can return typed results from get fns
     features: Arc<RwLock<Option<Arc<Vec<u8>>>>>,
 
-    // TODO: variations
     glyphs: Arc<RwLock<HashMap<GlyphName, Arc<Glyph>>>>,
+    gvar_fragments: Arc<RwLock<HashMap<GlyphName, Arc<GvarFragment>>>>,
 
     glyf_loca: ContextItem<GlyfLoca>,
     avar: ContextItem<Avar>,
     cmap: ContextItem<Cmap>,
     fvar: ContextItem<Fvar>,
+    gvar: ContextItem<Bytes>,
     post: ContextItem<Post>,
     maxp: ContextItem<Maxp>,
     name: ContextItem<Name>,
@@ -191,10 +206,12 @@ impl Context {
             acl,
             features: self.features.clone(),
             glyphs: self.glyphs.clone(),
+            gvar_fragments: self.gvar_fragments.clone(),
             glyf_loca: self.glyf_loca.clone(),
             avar: self.avar.clone(),
             cmap: self.cmap.clone(),
             fvar: self.fvar.clone(),
+            gvar: self.gvar.clone(),
             post: self.post.clone(),
             maxp: self.maxp.clone(),
             name: self.name.clone(),
@@ -214,10 +231,12 @@ impl Context {
             acl: AccessControlList::read_only(),
             features: Arc::from(RwLock::new(None)),
             glyphs: Arc::from(RwLock::new(HashMap::new())),
+            gvar_fragments: Arc::from(RwLock::new(HashMap::new())),
             glyf_loca: Arc::from(RwLock::new(None)),
             avar: Arc::from(RwLock::new(None)),
             cmap: Arc::from(RwLock::new(None)),
             fvar: Arc::from(RwLock::new(None)),
+            gvar: Arc::from(RwLock::new(None)),
             post: Arc::from(RwLock::new(None)),
             maxp: Arc::from(RwLock::new(None)),
             name: Arc::from(RwLock::new(None)),
@@ -293,7 +312,7 @@ impl Context {
     }
 
     pub fn get_glyph(&self, glyph_name: &GlyphName) -> Arc<Glyph> {
-        let id = WorkId::Glyph(glyph_name.clone());
+        let id = WorkId::GlyfFragment(glyph_name.clone());
         self.acl.assert_read_access(&id.clone().into());
         {
             let rl = self.glyphs.read();
@@ -313,10 +332,46 @@ impl Context {
     }
 
     pub fn set_glyph(&self, glyph_name: GlyphName, glyph: Glyph) {
-        let id = WorkId::Glyph(glyph_name.clone());
+        let id = WorkId::GlyfFragment(glyph_name.clone());
         self.acl.assert_write_access(&id.clone().into());
-        self.maybe_persist(&self.paths.target_file(&id), &glyph.to_bytes());
+        if self.flags.contains(Flags::EMIT_IR) {
+            self.persist(&self.paths.target_file(&id), &glyph.to_bytes());
+        }
         self.set_cached_glyph(glyph_name, glyph);
+    }
+
+    fn set_cached_gvar_fragment(&self, glyph_name: GlyphName, variations: GvarFragment) {
+        let mut wl = self.gvar_fragments.write();
+        wl.insert(glyph_name, Arc::from(variations));
+    }
+
+    pub fn get_gvar_fragment(&self, glyph_name: &GlyphName) -> Arc<GvarFragment> {
+        let id = WorkId::GvarFragment(glyph_name.clone());
+        self.acl.assert_read_access(&id.clone().into());
+        {
+            let rl = self.gvar_fragments.read();
+            if let Some(variations) = rl.get(glyph_name) {
+                return variations.clone();
+            }
+        }
+
+        let gvar_fragment = read_entire_file(&self.paths.target_file(&id));
+        let variations: GvarFragment = bincode::deserialize(&gvar_fragment).unwrap();
+
+        self.set_cached_gvar_fragment(glyph_name.clone(), variations);
+        let rl = self.gvar_fragments.read();
+        rl.get(glyph_name).expect(MISSING_DATA).clone()
+    }
+
+    pub fn set_gvar_fragment(&self, glyph_name: GlyphName, gvar_fragment: GvarFragment) {
+        let id = WorkId::GvarFragment(glyph_name.clone());
+        self.acl.assert_write_access(&id.clone().into());
+
+        if self.flags.contains(Flags::EMIT_IR) {
+            let bytes = bincode::serialize(&gvar_fragment).unwrap();
+            self.persist(&self.paths.target_file(&id), &bytes);
+        }
+        self.set_cached_gvar_fragment(glyph_name, gvar_fragment);
     }
 
     pub fn get_glyf_loca(&self) -> Arc<GlyfLoca> {
@@ -345,14 +400,16 @@ impl Context {
         self.acl.assert_write_access_to_all(&ids);
 
         let (glyf, loca) = glyf_loca;
-        self.maybe_persist(&self.paths.target_file(&WorkId::Glyf), &glyf);
-        self.maybe_persist(
-            &self.paths.target_file(&WorkId::Loca),
-            &loca
-                .iter()
-                .flat_map(|v| v.to_be_bytes())
-                .collect::<Vec<u8>>(),
-        );
+        if self.flags.contains(Flags::EMIT_IR) {
+            self.persist(&self.paths.target_file(&WorkId::Glyf), &glyf);
+            self.persist(
+                &self.paths.target_file(&WorkId::Loca),
+                &loca
+                    .iter()
+                    .flat_map(|v| v.to_be_bytes())
+                    .collect::<Vec<u8>>(),
+            );
+        }
 
         set_cached(&self.glyf_loca, (glyf, loca));
     }
@@ -369,6 +426,7 @@ impl Context {
     context_accessors! { get_hhea, set_hhea, hhea, Hhea, WorkId::Hhea, from_file, to_bytes }
 
     // Accessors where value is raw bytes
+    context_accessors! { get_gvar, set_gvar, gvar, Bytes, WorkId::Gvar, raw_from_file, raw_to_bytes }
     context_accessors! { get_hmtx, set_hmtx, hmtx, Bytes, WorkId::Hmtx, raw_from_file, raw_to_bytes }
     context_accessors! { get_font, set_font, font, Bytes, WorkId::Font, raw_from_file, raw_to_bytes }
 }

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -37,16 +37,22 @@ impl Paths {
         &self.glyph_dir
     }
 
-    fn glyph_file(&self, name: &str) -> PathBuf {
-        self.glyph_dir.join(glyph_file(name, ".glyph"))
+    fn glyph_glyf_file(&self, name: &str) -> PathBuf {
+        self.glyph_dir.join(glyph_file(name, ".glyf"))
+    }
+
+    fn glyph_gvar_file(&self, name: &str) -> PathBuf {
+        self.glyph_dir.join(glyph_file(name, ".gvar"))
     }
 
     pub fn target_file(&self, id: &WorkId) -> PathBuf {
         match id {
             WorkId::Features => self.build_dir.join("features.ttf"),
-            WorkId::Glyph(name) => self.glyph_file(name.as_str()),
+            WorkId::GlyfFragment(name) => self.glyph_glyf_file(name.as_str()),
+            WorkId::GvarFragment(name) => self.glyph_gvar_file(name.as_str()),
             WorkId::Avar => self.build_dir.join("avar.table"),
             WorkId::Glyf => self.build_dir.join("glyf.table"),
+            WorkId::Gvar => self.build_dir.join("gvar.table"),
             WorkId::Loca => self.build_dir.join("loca.table"),
             WorkId::Cmap => self.build_dir.join("cmap.table"),
             WorkId::Fvar => self.build_dir.join("fvar.table"),

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -33,7 +33,7 @@ regex = "1.7.1"
 
 indexmap = "1.9.2"
 
-write-fonts = "0.1.9"
+write-fonts = "0.1.11"
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -33,11 +33,13 @@ regex = "1.7.1"
 
 indexmap = "1.9.2"
 
-write-fonts = "0.1.8"
+write-fonts = "0.1.9"
 
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"
 tempfile = "3.3.0"
-read-fonts = "0.1.3"
+read-fonts = "0.1.4"
 pretty_assertions = "1.3.0"
+skrifa = { git = "https://github.com/googlefonts/fontations.git" }
+kurbo = { version = "0.9.2" }

--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -17,6 +17,8 @@ pub enum Access<I> {
     All,
     /// Access to one specific resource is permitted
     One(I),
+    /// Access to two specific resource is permitted
+    Two(I, I),
     /// A closure is used to determine access
     Custom(Arc<dyn Fn(&I) -> bool + Send + Sync>),
 }
@@ -86,6 +88,7 @@ impl<I: Eq> Access<I> {
             Access::None => false,
             Access::All => true,
             Access::One(allow) => id == allow,
+            Access::Two(a1, a2) => id == a1 || id == a2,
             Access::Custom(f) => f(id),
         }
     }

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -29,7 +29,7 @@ env_logger = "0.10.0"
 parking_lot = "0.12.1"
 
 font-types = "0.1.4"
-write-fonts = "0.1.9"  # for pens
+write-fonts = "0.1.11"  # for pens
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -28,8 +28,8 @@ log = "0.4"
 env_logger = "0.10.0"
 parking_lot = "0.12.1"
 
-font-types = "0.1.3"
-write-fonts = "0.1.8"  # for pens
+font-types = "0.1.4"
+write-fonts = "0.1.9"  # for pens
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -271,6 +271,10 @@ impl<T: Copy> Location<T> {
     pub fn get(&self, axis_name: &String) -> Option<T> {
         self.0.get(axis_name).copied()
     }
+
+    pub fn retain(&mut self, pred: impl Fn(&String, &mut T) -> bool) {
+        self.0.retain(pred);
+    }
 }
 
 impl DesignLocation {

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -252,6 +252,10 @@ impl<T: Copy> Location<T> {
         self
     }
 
+    pub fn rm_pos(&mut self, axis: &str) {
+        self.0.remove(axis);
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (&String, &T)> {
         self.0.iter()
     }

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -216,6 +216,10 @@ impl NormalizedCoord {
     pub fn into_inner(self) -> OrderedFloat<f32> {
         self.0
     }
+
+    pub fn to_f32(&self) -> f32 {
+        self.0.into_inner()
+    }
 }
 
 impl From<NormalizedCoord> for F2Dot14 {
@@ -295,8 +299,13 @@ impl NormalizedLocation {
                 .collect(),
         )
     }
+
     pub fn has_non_zero(&self, axis_name: &String) -> bool {
         self.get(axis_name).unwrap_or_default().into_inner() != OrderedFloat(0.0)
+    }
+
+    pub fn has_any_non_zero(&self) -> bool {
+        self.0.values().any(|v| v.into_inner() != OrderedFloat(0.0))
     }
 }
 

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -147,4 +147,6 @@ pub enum VariationModelError {
         axis_names: Vec<String>,
         location: NormalizedLocation,
     },
+    #[error("{0} is is an axis of variation defined only at a single point")]
+    PointAxis(String),
 }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -122,10 +122,10 @@ impl From<CoordConverter> for CoordConverterSerdeRepr {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StaticMetadataSerdeRepr {
     pub units_per_em: u16,
-    pub names: HashMap<NameKey, String>,
     pub axes: Vec<Axis>,
-    pub glyph_order: Vec<String>,
     pub glyph_locations: Vec<NormalizedLocation>,
+    pub names: HashMap<NameKey, String>,
+    pub glyph_order: Vec<String>,
 }
 
 impl From<StaticMetadataSerdeRepr> for StaticMetadata {
@@ -143,16 +143,17 @@ impl From<StaticMetadataSerdeRepr> for StaticMetadata {
 
 impl From<StaticMetadata> for StaticMetadataSerdeRepr {
     fn from(from: StaticMetadata) -> Self {
+        let glyph_locations = from.variation_model.locations().cloned().collect();
         StaticMetadataSerdeRepr {
             units_per_em: from.units_per_em,
-            names: from.names,
             axes: from.axes,
+            glyph_locations,
+            names: from.names,
             glyph_order: from
                 .glyph_order
                 .into_iter()
                 .map(|n| n.as_str().to_string())
                 .collect(),
-            glyph_locations: from.variation_model.locations().cloned().collect(),
         }
     }
 }

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -26,7 +26,7 @@ kurbo = { version="0.9.2", features=["serde"] }
 ordered-float = "3.4.0"
 indexmap = "1.9.2"
 
-font-types = "0.1.3"
+font-types = "0.1.4"
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -28,8 +28,8 @@ thiserror = "1.0.37"
 
 plist = { version =  "1.3.1", features = ["serde"] }
 
-font-types = "0.1.3"
-write-fonts = "0.1.8"  # for ot_round
+font-types = "0.1.4"
+write-fonts = "0.1.9"  # for ot_round
 
 ordered-float = { version = "3.4.0", features = ["serde"] }
 indexmap = "1.9.2"

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1.0.37"
 plist = { version =  "1.3.1", features = ["serde"] }
 
 font-types = "0.1.4"
-write-fonts = "0.1.9"  # for ot_round
+write-fonts = "0.1.11"  # for ot_round
 
 ordered-float = { version = "3.4.0", features = ["serde"] }
 indexmap = "1.9.2"

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1052,7 +1052,7 @@ mod tests {
     fn glyph_locations() {
         let (_, context) = build_static_metadata("wght_var.designspace");
         let static_metadata = &context.get_init_static_metadata();
-        let wght = static_metadata.axes.first().unwrap();
+        let wght = static_metadata.variable_axes.first().unwrap();
 
         assert_eq!(
             vec![
@@ -1072,7 +1072,7 @@ mod tests {
     fn no_metrics_for_glyph_only_sources() {
         let (_, context) = build_global_metrics("wght_var.designspace");
         let static_metadata = &context.get_init_static_metadata();
-        let wght = static_metadata.axes.first().unwrap();
+        let wght = static_metadata.variable_axes.first().unwrap();
         let mut metric_locations = context
             .get_global_metrics()
             .iter()


### PR DESCRIPTION
Builds on #230, #239. Fixes #207. Fixes #95. 

Update fontations to pickup gvar fixes and thereby fixes #245.

`cargo run -p fontc -- --source resources/testdata/mov_xy.designspace` now produces a VF that works in a browser.

I have punted some feedback to issues as I believe just compiling any vf that works is worth capturing, specifically:

1. https://github.com/googlefonts/fontmake-rs/issues/240
1. https://github.com/googlefonts/fontmake-rs/issues/241

Sufficient to compile an at least somewhat functional Oswald:

```shell
$ git clone https://github.com/googlefonts/OswaldFont
$ cd fontmake-rs
$ cargo run -p fontc -- --source ../OswaldFont/sources/Oswald.glyphs
```

In browser:

![image](https://user-images.githubusercontent.com/6466432/231008778-4d2b0e7e-ab00-495e-8418-8c892dd6a97e.png)


