### PR TITLE
Bring OS/2 and named instance support for ufo+ds up to par with .glyphs

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1642,14 +1642,10 @@ mod tests {
         })
     }
 
-    #[test]
-    fn compile_named_instances() {
+    fn assert_named_instances(source: &str, expected: Vec<(String, Vec<(&str, f32)>)>) {
         let temp_dir = tempdir().unwrap();
         let build_dir = temp_dir.path();
-        compile(Args::for_test(
-            build_dir,
-            "glyphs3/WghtVar_Instances.glyphs",
-        ));
+        compile(Args::for_test(build_dir, source));
 
         let font_file = build_dir.join("font.ttf");
         assert!(font_file.exists());
@@ -1667,10 +1663,7 @@ mod tests {
         let instances = fvar.instances().unwrap();
 
         assert_eq!(
-            vec![
-                ("Regular".to_string(), vec![("Weight", 400.0)]),
-                ("Bold".to_string(), vec![("Weight", 700.0)])
-            ],
+            expected,
             instances
                 .iter()
                 .map(|i| i.unwrap())
@@ -1684,6 +1677,28 @@ mod tests {
                         .collect(),
                 ))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn compile_named_instances_from_glyphs() {
+        assert_named_instances(
+            "glyphs3/WghtVar_Instances.glyphs",
+            vec![
+                ("Regular".to_string(), vec![("Weight", 400.0)]),
+                ("Bold".to_string(), vec![("Weight", 700.0)]),
+            ],
+        );
+    }
+
+    #[test]
+    fn compile_named_instances_from_designspace() {
+        assert_named_instances(
+            "wght_var.designspace",
+            vec![
+                ("Regular".to_string(), vec![("Weight", 400.0)]),
+                ("Bold".to_string(), vec![("Weight", 700.0)]),
+            ],
         );
     }
 }

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -291,6 +291,20 @@ impl DesignLocation {
                 .collect(),
         )
     }
+
+    pub fn to_user(&self, axes: &HashMap<&String, &Axis>) -> UserLocation {
+        Location::<UserCoord>(
+            self.0
+                .iter()
+                .map(|(name, coord)| {
+                    (
+                        name.clone(),
+                        coord.to_user(&axes.get(name).unwrap().converter),
+                    )
+                })
+                .collect(),
+        )
+    }
 }
 
 impl NormalizedLocation {

--- a/resources/testdata/FontInfo-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/FontInfo-Regular.ufo/fontinfo.plist
@@ -10,5 +10,23 @@
     <string>Regular</string>
     <key>openTypeOS2VendorID</key>
     <string>RODS</string>
+    <key>ascender</key>
+    <integer>737</integer>
+    <key>capHeight</key>
+    <integer>702</integer>
+    <key>descender</key>
+    <integer>-42</integer>
+    <key>xHeight</key>
+    <integer>501</integer>
+    <key>openTypeOS2TypoAscender</key>
+    <integer>1193</integer>
+    <key>openTypeOS2TypoDescender</key>
+    <integer>-289</integer>
+    <key>openTypeOS2TypoLineGap</key>
+    <integer>42</integer>
+    <key>openTypeOS2WinAscent</key>
+    <integer>1325</integer>
+    <key>openTypeOS2WinDescent</key>
+    <integer>377</integer>
   </dict>
 </plist>

--- a/resources/testdata/WghtVar-Bold.ufo/fontinfo.plist
+++ b/resources/testdata/WghtVar-Bold.ufo/fontinfo.plist
@@ -6,5 +6,7 @@
     <integer>1000</integer>
     <key>ascender</key>
     <real>801</real>
+    <key>familyName</key>
+    <string>Wght Var</string>
   </dict>
 </plist>

--- a/resources/testdata/WghtVar-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/WghtVar-Regular.ufo/fontinfo.plist
@@ -6,5 +6,7 @@
     <integer>1000</integer>
     <key>ascender</key>
     <real>799</real>
+    <key>familyName</key>
+    <string>Wght Var</string>
   </dict>
 </plist>


### PR DESCRIPTION
fvar is now identical, OS/2 has the same diff as #294 shows for .glyphs