### PR TITLE
Centralize versions of shared dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,40 @@
+[workspace.dependencies]
+
+bincode = "1.3.3"
+serde = {version = "1.0", features = ["derive"] }
+serde_yaml = "0.9.14"
+
+thiserror = "1.0.37"
+
+log = "0.4"
+env_logger = "0.10.0"
+
+parking_lot = "0.12.1"
+
+fea-rs = "0.3.1"
+font-types = "0.1.4"
+read-fonts = "0.1.4"
+write-fonts = "0.1.11"
+skrifa = "0.0.1"
+
+bitflags = "2.0"
+chrono = "0.4.24"
+filetime = "0.2.18"
+indexmap = "1.9.2"
+kurbo = { version = "0.9.3", features = ["serde"] }
+ordered-float = { version = "3.4.0", features = ["serde"] }
+smol_str = { version = "0.1.24", features = ["serde"] }
+quick-xml = { version = "0.28.0", features = ["serialize"] }
+regex = "1.7.1"
+
+# dev dependencies
+diff = "0.1.12"
+ansi_term = "0.12.1"
+tempfile = "3.3.0"
+more-asserts = "0.3.1"
+pretty_assertions = "1.3.0"
+temp-env = "0.3.3"
+
 [workspace]
 
 members = [

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -14,32 +14,32 @@ categories = ["text-processing", "parsing", "graphics"]
 fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontir = { version = "0.0.1", path = "../fontir" }
 
-serde = {version = "1.0", features = ["derive"] }
-bincode = "1.3.3"
+serde.workspace = true
+bincode.workspace = true
 
-thiserror = "1.0.37"
-ordered-float = { version = "3.4.0", features = ["serde"] }
-indexmap = "1.9.2"
+thiserror.workspace = true
+ordered-float.workspace = true
+indexmap.workspace = true
 
-log = "0.4"
-env_logger = "0.10.0"
+log.workspace = true
+env_logger.workspace = true
 
-parking_lot = "0.12.1"
+parking_lot.workspace = true
 
-font-types = "0.1.4"
-read-fonts = "0.1.4"
-write-fonts = "0.1.11"
+font-types.workspace = true
+read-fonts.workspace = true
+write-fonts.workspace = true
 
-kurbo = { version = "0.9.3", features = ["serde"] }
+kurbo.workspace = true
 
-fea-rs = "0.3.1"
-smol_str = { version = "0.1.24", features = ["serde"] }
+fea-rs.workspace = true
+smol_str.workspace = true
 
-chrono = "0.4.24"
+chrono.workspace = true
 
 [dev-dependencies]
-diff = "0.1.12"
-ansi_term = "0.12.1"
-tempfile = "3.3.0"
-more-asserts = "0.3.1"
-temp-env = "0.3.3"
+diff.workspace = true
+ansi_term.workspace = true
+tempfile.workspace = true
+more-asserts.workspace = true
+temp-env.workspace = true

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -16,30 +16,35 @@ fontbe = { version = "0.0.1", path = "../fontbe" }
 fontir = { version = "0.0.1", path = "../fontir" }
 glyphs2fontir = { version = "0.0.1", path = "../glyphs2fontir" }
 ufo2fontir = { version = "0.0.1", path = "../ufo2fontir" }
-bitflags = "2.0"
-serde = {version = "1.0", features = ["derive"] }
-serde_yaml = "0.9.14"
-bincode = "1.3.3"
-filetime = "0.2.18"
+
+bitflags.workspace = true
+bincode.workspace = true
+
+serde.workspace = true
+serde_yaml.workspace = true
+
+filetime.workspace = true
+
+log.workspace = true
+env_logger.workspace = true
+thiserror.workspace = true
+
+indexmap.workspace = true
+regex.workspace = true
+
+write-fonts.workspace = true
+
+# just for fontc!
 clap = { version = "4.2.1", features = ["derive"] }
-log = "0.4"
-env_logger = "0.10.0"
-thiserror = "1.0.37"
 
 rayon = "1.6.0"
 crossbeam-channel = "0.5.6"
 
-regex = "1.7.1"
-
-indexmap = "1.9.2"
-
-write-fonts = "0.1.11"
-
 [dev-dependencies]
-diff = "0.1.12"
-ansi_term = "0.12.1"
-tempfile = "3.3.0"
-read-fonts = "0.1.4"
-pretty_assertions = "1.3.0"
-skrifa = { version = "0.0.1" }
-kurbo = { version = "0.9.3" }
+diff.workspace = true
+ansi_term.workspace = true
+tempfile.workspace = true
+read-fonts.workspace = true
+pretty_assertions.workspace = true
+skrifa.workspace = true
+kurbo.workspace = true

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -11,11 +11,11 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-smol_str = { version = "0.1.24", features = ["serde"] }
+smol_str.workspace = true
 
-serde = {version = "1.0", features = ["derive"] }
+serde.workspace = true
 
 [dev-dependencies]
-diff = "0.1.12"
-ansi_term = "0.12.1"
-tempfile = "3.3.0"
+diff.workspace = true
+ansi_term.workspace = true
+tempfile.workspace = true

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -13,26 +13,29 @@ categories = ["text-processing", "parsing", "graphics"]
 [dependencies]
 fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 
-bitflags = "2.0"
-serde = {version = "1.0", features = ["derive"] }
-serde_yaml = "0.9.14"
-bincode = "1.3.3"
-filetime = "0.2.18"
-thiserror = "1.0.37"
+bitflags.workspace = true
+serde.workspace = true
+serde_yaml.workspace = true
+bincode.workspace = true
+filetime.workspace = true
+thiserror.workspace = true
 
-kurbo = { version = "0.9.3", features = ["serde"] }
-ordered-float = { version = "3.4.0", features = ["serde"] }
-indexmap = "1.9.2"
+kurbo.workspace = true
+ordered-float.workspace = true
+indexmap.workspace = true
+
+log.workspace = true
+env_logger.workspace = true
+parking_lot.workspace = true
+
+font-types.workspace = true
+write-fonts.workspace = true  # for pens
+
+# unique to me!
 blake3 = "1.3.3"
-log = "0.4"
-env_logger = "0.10.0"
-parking_lot = "0.12.1"
-
-font-types = "0.1.4"
-write-fonts = "0.1.11"  # for pens
 
 [dev-dependencies]
-diff = "0.1.12"
-ansi_term = "0.12.1"
-tempfile = "3.3.0"
-pretty_assertions = "1.3.0"
+diff.workspace = true
+ansi_term.workspace = true
+tempfile.workspace = true
+pretty_assertions.workspace = true

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -9,15 +9,15 @@ edition = "2021"
 
 [dependencies]
 plist_derive = { path = "plist_derive" }
-ordered-float = "3.4.0"
-kurbo = { version="0.9.3", features=["serde"] }
+ordered-float.workspace = true
+kurbo.workspace = true
 
-thiserror = "1.0.37"
+thiserror.workspace = true
 
-log = "0.4"
-env_logger = "0.10.0"
+log.workspace = true
+env_logger.workspace = true
 
-regex = "1.7.0"
+regex.workspace = true
 
 [dev-dependencies]
-pretty_assertions = "1.3.0"
+pretty_assertions.workspace = true

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -15,21 +15,20 @@ fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontir = { version = "0.0.1", path = "../fontir" }
 glyphs-reader = { version = "0.0.1", path = "../glyphs-reader" }
 
-quick-xml = { version = "0.28.0", features = ["serialize"] }
+log.workspace = true
+env_logger.workspace = true
 
-log = "0.4"
-env_logger = "0.10.0"
+thiserror.workspace = true
 
-thiserror = "1.0.37"
+kurbo.workspace = true
+ordered-float.workspace = true
+indexmap.workspace = true
+quick-xml.workspace = true
 
-kurbo = { version="0.9.3", features=["serde"] }
-ordered-float = "3.4.0"
-indexmap = "1.9.2"
-
-font-types = "0.1.4"
+font-types.workspace = true
 
 [dev-dependencies]
-diff = "0.1.12"
-ansi_term = "0.12.1"
-tempfile = "3.3.0"
-pretty_assertions = "1.3.0"
+diff.workspace = true
+ansi_term.workspace = true
+tempfile.workspace = true
+pretty_assertions.workspace = true

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -14,28 +14,28 @@ categories = ["text-processing", "parsing", "graphics"]
 fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontir = { version = "0.0.1", path = "../fontir" }
 
+kurbo.workspace = true
+serde.workspace = true
+serde_yaml.workspace = true
+
+log.workspace = true
+env_logger.workspace = true
+
+thiserror.workspace = true
+
+font-types.workspace = true
+write-fonts.workspace = true  # for ot_round
+
+ordered-float.workspace = true
+indexmap.workspace = true
+quick-xml.workspace = true
+
+# unique to me!
 norad = "0.10.0"
-kurbo = { version="0.9.3", features=["serde"] }
-serde = {version = "1.0", features = ["derive"] }
-serde_yaml = "0.9.14"
-
-quick-xml = { version = "0.28.0", features = ["serialize"] }
-
-log = "0.4"
-env_logger = "0.10.0"
-
-thiserror = "1.0.37"
-
 plist = { version =  "1.3.1", features = ["serde"] }
 
-font-types = "0.1.4"
-write-fonts = "0.1.11"  # for ot_round
-
-ordered-float = { version = "3.4.0", features = ["serde"] }
-indexmap = "1.9.2"
-
 [dev-dependencies]
-diff = "0.1.12"
-ansi_term = "0.12.1"
-tempfile = "3.3.0"
-pretty_assertions = "1.3.0"
+diff.workspace = true
+ansi_term.workspace = true
+tempfile.workspace = true
+pretty_assertions.workspace = true


### PR DESCRIPTION
It's unlikely these wouldn't match on purpose. If we do need inconsistency it becomes very visible: everything but that uses workspace, why doesn't that?