### PR TITLE
Only convert to contours if basis vectors vary

### DIFF
--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -386,6 +386,10 @@ impl TryFrom<&ir::Glyph> for CheckedGlyph {
             })
             .collect();
         if path_els.len() > 1 {
+            warn!(
+                "{} has inconsistent path elements: {path_els:?}",
+                glyph.name
+            );
             return Err(Error::GlyphError(
                 glyph.name.clone(),
                 GlyphProblem::InconsistentPathElements,


### PR DESCRIPTION
Only consider basis vectors - not translation - when deciding if we need to convert to contours. Numerous Oswald glyphs we previously unnecessarily converted to contours are now kept as components, ref https://github.com/googlefonts/fontmake-rs/issues/250#issuecomment-1507845219, 2.

Credit @anthrotype for pointing out the problem in IM.