### PR TITLE
Use `#[fromplist(rest)]` instead of `#[rest]`

### DIFF
--- a/glyphs-reader/plist_derive/src/lib.rs
+++ b/glyphs-reader/plist_derive/src/lib.rs
@@ -1,11 +1,11 @@
 extern crate proc_macro;
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, Attribute, Data, DeriveInput, Fields};
 
-#[proc_macro_derive(FromPlist, attributes(rest))]
+#[proc_macro_derive(FromPlist, attributes(fromplist))]
 pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident;
@@ -25,7 +25,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(expanded)
 }
 
-#[proc_macro_derive(ToPlist, attributes(rest))]
+#[proc_macro_derive(ToPlist, attributes(fromplist))]
 pub fn derive_to(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident;
@@ -134,10 +134,8 @@ fn add_ser_rest(data: &Data) -> TokenStream {
 
 fn is_rest(attrs: &[Attribute]) -> bool {
     attrs.iter().any(|attr| {
-        attr.path
-            .get_ident()
-            .map(|ident| ident == "rest")
-            .unwrap_or(false)
+        matches!((attr.path.get_ident(), attr.parse_args::<Ident>()), 
+            (Some(ident), Ok(arg)) if ident == "fromplist" && arg == "rest")
     })
 }
 

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -113,7 +113,7 @@ struct RawFont {
     pub classes: Option<Vec<RawFeature>>,
     pub properties: Option<Vec<RawName>>,
 
-    #[rest]
+    #[fromplist(rest)]
     pub other_stuff: BTreeMap<String, Plist>,
 }
 
@@ -143,7 +143,7 @@ pub struct RawFeature {
     pub tag: Option<String>,
     pub code: String,
 
-    #[rest]
+    #[fromplist(rest)]
     pub other_stuff: BTreeMap<String, Plist>,
 }
 
@@ -158,7 +158,7 @@ pub struct Axis {
 pub struct RawGlyph {
     pub layers: Vec<RawLayer>,
     pub glyphname: String,
-    #[rest]
+    #[fromplist(rest)]
     pub other_stuff: BTreeMap<String, Plist>,
 }
 
@@ -171,7 +171,7 @@ pub struct RawLayer {
     paths: Option<Vec<Path>>,
     components: Option<Vec<Component>>,
     //pub anchors: Option<Vec<Anchor>>,
-    #[rest]
+    #[fromplist(rest)]
     pub other_stuff: BTreeMap<String, Plist>,
 }
 
@@ -190,7 +190,7 @@ pub struct RawShape {
     // My Component'ness can be detected by presence of a ref (Glyphs3) or name(Glyphs2) attribute
 
     // Always
-    #[rest]
+    #[fromplist(rest)]
     pub other_stuff: BTreeMap<String, Plist>,
 }
 
@@ -299,7 +299,7 @@ struct RawFontMaster {
     pub id: String,
     pub axes_values: Option<Vec<OrderedFloat<f64>>>,
     pub metric_values: Option<Vec<RawMetricValue>>,
-    #[rest]
+    #[fromplist(rest)]
     pub other_stuff: BTreeMap<String, Plist>,
 }
 
@@ -355,7 +355,7 @@ struct RawInstance {
     pub type_: Option<String>,
     pub axes_values: Option<Vec<OrderedFloat<f64>>>,
 
-    #[rest]
+    #[fromplist(rest)]
     pub other_stuff: BTreeMap<String, Plist>,
 }
 


### PR DESCRIPTION
As requested in https://github.com/googlefonts/fontmake-rs/pull/252#discussion_r1165739577