### PR TITLE
Helper for frequent diff pattern

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -141,10 +141,16 @@ def main(argv):
     t1e = {e.tag: e for e in fontc.getroot()}
     t2e = {e.tag: e for e in fontmake.getroot()}
     for tag in sorted(t1 & t2):
-        if etree.tostring(t1e[tag]) == etree.tostring(t2e[tag]):
+        t1s = etree.tostring(t1e[tag])
+        t2s = etree.tostring(t2e[tag])
+        if t1s == t2s:
             print(f"  Identical '{tag}'")
         else:
-            print(f"  DIFF '{tag}'")
+            p1 = build_dir / f"fontc.{tag}.ttx"
+            p1.write_bytes(t1s)
+            p2 = build_dir / f"fontmake.{tag}.ttx"
+            p2.write_bytes(t2s)
+            print(f"  DIFF '{tag}', {p1} {p2}")
 
 
 if __name__ == "__main__":

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Helper for comparing fontc (Rust) vs fontmake (Python) binaries.
+
+Turns each into ttx, eliminates expected sources of difference and prints
+a brief summary of the result.
+
+fontmake should be installed in an active virtual environment.
+
+Usage:
+    # rebuild with fontmake and fontc and compare
+    python resources/scripts/ttx_diff.py ../OswaldFont/sources/Oswald.glyphs
+    # rebuild the fontc copy, reuse the prior fontmake copy (if present), and compare
+    python resources/scripts/ttx_diff.py --rebuild fontc ../OswaldFont/sources/Oswald.glyphs
+"""
+
+from absl import app
+from absl import flags
+from lxml import etree
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+
+FLAGS = flags.FLAGS
+
+
+flags.DEFINE_enum('rebuild', 'both', ['both', 'fontc', 'fontmake'], 'Which compilers to rebuild with if the output appears to already exist')
+
+
+def run(cmd, **kwargs):
+    cmd_string = " ".join(cmd)
+    print(f"Running {cmd_string}")
+    subprocess.run(cmd, text=True, check=True, **kwargs)
+
+
+def ttx(font_file):
+    ttx_file = font_file.with_suffix(".ttx")
+    cmd = [
+        "ttx",
+        "-o",
+        str(ttx_file),
+        str(font_file),
+    ]
+    run(cmd)
+    return ttx_file
+
+
+def build(cmd, build_tool, ttf_find_fn, **kwargs):
+    try_skip = FLAGS.rebuild not in [build_tool, "both"]
+    ttfs = ttf_find_fn()
+    if try_skip and len(ttfs) == 1:
+        ttx_file = ttfs[0].with_suffix(".ttx")
+        if ttx_file.is_file():
+            print(f"skipping {build_tool}")
+            return ttx_file 
+    run(cmd, **kwargs)
+    ttfs = ttf_find_fn()
+    assert len(ttfs) == 1, ttfs
+    return ttx(ttfs[0])
+
+
+def build_fontc(source, build_dir):    
+    cmd = [
+        "cargo",
+        "run",
+        "-p",
+        "fontc",
+        "--",
+        "--source",
+        str(source),
+        "--build-dir",
+        str(build_dir),
+    ]
+    return build(cmd, "fontc", lambda: (build_dir / "font.ttf",))
+
+
+def build_fontmake(source, build_dir):
+    cmd = [
+        "fontmake",
+        "-o",
+        "variable",
+        "--no-production-names",
+        "--keep-direction",
+        "--filter",
+        "FlattenComponentsFilter",
+        "--filter",
+        "DecomposeTransformedComponentsFilter",
+        str(source),
+    ]
+    return build(cmd, "fontmake", lambda: tuple((build_dir /"variable_ttf").rglob("*.ttf")), cwd=build_dir)
+
+
+def copy(old, new):
+    shutil.copyfile(old, new)
+    return new
+
+
+def main(argv):
+    if len(argv) != 2:
+        sys.exit("Only one argument, a source file, is expected")
+
+    source = Path(argv[1])
+    if not source.is_file():
+        sys.exit(f"No such file: {source}")
+
+    root = Path(".").resolve()
+    if root.name != "fontmake-rs":
+        sys.exit("Expected to be at the root of fontmake-rs")
+
+    build_dir = (root / "build").relative_to(root)
+    build_dir.mkdir(exist_ok = True)
+
+    if shutil.which("fontmake") is None:
+        sys.exit("No fontmake")
+    if shutil.which("ttx") is None:
+        sys.exit("No ttx")
+
+    fontc_ttx = copy(build_fontc(source, build_dir), build_dir / "fontc.ttx")
+    fontmake_ttx = copy(build_fontmake(source.resolve(), build_dir), build_dir / "fontmake.ttx")
+
+    print("TTX FILES")
+    print("  fontc    ", fontc_ttx)
+    print("  fontmake ", fontmake_ttx)
+
+    fontc = etree.parse(fontc_ttx)
+    fontmake = etree.parse(fontmake_ttx)
+
+    print("COMPARISON")
+    t1 = {e.tag for e in fontc.getroot()}
+    t2 = {e.tag for e in fontmake.getroot()}
+    if t1 != t2:
+        if t1 -t2:
+            tags = ", ".join(f"'{t}'" for t in sorted(t1 -t2))
+            print(f"  Only fontc produced {tags}")
+
+        if t2 -t1:
+            tags = ", ".join(f"'{t}'" for t in sorted(t2 - t1))
+            print(f"  Only fontmake produced {tags}")
+
+    t1e = {e.tag: e for e in fontc.getroot()}
+    t2e = {e.tag: e for e in fontmake.getroot()}
+    for tag in sorted(t1 & t2):
+        if etree.tostring(t1e[tag]) == etree.tostring(t2e[tag]):
+            print(f"  Identical '{tag}'")
+        else:
+            print(f"  DIFF '{tag}'")
+
+
+if __name__ == "__main__":
+    app.run(main)


### PR DESCRIPTION
Builds on #287 because I was using it to help test that. Submit #287 first. Current result:

```
COMPARISON
  Only fontmake produced 'GDEF', 'GPOS', 'GSUB', 'HVAR', 'STAT'
  Identical 'GlyphOrder'
  DIFF 'OS_2', build/fontc.OS_2.ttx build/fontmake.OS_2.ttx
  Identical 'avar'
  DIFF 'cmap', build/fontc.cmap.ttx build/fontmake.cmap.ttx
  DIFF 'fvar', build/fontc.fvar.ttx build/fontmake.fvar.ttx
  DIFF 'glyf', build/fontc.glyf.ttx build/fontmake.glyf.ttx
  DIFF 'gvar', build/fontc.gvar.ttx build/fontmake.gvar.ttx
  DIFF 'head', build/fontc.head.ttx build/fontmake.head.ttx
  DIFF 'hhea', build/fontc.hhea.ttx build/fontmake.hhea.ttx
  Identical 'hmtx'
  Identical 'loca'
  DIFF 'maxp', build/fontc.maxp.ttx build/fontmake.maxp.ttx
  DIFF 'name', build/fontc.name.ttx build/fontmake.name.ttx
  DIFF 'post', build/fontc.post.ttx build/fontmake.post.ttx
```
