### PR TITLE
Adjust the dependencies for hmtx to ensure bbox is available

### DIFF
--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -85,12 +85,11 @@ impl Workload {
 
                     debug!("Adding dependencies on {glyph_name}");
 
-                    // It would be lovely if our new glyph was in glyf, gvar, and hmtx
-                    // loca hides with glyf
+                    // It would be lovely if our new glyph was in glyf, and gvar
+                    // loca hides with glyf. hmtx blocks on glyf.
                     for (merge_work_id, new_dep) in [
                         (BeWorkIdentifier::Glyf, &glyph_work_id),
                         (BeWorkIdentifier::Gvar, &gvar_work_id),
-                        (BeWorkIdentifier::Hmtx, &glyph_work_id),
                     ] {
                         self.jobs_pending
                             .get_mut(&AnyWorkId::Be(merge_work_id))


### PR DESCRIPTION
Helps with #285, after this hmtx has just a handful of diffs. Most are small diffs in lsb, for example 15 vs 18, plus one weird one `<mtx name="brevecomb-cy" width="600" lsb="167"/>` that gets a width of 0 in the fontmake-py version.