### PR TITLE
Preallocate delta buffer

### DIFF
--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -191,6 +191,8 @@ impl VariationModel {
         {
             let master_influences = &self.delta_weights[model_idx];
             let mut deltas = Vec::new();
+            deltas.reserve(points.len());
+
             for (idx, point) in points.iter().enumerate() {
                 let initial_vector: V = *point - Default::default();
                 deltas.push(

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -190,8 +190,7 @@ impl VariationModel {
             })
         {
             let master_influences = &self.delta_weights[model_idx];
-            let mut deltas = Vec::new();
-            deltas.reserve(points.len());
+            let mut deltas = Vec::with_capacity(points.len());
 
             for (idx, point) in points.iter().enumerate() {
                 let initial_vector: V = *point - Default::default();


### PR DESCRIPTION
Purely out of curiosity - we're far from ready for any real perf tuning - I ran a flamegraph of Oswald building (`rm -rf build/ && cargo flamegraph -p fontc --  --source ../OswaldFont/sources/Oswald.glyphs --emit-ir false`). It showed an inordinate amount of time in variationmodel deltas, `fontir::variations::VariationModel::deltas (404 samples, 10.75%)`, dominated by `alloc::raw_vec::RawVec<T,A>::reserve_for_push`. Reserve ahead, reducing deltas enough to be hard to find on the flamegraph.