### PR TITLE
Use skrifa from crates

### DIFF
--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -41,5 +41,5 @@ ansi_term = "0.12.1"
 tempfile = "3.3.0"
 read-fonts = "0.1.4"
 pretty_assertions = "1.3.0"
-skrifa = { git = "https://github.com/googlefonts/fontations.git" }
+skrifa = { version = "0.0.1" }
 kurbo = { version = "0.9.2" }


### PR DESCRIPTION
Changes the dev dependency for skrifa to pull from crates.io so I can break it without breaking everything else.

JMM