### PR TITLE
Add examples of glyphs files with instances

### DIFF
--- a/resources/testdata/glyphs2/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Avar.glyphs
@@ -250,6 +250,15 @@ layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 width = 600;
 },
 {
+components = (
+{
+name = hyphen;
+transform = "{1, 0, 0, 1, -10, 100}";
+},
+{
+name = hyphen;
+}
+);
 layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
 width = 600;
 }

--- a/resources/testdata/glyphs2/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Avar.glyphs
@@ -1,0 +1,254 @@
+{
+.appVersion = "3151";
+DisplayStrings = (
+"-",
+"!"
+);
+copyright = "Copy!";
+customParameters = (
+{
+name = localizedFamilyName;
+value = "Spanish;SpanishWghtVar";
+},
+{
+name = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+name = description;
+value = "The greatest weight var";
+},
+{
+name = versionString;
+value = "New Value";
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+weight = Light;
+weightValue = 300;
+xHeight = 500;
+},
+{
+alignmentZones = (
+"{737, 16}",
+"{0, -16}",
+"{-42, -16}"
+);
+ascender = 737;
+capHeight = 702;
+descender = -42;
+id = m01;
+weightValue = 400;
+xHeight = 501;
+},
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+weight = Bold;
+weightValue = 700;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = exclam;
+lastChange = "2023-04-12 16:55:39 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"354 183 LINE",
+"414 585 LINE",
+"178 585 LINE",
+"238 182 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 0 LINE",
+"354 107 LINE",
+"238 107 LINE",
+"238 0 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"364 176 LINE",
+"434 605 LINE",
+"159 605 LINE",
+"228 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 -20 LINE",
+"364 94 LINE",
+"228 94 LINE",
+"228 -20 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+paths = (
+{
+closed = 1;
+nodes = (
+"345 188 LINE",
+"396 573 LINE",
+"196 573 LINE",
+"247 187 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"345 13 LINE",
+"345 115 LINE",
+"247 115 LINE",
+"247 13 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0021;
+},
+{
+glyphname = hyphen;
+lastChange = "2023-04-12 16:52:19 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"131 250 LINE",
+"470 250 LINE",
+"470 330 LINE",
+"131 330 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"92 224 LINE",
+"508 224 LINE",
+"508 356 LINE",
+"92 356 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+width = 600;
+}
+);
+unicode = 002D;
+},
+{
+glyphname = "manual-component";
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+components = (
+{
+name = hyphen;
+transform = "{1, 0, 0, 1, 0, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = m01;
+width = 600;
+},
+{
+components = (
+{
+name = hyphen;
+transform = "{1.15, 0, 0, 1.25, 10, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 003D;
+}
+);
+instances = (
+{
+interpolationWeight = 600;
+instanceInterpolations = {
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = 0.66667;
+m01 = 0.33333;
+};
+name = Medium;
+weightClass = Medium;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/resources/testdata/glyphs2/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Avar.glyphs
@@ -2,7 +2,8 @@
 .appVersion = "3151";
 DisplayStrings = (
 "-",
-"!"
+"!",
+"/space"
 );
 copyright = "Copy!";
 customParameters = (
@@ -70,7 +71,7 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
+lastChange = "2023-04-12 17:01:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -78,7 +79,11 @@ width = 200;
 },
 {
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
-width = 600;
+width = 250;
+},
+{
+layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+width = 150;
 }
 );
 unicode = 0020;
@@ -164,7 +169,7 @@ unicode = 0021;
 },
 {
 glyphname = hyphen;
-lastChange = "2023-04-12 16:52:19 +0000";
+lastChange = "2023-04-12 17:01:20 +0000";
 layers = (
 {
 layerId = m01;
@@ -198,6 +203,17 @@ width = 600;
 },
 {
 layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+paths = (
+{
+closed = 1;
+nodes = (
+"146 260 LINE",
+"456 260 LINE",
+"456 320 LINE",
+"146 320 LINE"
+);
+}
+);
 width = 600;
 }
 );
@@ -205,7 +221,7 @@ unicode = 002D;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
+lastChange = "2023-04-12 17:00:55 +0000";
 layers = (
 {
 components = (
@@ -231,6 +247,10 @@ name = hyphen;
 }
 );
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+},
+{
+layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
 width = 600;
 }
 );

--- a/resources/testdata/glyphs3/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_Avar.glyphs
@@ -274,6 +274,16 @@ width = 600;
 },
 {
 layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+shapes = (
+{
+pos = (-10,100);
+ref = hyphen;
+scale = (1.15,1.25);
+},
+{
+ref = hyphen;
+}
+);
 width = 600;
 }
 );

--- a/resources/testdata/glyphs3/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_Avar.glyphs
@@ -1,0 +1,333 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+DisplayStrings = (
+"-",
+"!"
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+300
+);
+iconName = Light;
+id = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Light;
+},
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 737;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -42;
+},
+{
+pos = 702;
+},
+{
+pos = 501;
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+},
+{
+glyphname = exclam;
+lastChange = "2023-04-12 16:55:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,183,l),
+(414,585,l),
+(178,585,l),
+(238,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,0,l),
+(354,107,l),
+(238,107,l),
+(238,0,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,176,l),
+(434,605,l),
+(159,605,l),
+(228,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,-20,l),
+(364,94,l),
+(228,94,l),
+(228,-20,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(345,188,l),
+(396,573,l),
+(196,573,l),
+(247,187,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(345,13,l),
+(345,115,l),
+(247,115,l),
+(247,13,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 33;
+},
+{
+glyphname = hyphen;
+lastChange = "2023-04-12 16:52:19 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,250,l),
+(470,250,l),
+(470,330,l),
+(131,330,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,224,l),
+(508,224,l),
+(508,356,l),
+(92,356,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+width = 600;
+}
+);
+unicode = 45;
+},
+{
+glyphname = "manual-component";
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+pos = (0,100);
+ref = hyphen;
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+pos = (10,100);
+ref = hyphen;
+scale = (1.15,1.25);
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+}
+);
+unicode = 61;
+}
+);
+instances = (
+{
+axesValues = (
+600
+);
+instanceInterpolations = {
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = 0.66667;
+m01 = 0.33333;
+};
+name = Medium;
+weightClass = 500;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+properties = (
+{
+key = familyNames;
+values = (
+{
+language = ESP;
+value = SpanishWghtVar;
+}
+);
+},
+{
+key = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+key = descriptions;
+values = (
+{
+language = dflt;
+value = "The greatest weight var";
+}
+);
+},
+{
+key = copyrights;
+values = (
+{
+language = dflt;
+value = "Copy!";
+}
+);
+},
+{
+key = versionString;
+value = "New Value";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/resources/testdata/glyphs3/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_Avar.glyphs
@@ -3,7 +3,8 @@
 .formatVersion = 3;
 DisplayStrings = (
 "-",
-"!"
+"!",
+" "
 );
 axes = (
 {
@@ -92,7 +93,7 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
+lastChange = "2023-04-12 17:01:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -100,7 +101,11 @@ width = 200;
 },
 {
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
-width = 600;
+width = 250;
+},
+{
+layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+width = 150;
 }
 );
 unicode = 32;
@@ -186,7 +191,7 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2023-04-12 16:52:19 +0000";
+lastChange = "2023-04-12 17:01:20 +0000";
 layers = (
 {
 layerId = m01;
@@ -220,6 +225,17 @@ width = 600;
 },
 {
 layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
+shapes = (
+{
+closed = 1;
+nodes = (
+(146,260,l),
+(456,260,l),
+(456,320,l),
+(146,320,l)
+);
+}
+);
 width = 600;
 }
 );
@@ -227,7 +243,7 @@ unicode = 45;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
+lastChange = "2023-04-12 17:00:55 +0000";
 layers = (
 {
 layerId = m01;
@@ -254,6 +270,10 @@ scale = (1.15,1.25);
 ref = hyphen;
 }
 );
+width = 600;
+},
+{
+layerId = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
 width = 600;
 }
 );


### PR DESCRIPTION
Includes:

1. An instance that remaps weight, so an avar table is needed
1. A master below weight 400 so we need to pick the default properly (e.g. search for Regular as fontmake does)

Not handling these features causes Oswald to compile wrong, hence the milestone assignment.