### PR TITLE
GlyphPathBuilder: always output implicit closing line for closed paths 

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -695,7 +695,7 @@ impl GlyphPathBuilder {
 
     pub fn close_path(&mut self) -> Result<(), PathConversionError> {
         // Take dangling off-curves to imply a curve back to sub-path start
-        if let Some(last_move) = self.last_move_to.take() {
+        if let Some(last_move) = self.last_move_to {
             if !self.offcurve.is_empty() {
                 self.curve_to(last_move)?;
             }

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -64,9 +64,10 @@ fn to_ir_path(glyph_name: GlyphName, src_path: &Path) -> Result<BezPath, WorkErr
     } else {
         // In Glyphs.app, the starting node of a closed contour is always
         // stored at the end of the nodes list.
-        let (last, _) = nodes
+        let (last, elements) = nodes
             .split_last()
             .expect("Not empty and no last is a good trick");
+        nodes = elements;
         last
     };
     if first.node_type == NodeType::OffCurve {

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -198,7 +198,7 @@ mod tests {
         ];
         let contour = norad::Contour::new(points, None, None);
         let bez = to_ir_contour("test".into(), &contour).unwrap();
-        assert_eq!("M1,1 L9,1 L9,2 L1,2 Z", bez.to_svg());
+        assert_eq!("M1,1 L9,1 L9,2 L1,2 L1,1 Z", bez.to_svg());
     }
 
     // https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#point-types


### PR DESCRIPTION
this is to match fonttools PointToSegmentPen(outputImpliedClosingLine=True) and make sure that we don't lose or add any points when converting from points to BezPath and back to points (cf. https://github.com/googlefonts/fontmake-rs/pull/236#discussion_r1158279820).

(I pushed this last minute before leaving and plan to add more tests tomorrow hence marked as draft, but feel free to take a look if you want)