### PR TITLE
Load .glyphs instances and use them to inform axis rigging

### DIFF
--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -5,7 +5,7 @@ use fontir::{
     coords::{CoordConverter, DesignCoord},
     ir::Axis,
 };
-use log::trace;
+use log::debug;
 use read_fonts::types::MajorMinor;
 use write_fonts::tables::avar::{Avar, AxisValueMap, SegmentMaps};
 
@@ -59,8 +59,9 @@ impl Work<Context, Error> for AvarWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_init_static_metadata();
         // Guard clause: don't produce avar for a static font
+        eprintln!("AVAR {:?}", static_metadata.variable_axes);
         if static_metadata.variable_axes.is_empty() {
-            trace!("Skip avar; this is not a variable font");
+            debug!("Skip avar; this is not a variable font");
             return Ok(());
         }
         context.set_avar(Avar::new(

--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -59,7 +59,6 @@ impl Work<Context, Error> for AvarWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_init_static_metadata();
         // Guard clause: don't produce avar for a static font
-        eprintln!("AVAR {:?}", static_metadata.variable_axes);
         if static_metadata.variable_axes.is_empty() {
             debug!("Skip avar; this is not a variable font");
             return Ok(());

--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -4,8 +4,8 @@ use fontdrasil::orchestration::Work;
 use log::debug;
 use read_fonts::{
     tables::{
-        cmap::Cmap, fvar::Fvar, glyf::Glyf, gvar::Gvar, head::Head, hhea::Hhea, hmtx::Hmtx,
-        loca::Loca, maxp::Maxp, name::Name, os2::Os2, post::Post, avar::Avar,
+        avar::Avar, cmap::Cmap, fvar::Fvar, glyf::Glyf, gvar::Gvar, head::Head, hhea::Hhea,
+        hmtx::Hmtx, loca::Loca, maxp::Maxp, name::Name, os2::Os2, post::Post,
     },
     types::Tag,
     TopLevelTable,

--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -1,11 +1,11 @@
 //! Merge tables into a font
 
 use fontdrasil::orchestration::Work;
-use log::trace;
+use log::debug;
 use read_fonts::{
     tables::{
         cmap::Cmap, fvar::Fvar, glyf::Glyf, gvar::Gvar, head::Head, hhea::Hhea, hmtx::Hmtx,
-        loca::Loca, maxp::Maxp, name::Name, os2::Os2, post::Post,
+        loca::Loca, maxp::Maxp, name::Name, os2::Os2, post::Post, avar::Avar,
     },
     types::Tag,
     TopLevelTable,
@@ -29,7 +29,7 @@ enum TableType {
 }
 
 const TABLES_TO_MERGE: &[(WorkId, Tag, TableType)] = &[
-    (WorkId::Avar, Cmap::TAG, TableType::Variable),
+    (WorkId::Avar, Avar::TAG, TableType::Variable),
     (WorkId::Cmap, Cmap::TAG, TableType::Static),
     (WorkId::Fvar, Fvar::TAG, TableType::Variable),
     (WorkId::Head, Head::TAG, TableType::Static),
@@ -58,10 +58,10 @@ impl Work<Context, Error> for FontWork {
             .is_empty();
         for (work_id, tag, table_type) in TABLES_TO_MERGE {
             if is_static && matches!(table_type, TableType::Variable) {
-                trace!("Skip {tag} because this is a static font");
+                debug!("Skip {tag} because this is a static font");
                 continue;
             }
-            trace!("Grabbing {tag} for final font");
+            debug!("Grabbing {tag} for final font");
             let bytes = context.read_raw(work_id.clone()).map_err(Error::IoError)?;
             builder.add_table(*tag, bytes);
         }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1490,7 +1490,7 @@ mod tests {
             })
             .collect();
 
-        // 0 is 400, 7 is 700, .33 => .66 is mapping 500 => 600 as per instance definition
+        // 0 is 400, 1 is 700, .33 => .66 is mapping 500 => 600 as per instance definition
         assert_eq!(
             vec![vec![
                 (-1.0, -1.0),

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -5,7 +5,7 @@ use fontdrasil::types::GlyphName;
 use kurbo::Point;
 use thiserror::Error;
 
-use crate::coords::{DesignCoord, NormalizedCoord, NormalizedLocation, UserLocation};
+use crate::coords::{DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord, UserLocation};
 
 // TODO: eliminate dyn Error and collapse Error/WorkError
 
@@ -21,6 +21,8 @@ pub enum Error {
     ParseError(PathBuf, String),
     #[error("Missing required axis values for {0}")]
     NoAxisDefinitions(String),
+    #[error("Axis {0} has no entry in axes")]
+    NoEntryInAxes(String),
     #[error("Axis definitions are inconsistent")]
     InconsistentAxisDefinitions(String),
     #[error("Illegible source")]
@@ -41,10 +43,11 @@ pub enum Error {
     InvalidGlobalMetadata,
     #[error("No default master in {0:?}")]
     NoDefaultMaster(PathBuf),
-    #[error("Missing mapping on {axis_name} for {field} at {value:?}")]
+    #[error("Missing mapping on {axis_name} for {field} at {value:?}. Mappings {mappings:?}")]
     MissingMappingForDesignCoord {
         axis_name: String,
         field: String,
+        mappings: Vec<(UserCoord, DesignCoord)>,
         value: DesignCoord,
     },
     #[error("Invalid tag")]

--- a/glyphs-reader/src/error.rs
+++ b/glyphs-reader/src/error.rs
@@ -14,4 +14,6 @@ pub enum Error {
     NoUnitsPerEm,
     #[error("Invalid upem")]
     InvalidUpem(#[from] TryFromIntError),
+    #[error("Unrecognized name {0}")]
+    UnknownValueName(String),
 }

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -1021,16 +1021,12 @@ fn default_master_idx(raw_font: &RawFont) -> usize {
         })
         // TODO: implement searching for "a base style shared between all masters" as FontTools does
         // Still nothing? - just look for one called Regular
-        .unwrap_or_else(|| {
-            raw_font
-                .font_master
-                .iter()
-                .position(|m| match m.other_stuff.get("name") {
-                    Some(Plist::String(name)) => name == "Regular",
-                    _ => false,
-                })
-                .unwrap_or_default()
+        .or_else(|| {
+            raw_font.font_master.iter().position(
+                |m| matches!(m.other_stuff.get("name"), Some(Plist::String(name)) if name == "Regular"),
+            )
         })
+        .unwrap_or_default()
 }
 
 fn axis_index(from: &RawFont, pred: impl Fn(&Axis) -> bool) -> Option<usize> {

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -80,6 +80,7 @@ impl GlyphsIrSource {
             axis_mappings: font.axis_mappings.clone(),
             features: Default::default(),
             names: Default::default(),
+            instances: font.instances.clone(),
             version_major: Default::default(),
             version_minor: Default::default(),
         };
@@ -103,6 +104,7 @@ impl GlyphsIrSource {
             axis_mappings: Default::default(),
             features: Default::default(),
             names: Default::default(),
+            instances: font.instances.clone(),
             version_major: Default::default(),
             version_minor: Default::default(),
         };

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -166,7 +166,7 @@ fn to_ir_axis(
     let min = DesignCoord::new(min);
     let max = DesignCoord::new(max);
 
-    let converter = if font.axis_mappings.contains_key(&axis.name) {
+    let converter = if font.axis_mappings.contains(&axis.name) {
         let mappings: Vec<_> = font
             .axis_mappings
             .get(&axis.name)

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -139,6 +139,9 @@ fn find_by_design_coord(
         })
 }
 
+/// Convert .glyphs axes to IR axes.
+///
+///  See <https://github.com/googlefonts/glyphsLib/blob/6f243c1f732ea1092717918d0328f3b5303ffe56/Lib/glyphsLib/builder/axes.py#L155>
 fn to_ir_axis(
     font: &Font,
     axis_values: &[OrderedFloat<f64>],
@@ -181,6 +184,8 @@ fn to_ir_axis(
         let default = UserCoord::new(default.into_inner());
         CoordConverter::unmapped(min, default, max)
     };
+
+    eprintln!("font.axis_mappings for {} ({min:?}, {default:?}, {max:?}):\n{:#?}", axis.name, font.axis_mappings.get(&axis.name));
 
     Ok(ir::Axis {
         name: axis.name.clone(),

--- a/resources/testdata/glyphs2/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Avar.glyphs
@@ -253,7 +253,7 @@ width = 600;
 components = (
 {
 name = hyphen;
-transform = "{1, 0, 0, 1, -10, 100}";
+transform = "{1.15, 0, 0, 1.25, -10, 100}";
 },
 {
 name = hyphen;


### PR DESCRIPTION
Improve, though not yet to parity with fontmake, handling of glyphs 2/3 instances:

* Load glyphs instances for glyphs v2 and v3
   * Upgrade v2 to v3 per our std practice
   * We do not yet support all fields. Baby steps.
   * The code for this is tiresome and lengthy
* Fix typo that lead to avar not being merged into final font
* Include instance mappings in user:design mappings, which improves avar production
   * We now match the Oswald avar noted in https://github.com/googlefonts/fontmake-rs/issues/250#issuecomment-1504057038
* Figure out the default instance and use it to assign axis defaults
   * We now match the Oswald fvar axes noted in https://github.com/googlefonts/fontmake-rs/issues/250#issuecomment-1504057038
   * We do not yet emit any named instances

Step toward #250