### PR TITLE
Set USE_MY_METRICS similar to how ufo2ft does it

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -529,6 +529,10 @@ impl Glyph {
     pub fn sources(&self) -> &HashMap<NormalizedLocation, GlyphInstance> {
         &self.sources
     }
+
+    pub fn source_mut(&mut self, loc: &NormalizedLocation) -> Option<&mut GlyphInstance> {
+        self.sources.get_mut(loc)
+    }
 }
 
 /// A variable definition of a single glyph.


### PR DESCRIPTION
Builds on #266. Many Oswald glyphs now set USE_MY_METRICS and produce identical results to fontmake. Improves results for https://github.com/googlefonts/fontmake-rs/issues/250#issuecomment-1507845219, 3.