### PR TITLE
Use latest write-fonts so we produce identical cmap's for Oswald.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ parking_lot = "0.12.1"
 fea-rs = "= 0.3.3"
 font-types = { version = "0.1.6", features = ["serde"] }
 read-fonts = "0.2.0"
-write-fonts = "0.3.4"
+write-fonts = "0.3.5"
 skrifa = "0.1.0"
 
 bitflags = "2.0"


### PR DESCRIPTION
Fixes #251. Do not just merge because the key fontations change, in https://github.com/googlefonts/fontations/pull/417, is not yet published.