### PR TITLE
Add basic support for named instances for .glyphs files

### DIFF
--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -63,11 +63,9 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
                     .variable_axes
                     .iter()
                     .map(|axis| {
-                        eprintln!("{} lookup in {:?}", axis.name, ni.location);
                         let loc = ni
                             .location
                             .get(&axis.name)
-                            .map(|nc| nc.to_user(&axis.converter))
                             .unwrap_or(axis.default)
                             .into_inner();
                         Fixed::from_f64(loc.into_inner() as f64)

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -76,6 +76,7 @@ mod tests {
             1000,
             Default::default(),
             [axis(400.0, 400.0, 700.0)].to_vec(),
+            Default::default(),
             IndexSet::from_iter(glyph_order.iter().map(|n| GlyphName::from(*n))),
             Default::default(),
         )

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -457,7 +457,7 @@ impl Axis {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct NamedInstance {
     pub name: String,
-    pub location: NormalizedLocation,
+    pub location: UserLocation,
 }
 
 /// Features (Adobe fea).

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -11,7 +11,7 @@ use crate::{
     coords::{CoordConverter, DesignCoord, NormalizedLocation, UserCoord},
     ir::{
         Axis, GlobalMetric, GlobalMetrics, Glyph, GlyphBuilder, GlyphInstance, NameKey,
-        StaticMetadata,
+        NamedInstance, StaticMetadata,
     },
     stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
 };
@@ -53,6 +53,7 @@ impl From<CoordConverter> for CoordConverterSerdeRepr {
 pub struct StaticMetadataSerdeRepr {
     pub units_per_em: u16,
     pub axes: Vec<Axis>,
+    pub named_instances: Vec<NamedInstance>,
     pub glyph_locations: Vec<NormalizedLocation>,
     pub names: HashMap<NameKey, String>,
     pub glyph_order: Vec<String>,
@@ -64,6 +65,7 @@ impl From<StaticMetadataSerdeRepr> for StaticMetadata {
             from.units_per_em,
             from.names,
             from.axes,
+            from.named_instances,
             from.glyph_order.into_iter().map(|s| s.into()).collect(),
             from.glyph_locations.into_iter().collect(),
         )
@@ -77,6 +79,7 @@ impl From<StaticMetadata> for StaticMetadataSerdeRepr {
         StaticMetadataSerdeRepr {
             units_per_em: from.units_per_em,
             axes: from.axes,
+            named_instances: from.named_instances,
             glyph_locations,
             names: from.names,
             glyph_order: from

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -786,7 +786,6 @@ impl RawFont {
         }
         for instance in self.instances.iter_mut() {
             instance.axes_values = v2_to_v3_axis_values(axes, &mut instance.other_stuff)?;
-            eprintln!("{} at {:?}", instance.name, instance.axes_values);
         }
 
         if custom_params_mut(&mut self.other_stuff).map_or(false, |d| d.is_empty()) {
@@ -1723,6 +1722,11 @@ mod tests {
         assert_load_v2_matches_load_v3("WghtVar_Avar.glyphs");
     }
 
+    #[test]
+    fn read_wght_var_instances_2_and_3() {
+        assert_load_v2_matches_load_v3("WghtVar_Instances.glyphs");
+    }
+
     fn only_shape_in_only_layer<'a>(font: &'a Font, glyph_name: &str) -> &'a Shape {
         let glyph = font.glyphs.get(glyph_name).unwrap();
         assert_eq!(1, glyph.layers.len());
@@ -2035,5 +2039,27 @@ mod tests {
     #[test]
     fn favor_regular_as_origin_glyphs3() {
         assert_wghtvar_avar_master_and_axes(&glyphs3_dir().join("WghtVar_Avar.glyphs"));
+    }
+
+    #[test]
+    fn have_all_the_best_instances() {
+        let font = Font::load(&glyphs3_dir().join("WghtVar_Instances.glyphs")).unwrap();
+        assert_eq!(
+            vec![
+                ("Regular", vec![("Weight", 400.0)]),
+                ("Bold", vec![("Weight", 700.0)])
+            ],
+            font.instances
+                .iter()
+                .map(|inst| (
+                    inst.name.as_str(),
+                    font.axes
+                        .iter()
+                        .zip(&inst.axes_values)
+                        .map(|(a, v)| (a.name.as_str(), v.0 as f32))
+                        .collect::<Vec<_>>()
+                ))
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -7,7 +7,8 @@ mod plist;
 mod to_plist;
 
 pub use font::{
-    Axis, Component, FeatureSnippet, Font, FontMaster, Glyph, Layer, Node, NodeType, Path, Shape,
+    Axis, Component, FeatureSnippet, Font, FontMaster, Glyph, InstanceType, Layer, Node, NodeType,
+    Path, Shape,
 };
 pub use from_plist::FromPlist;
 pub use plist::Plist;

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -269,6 +269,7 @@ impl Work<Context, WorkError> for StaticMetadataWork {
                 .unwrap_or("<nameless family>")
         );
         let axes = font_info.axes.clone();
+        let axis_map = axes.iter().map(|a| (&a.name, a)).collect();
         let named_instances = font
             .instances
             .iter()
@@ -278,7 +279,11 @@ impl Work<Context, WorkError> for StaticMetadataWork {
                 }
                 Some(NamedInstance {
                     name: inst.name.clone(),
-                    location: font_info.locations.get(&inst.axes_values).cloned().unwrap(),
+                    location: font_info
+                        .locations
+                        .get(&inst.axes_values)
+                        .map(|nc| nc.to_user(&axis_map))
+                        .unwrap(),
                 })
             })
             .collect();
@@ -306,10 +311,6 @@ impl Work<Context, WorkError> for StaticMetadataWork {
         if let Some(vendor_id) = font.names.get("vendorID") {
             static_metadata.vendor_id = Tag::from_str(vendor_id).map_err(WorkError::InvalidTag)?;
         }
-        // for instance in font.instances.iter() {
-        //     eprintln!("{instance:?}");
-        // }
-        // todo!();
         context.set_init_static_metadata(static_metadata);
         Ok(())
     }

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -116,7 +116,7 @@ pub(crate) fn to_ir_features(features: &[FeatureSnippet]) -> Result<ir::Features
     Ok(ir::Features::Memory(fea_snippets.join("\n\n")))
 }
 
-fn design_location(axes: &[ir::Axis], axes_values: &Vec<OrderedFloat<f64>>) -> DesignLocation {
+fn design_location(axes: &[ir::Axis], axes_values: &[OrderedFloat<f64>]) -> DesignLocation {
     axes.iter()
         .zip(axes_values.iter())
         .map(|(axis, pos)| (axis.name.clone(), DesignCoord::new(pos.into_inner() as f32)))

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -7,7 +7,7 @@ use fontir::{
     error::{Error, WorkError},
     ir::{self, GlyphPathBuilder},
 };
-use glyphs_reader::{Component, FeatureSnippet, Font, FontMaster, NodeType, Path, Shape};
+use glyphs_reader::{Component, FeatureSnippet, Font, NodeType, Path, Shape};
 use kurbo::BezPath;
 use log::trace;
 use ordered_float::OrderedFloat;

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -116,9 +116,9 @@ pub(crate) fn to_ir_features(features: &[FeatureSnippet]) -> Result<ir::Features
     Ok(ir::Features::Memory(fea_snippets.join("\n\n")))
 }
 
-fn design_location(axes: &[ir::Axis], master: &FontMaster) -> DesignLocation {
+fn design_location(axes: &[ir::Axis], axes_values: &Vec<OrderedFloat<f64>>) -> DesignLocation {
     axes.iter()
-        .zip(master.axes_values.iter())
+        .zip(axes_values.iter())
         .map(|(axis, pos)| (axis.name.clone(), DesignCoord::new(pos.into_inner() as f32)))
         .collect()
 }
@@ -224,8 +224,8 @@ pub struct FontInfo {
     pub font: Font,
     /// Index by master id
     pub master_indices: HashMap<String, usize>,
-    /// Location by master id
-    pub master_locations: HashMap<String, NormalizedLocation>,
+    /// Axes values => location for every instance and master
+    pub locations: HashMap<Vec<OrderedFloat<f64>>, NormalizedLocation>,
     pub axes: Vec<ir::Axis>,
     /// Index by tag
     pub axis_indices: HashMap<Tag, usize>,
@@ -250,21 +250,27 @@ impl TryFrom<Font> for FontInfo {
             .collect();
 
         let axes_by_name = axes.iter().map(|a| (&a.name, a)).collect();
-        let master_locations: HashMap<_, _> = font
+        let locations: HashMap<_, _> = font
             .masters
             .iter()
             .map(|m| {
                 (
-                    m.id.clone(),
-                    design_location(&axes, m).to_normalized(&axes_by_name),
+                    m.axes_values.clone(),
+                    design_location(&axes, &m.axes_values).to_normalized(&axes_by_name),
                 )
             })
+            .chain(font.instances.iter().map(|i| {
+                (
+                    i.axes_values.clone(),
+                    design_location(&axes, &i.axes_values).to_normalized(&axes_by_name),
+                )
+            }))
             .collect();
 
         Ok(FontInfo {
             font,
             master_indices,
-            master_locations,
+            locations,
             axes,
             axis_indices,
         })

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -41,8 +41,8 @@ flags.DEFINE_enum(
 flags.DEFINE_enum(
     "rebuild",
     "both",
-    ["both", "fontc", "fontmake"],
-    "Which compilers to rebuild with if the output appears to already exist",
+    ["both", "fontc", "fontmake", "none"],
+    "Which compilers to rebuild with if the output appears to already exist. None is handy when playing with ttx_diff.py itself.",
 )
 
 
@@ -138,6 +138,25 @@ def copy(old, new):
     return new
 
 
+def name_id_to_name(ttx, xpath, attr):
+    id_to_name = {
+        el.attrib["nameID"]: el.text.strip()
+        for el in ttx.xpath("//name/namerecord[@platformID='3' and @platEncID='1' and @langID='0x409']")
+    }
+    for el in ttx.xpath(xpath):
+        if attr not in el.attrib:
+            continue
+        print(f"{el.attrib[attr]} => {id_to_name[el.attrib[attr]]}")
+        el.attrib[attr] = id_to_name[el.attrib[attr]]
+
+
+def reduce_diff_noise(fontc, fontmake):
+    for ttx in (fontc, fontmake):
+        # different name ids with the same value is fine
+        name_id_to_name(ttx, "//NamedInstance", "subfamilyNameID")
+    
+
+
 def main(argv):
     if len(argv) != 2:
         sys.exit("Only one argument, a source file, is expected")
@@ -178,6 +197,8 @@ def main(argv):
 
         fontc = etree.parse(fontc_ttx)
         fontmake = etree.parse(fontmake_ttx)
+
+        reduce_diff_noise(fontc, fontmake)
 
         print("COMPARISON")
         t1 = {e.tag for e in fontc.getroot()}

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -146,7 +146,10 @@ def name_id_to_name(ttx, xpath, attr):
     for el in ttx.xpath(xpath):
         if attr not in el.attrib:
             continue
-        print(f"{el.attrib[attr]} => {id_to_name[el.attrib[attr]]}")
+        # names <= 255 have specific assigned slots, names > 255 not
+        name_id = int(el.attrib[attr])
+        if name_id <= 255:
+            continue
         el.attrib[attr] = id_to_name[el.attrib[attr]]
 
 
@@ -217,13 +220,13 @@ def main(argv):
         for tag in sorted(t1 & t2):
             t1s = etree.tostring(t1e[tag])
             t2s = etree.tostring(t2e[tag])
+            p1 = build_dir / f"fontc.{tag}.ttx"
+            p1.write_bytes(t1s)
+            p2 = build_dir / f"fontmake.{tag}.ttx"
+            p2.write_bytes(t2s)
             if t1s == t2s:
                 print(f"  Identical '{tag}'")
             else:
-                p1 = build_dir / f"fontc.{tag}.ttx"
-                p1.write_bytes(t1s)
-                p2 = build_dir / f"fontmake.{tag}.ttx"
-                p2.write_bytes(t2s)
                 print(f"  DIFF '{tag}', {p1} {p2}")
 
 

--- a/resources/testdata/glyphs2/WghtVar_Instances.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Instances.glyphs
@@ -1,0 +1,224 @@
+{
+.appVersion = "3151";
+DisplayStrings = (
+"-",
+"!"
+);
+copyright = "Copy!";
+customParameters = (
+{
+name = localizedFamilyName;
+value = "Spanish;SpanishWghtVar";
+},
+{
+name = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+name = description;
+value = "The greatest weight var";
+},
+{
+name = versionString;
+value = "New Value";
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+alignmentZones = (
+"{737, 16}",
+"{0, -16}",
+"{-42, -16}"
+);
+ascender = 737;
+capHeight = 702;
+descender = -42;
+id = m01;
+weightValue = 400;
+xHeight = 501;
+},
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+weight = Bold;
+weightValue = 700;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = exclam;
+lastChange = "2022-12-01 05:10:49 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"354 183 LINE",
+"414 585 LINE",
+"178 585 LINE",
+"238 182 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 0 LINE",
+"354 107 LINE",
+"238 107 LINE",
+"238 0 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"364 176 LINE",
+"434 605 LINE",
+"159 605 LINE",
+"228 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 -20 LINE",
+"364 94 LINE",
+"228 94 LINE",
+"228 -20 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0021;
+},
+{
+glyphname = hyphen;
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"131 250 LINE",
+"470 250 LINE",
+"470 330 LINE",
+"131 330 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"92 224 LINE",
+"508 224 LINE",
+"508 356 LINE",
+"92 356 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 002D;
+},
+{
+glyphname = "manual-component";
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+components = (
+{
+name = hyphen;
+transform = "{1, 0, 0, 1, 0, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = m01;
+width = 600;
+},
+{
+components = (
+{
+name = hyphen;
+transform = "{1.15, 0, 0, 1.25, 10, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 003D;
+}
+);
+instances = (
+{
+interpolationWeight = 400;
+instanceInterpolations = {
+m01 = 1;
+};
+name = Regular;
+},
+{
+interpolationWeight = 700;
+instanceInterpolations = {
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = 1;
+};
+isBold = 1;
+linkStyle = Regular;
+name = Bold;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/resources/testdata/glyphs3/WghtVar_Instances.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_Instances.glyphs
@@ -1,0 +1,294 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+DisplayStrings = (
+"-",
+"!"
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 737;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -42;
+},
+{
+pos = 702;
+},
+{
+pos = 501;
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+},
+{
+glyphname = exclam;
+lastChange = "2022-12-01 05:10:49 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,183,l),
+(414,585,l),
+(178,585,l),
+(238,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,0,l),
+(354,107,l),
+(238,107,l),
+(238,0,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,176,l),
+(434,605,l),
+(159,605,l),
+(228,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,-20,l),
+(364,94,l),
+(228,94,l),
+(228,-20,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 33;
+},
+{
+glyphname = hyphen;
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,250,l),
+(470,250,l),
+(470,330,l),
+(131,330,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,224,l),
+(508,224,l),
+(508,356,l),
+(92,356,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 45;
+},
+{
+glyphname = "manual-component";
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+pos = (0,100);
+ref = hyphen;
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+pos = (10,100);
+ref = hyphen;
+scale = (1.15,1.25);
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+}
+);
+unicode = 61;
+}
+);
+instances = (
+{
+axesValues = (
+400
+);
+instanceInterpolations = {
+m01 = 1;
+};
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+instanceInterpolations = {
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = 1;
+};
+isBold = 1;
+linkStyle = Regular;
+name = Bold;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+properties = (
+{
+key = familyNames;
+values = (
+{
+language = ESP;
+value = SpanishWghtVar;
+}
+);
+},
+{
+key = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+key = descriptions;
+values = (
+{
+language = dflt;
+value = "The greatest weight var";
+},
+{
+language = ESP;
+value = "The greatest Spanish weight var";
+}
+);
+},
+{
+key = copyrights;
+values = (
+{
+language = dflt;
+value = "Copy!";
+}
+);
+},
+{
+key = versionString;
+value = "New Value";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -594,13 +594,20 @@ impl Work<Context, WorkError> for StaticMetadataWork {
         let units_per_em = units_per_em(font_infos.values())?;
         let names = names(font_info_at_default);
         let axes = to_ir_axes(&self.designspace.axes)?;
+        let named_instances = Vec::new(); // TODO
         let master_locations = master_locations(&axes, &self.designspace.sources);
         let glyph_locations = master_locations.values().cloned().collect();
         let glyph_order = glyph_order(default_master, designspace_dir, &self.glyph_names)?;
 
-        let mut static_metadata =
-            StaticMetadata::new(units_per_em, names, axes, glyph_order, glyph_locations)
-                .map_err(WorkError::VariationModelError)?;
+        let mut static_metadata = StaticMetadata::new(
+            units_per_em,
+            names,
+            axes,
+            named_instances,
+            glyph_order,
+            glyph_locations,
+        )
+        .map_err(WorkError::VariationModelError)?;
         if let Some(vendor_id) = &font_info_at_default.open_type_os2_vendor_id {
             static_metadata.vendor_id = Tag::from_str(vendor_id).map_err(WorkError::InvalidTag)?;
         }


### PR DESCRIPTION
Sufficient to make Oswald fvar report to match the one from fontmake:

```shell
python resources/scripts/ttx_diff.py ../OswaldFont/sources/Oswald.glyphs | grep "'fvar'"
  Identical 'fvar'
  Identical 'fvar'
```

New test files created by loading WghtVar.glyphs in Glyphs, running add instance for each master, and saving as v2/3.
