### PR TITLE
Make Oswald OS/2 from fontc closer to that from fontmake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ parking_lot = "0.12.1"
 fea-rs = "= 0.3.3"
 font-types = { version = "0.1.6", features = ["serde"] }
 read-fonts = "0.2.0"
-write-fonts = "0.3.5"
+write-fonts = "0.3.6"
 skrifa = "0.1.0"
 
 bitflags = "2.0"

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Display, io};
 
 use fea_rs::compile::error::{BinaryCompilationError, CompilerError};
+use font_types::Tag;
 use fontdrasil::types::GlyphName;
 use fontir::variations::DeltaError;
 use read_fonts::ReadError;
@@ -49,6 +50,8 @@ pub enum Error {
     ReadFontsReadError(#[from] ReadError),
     #[error("IUP error for {0}: {1:?}")]
     IupError(GlyphName, IupError),
+    #[error("Unable to interpret bytes as {0}")]
+    InvalidTableBytes(Tag),
 }
 
 #[derive(Debug)]

--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -2,7 +2,7 @@
 
 use fontdrasil::orchestration::Work;
 use fontir::ir::GlobalMetricsInstance;
-use read_fonts::types::Tag;
+use read_fonts::{tables::hmtx::Hmtx, types::Tag, FontData, TopLevelTable};
 use write_fonts::{tables::os2::Os2, OtRound};
 
 use crate::{
@@ -16,9 +16,51 @@ pub fn create_os2_work() -> Box<BeWork> {
     Box::new(Os2Work {})
 }
 
-fn build_os2(vendor_id: Tag, metrics: &GlobalMetricsInstance) -> Os2 {
+/// <https://github.com/fonttools/fonttools/blob/115275cbf429d91b75ac5536f5f0b2d6fe9d823a/Lib/fontTools/ttLib/tables/O_S_2f_2.py#L336-L348>
+fn x_avg_char_width(context: &Context) -> Result<i16, Error> {
+    let static_metadata = context.ir.get_final_static_metadata();
+    let hhea = context.get_hhea();
+    let raw_hmtx = context.get_hmtx();
+    let num_glyphs = static_metadata.glyph_order.len() as u64;
+    let hmtx = Hmtx::read(
+        FontData::new(raw_hmtx.get()),
+        hhea.number_of_long_metrics,
+        num_glyphs as u16,
+    )
+    .map_err(|_| Error::InvalidTableBytes(Hmtx::TAG))?;
+
+    // count width > 0 only, including adding tail only if > 0
+    let (count, total) = hmtx
+        .h_metrics()
+        .iter()
+        .filter_map(|metric| match metric.advance() {
+            0 => None,
+            v => Some(v as u64),
+        })
+        .fold((0_u64, 0_u64), |(count, total), value| {
+            (count + 1, total + value)
+        });
+    // plus any copies of the final advance
+    let last_advance = hmtx
+        .h_metrics()
+        .last()
+        .map(|m| m.advance() as u64)
+        .unwrap_or_default();
+    let (count, total) = if last_advance > 0 {
+        let num_short = num_glyphs - hhea.number_of_long_metrics as u64;
+        (count + num_short, total + num_short * last_advance)
+    } else {
+        (count, total)
+    };
+
+    Ok((total as f32 / count as f32).ot_round())
+}
+
+fn build_os2(x_avg_char_width: i16, vendor_id: Tag, metrics: &GlobalMetricsInstance) -> Os2 {
     Os2 {
         ach_vend_id: vendor_id,
+
+        x_avg_char_width,
 
         s_cap_height: Some(metrics.cap_height.ot_round()),
         sx_height: Some(metrics.x_height.ot_round()),
@@ -37,12 +79,17 @@ fn build_os2(vendor_id: Tag, metrics: &GlobalMetricsInstance) -> Os2 {
 impl Work<Context, Error> for Os2Work {
     /// Generate [OS/2](https://learn.microsoft.com/en-us/typography/opentype/spec/os2)
     fn exec(&self, context: &Context) -> Result<(), Error> {
-        let static_metadata = context.ir.get_init_static_metadata();
+        let static_metadata = context.ir.get_final_static_metadata();
         let metrics = context
             .ir
             .get_global_metrics()
             .at(static_metadata.default_location());
-        context.set_os2(build_os2(static_metadata.vendor_id, &metrics));
+
+        context.set_os2(build_os2(
+            x_avg_char_width(context)?,
+            static_metadata.vendor_id,
+            &metrics,
+        ));
         Ok(())
     }
 }
@@ -65,9 +112,10 @@ mod tests {
         global_metrics.set(GlobalMetric::CapHeight, default_location.clone(), 37.5);
         global_metrics.set(GlobalMetric::XHeight, default_location.clone(), 112.2);
 
-        let os2 = build_os2(Tag::new(b"DUCK"), &global_metrics.at(&default_location));
+        let os2 = build_os2(42, Tag::new(b"DUCK"), &global_metrics.at(&default_location));
 
         assert_eq!(Tag::new(b"DUCK"), os2.ach_vend_id);
+        assert_eq!(42, os2.x_avg_char_width);
         assert_eq!(Some(38), os2.s_cap_height);
         assert_eq!(Some(112), os2.sx_height);
     }

--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -65,6 +65,25 @@ fn build_os2(x_avg_char_width: i16, vendor_id: Tag, metrics: &GlobalMetricsInsta
         s_cap_height: Some(metrics.cap_height.ot_round()),
         sx_height: Some(metrics.x_height.ot_round()),
 
+        y_subscript_x_size: metrics.y_subscript_x_size.ot_round(),
+        y_subscript_y_size: metrics.y_subscript_y_size.ot_round(),
+        y_subscript_x_offset: metrics.y_subscript_x_offset.ot_round(),
+        y_subscript_y_offset: metrics.y_subscript_y_offset.ot_round(),
+
+        y_superscript_x_size: metrics.y_superscript_x_size.ot_round(),
+        y_superscript_y_size: metrics.y_superscript_y_size.ot_round(),
+        y_superscript_x_offset: metrics.y_superscript_x_offset.ot_round(),
+        y_superscript_y_offset: metrics.y_superscript_y_offset.ot_round(),
+
+        y_strikeout_size: metrics.y_strikeout_size.ot_round(),
+        y_strikeout_position: metrics.y_strikeout_position.ot_round(),
+
+        s_typo_ascender: metrics.os2_typo_ascender.ot_round(),
+        s_typo_descender: metrics.os2_typo_descender.ot_round(),
+        s_typo_line_gap: metrics.os2_typo_line_gap.ot_round(),
+        us_win_ascent: metrics.os2_win_ascent.ot_round(),
+        us_win_descent: metrics.os2_win_descent.ot_round(),
+
         // Avoid "field must be present for version 2"
         ul_code_page_range_1: Some(0),
         ul_code_page_range_2: Some(0),
@@ -80,6 +99,7 @@ impl Work<Context, Error> for Os2Work {
     /// Generate [OS/2](https://learn.microsoft.com/en-us/typography/opentype/spec/os2)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_final_static_metadata();
+
         let metrics = context
             .ir
             .get_global_metrics()
@@ -107,7 +127,7 @@ mod tests {
     #[test]
     fn build_basic_os2() {
         let default_location = NormalizedLocation::new();
-        let mut global_metrics = GlobalMetrics::new(default_location.clone(), 1000);
+        let mut global_metrics = GlobalMetrics::new(default_location.clone(), 1000, None);
 
         global_metrics.set(GlobalMetric::CapHeight, default_location.clone(), 37.5);
         global_metrics.set(GlobalMetric::XHeight, default_location.clone(), 112.2);

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -564,6 +564,8 @@ fn add_os2_be_job(
         let mut dependencies = HashSet::new();
         dependencies.insert(FeWorkIdentifier::InitStaticMetadata.into());
         dependencies.insert(FeWorkIdentifier::GlobalMetrics.into());
+        dependencies.insert(BeWorkIdentifier::Hhea.into());
+        dependencies.insert(BeWorkIdentifier::Hmtx.into());
 
         let id: AnyWorkId = BeWorkIdentifier::Os2.into();
         workload.insert(

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -337,6 +337,7 @@ impl Work<Context, WorkError> for GlobalMetricWork {
         let mut metrics = GlobalMetrics::new(
             static_metadata.default_location().clone(),
             static_metadata.units_per_em,
+            font.default_master().x_height().map(|v| v.0 as f32),
         );
 
         for master in font.masters.iter() {
@@ -345,6 +346,31 @@ impl Work<Context, WorkError> for GlobalMetricWork {
             metrics.set_if_some(GlobalMetric::Descender, pos.clone(), master.descender());
             metrics.set_if_some(GlobalMetric::CapHeight, pos.clone(), master.cap_height());
             metrics.set_if_some(GlobalMetric::XHeight, pos.clone(), master.x_height());
+            metrics.set_if_some(
+                GlobalMetric::Os2TypoAscender,
+                pos.clone(),
+                master.typo_ascender.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::Os2TypoDescender,
+                pos.clone(),
+                master.typo_descender.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::Os2TypoLineGap,
+                pos.clone(),
+                master.typo_line_gap.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::Os2WinAscent,
+                pos.clone(),
+                master.win_ascent.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::Os2WinDescent,
+                pos.clone(),
+                master.win_descent.map(|v| v as f64),
+            );
         }
 
         context.set_global_metrics(metrics);
@@ -981,6 +1007,20 @@ mod tests {
                 descender: (-42.0).into(),
                 cap_height: 702.0.into(),
                 x_height: 501.0.into(),
+                y_subscript_x_size: 650.0.into(),
+                y_subscript_y_size: 600.0.into(),
+                y_subscript_y_offset: 75.0.into(),
+                y_superscript_x_size: 650.0.into(),
+                y_superscript_y_size: 600.0.into(),
+                y_superscript_y_offset: 350.0.into(),
+                y_strikeout_position: 300.6.into(),
+                y_strikeout_size: 50.0.into(),
+                os2_typo_ascender: 1000.0.into(),
+                os2_typo_descender: (-200.0).into(),
+                os2_typo_line_gap: 200.0.into(),
+                os2_win_ascent: 800.0.into(),
+                os2_win_descent: (-200.0).into(),
+                ..Default::default()
             },
             default_metrics
         );

--- a/resources/testdata/glyphs2/WghtVar_OS2.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_OS2.glyphs
@@ -1,0 +1,228 @@
+{
+.appVersion = "3151";
+DisplayStrings = (
+"-",
+"!"
+);
+copyright = "Copy!";
+customParameters = (
+{
+name = localizedFamilyName;
+value = "Spanish;SpanishWghtVar";
+},
+{
+name = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+name = description;
+value = "The greatest weight var";
+},
+{
+name = versionString;
+value = "New Value";
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+alignmentZones = (
+"{737, 16}",
+"{0, -16}",
+"{-42, -16}"
+);
+ascender = 737;
+capHeight = 702;
+customParameters = (
+{
+name = typoAscender;
+value = 1193;
+},
+{
+name = typoDescender;
+value = -289;
+},
+{
+name = typoLineGap;
+value = 42;
+},
+{
+name = winAscent;
+value = 1325;
+},
+{
+name = winDescent;
+value = 377;
+}
+);
+descender = -42;
+id = m01;
+weightValue = 400;
+xHeight = 501;
+},
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+weight = Bold;
+weightValue = 700;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = exclam;
+lastChange = "2022-12-01 05:10:49 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"354 183 LINE",
+"414 585 LINE",
+"178 585 LINE",
+"238 182 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 0 LINE",
+"354 107 LINE",
+"238 107 LINE",
+"238 0 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"364 176 LINE",
+"434 605 LINE",
+"159 605 LINE",
+"228 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 -20 LINE",
+"364 94 LINE",
+"228 94 LINE",
+"228 -20 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0021;
+},
+{
+glyphname = hyphen;
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"131 250 LINE",
+"470 250 LINE",
+"470 330 LINE",
+"131 330 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"92 224 LINE",
+"508 224 LINE",
+"508 356 LINE",
+"92 356 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 002D;
+},
+{
+glyphname = "manual-component";
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+components = (
+{
+name = hyphen;
+transform = "{1, 0, 0, 1, 0, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = m01;
+width = 600;
+},
+{
+components = (
+{
+name = hyphen;
+transform = "{1.15, 0, 0, 1.25, 10, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 003D;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/resources/testdata/glyphs3/WghtVar_OS2.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_OS2.glyphs
@@ -1,0 +1,294 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+DisplayStrings = (
+"-",
+"!"
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+400
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1193;
+},
+{
+name = typoDescender;
+value = -289;
+},
+{
+name = typoLineGap;
+value = 42;
+},
+{
+name = winAscent;
+value = 1325;
+},
+{
+name = winDescent;
+value = 377;
+}
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 737;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -42;
+},
+{
+pos = 702;
+},
+{
+pos = 501;
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+},
+{
+glyphname = exclam;
+lastChange = "2022-12-01 05:10:49 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,183,l),
+(414,585,l),
+(178,585,l),
+(238,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,0,l),
+(354,107,l),
+(238,107,l),
+(238,0,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,176,l),
+(434,605,l),
+(159,605,l),
+(228,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,-20,l),
+(364,94,l),
+(228,94,l),
+(228,-20,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 33;
+},
+{
+glyphname = hyphen;
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,250,l),
+(470,250,l),
+(470,330,l),
+(131,330,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,224,l),
+(508,224,l),
+(508,356,l),
+(92,356,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 45;
+},
+{
+glyphname = "manual-component";
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+pos = (0,100);
+ref = hyphen;
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+pos = (10,100);
+ref = hyphen;
+scale = (1.15,1.25);
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+}
+);
+unicode = 61;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+properties = (
+{
+key = familyNames;
+values = (
+{
+language = ESP;
+value = SpanishWghtVar;
+}
+);
+},
+{
+key = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+key = descriptions;
+values = (
+{
+language = dflt;
+value = "The greatest weight var";
+},
+{
+language = ESP;
+value = "The greatest Spanish weight var";
+}
+);
+},
+{
+key = copyrights;
+values = (
+{
+language = dflt;
+value = "Copy!";
+}
+);
+},
+{
+key = versionString;
+value = "New Value";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
Makes most, though not all, of OS/2 match. The following differences are not addressed in this PR:

![image](https://github.com/googlefonts/fontmake-rs/assets/6466432/f2d22b9c-3edd-4aae-83f0-87f7abea5565)


